### PR TITLE
fix(ale_claw): reconcile final_metrics from authoritative usage aggregate

### DIFF
--- a/ale_run/agents/ale_claw/transcript_to_trajectory.py
+++ b/ale_run/agents/ale_claw/transcript_to_trajectory.py
@@ -84,6 +84,32 @@ def parse_transcripts_into(work_dir: Path, builder: TrajectoryBuilder) -> None:
     aggregated = _aggregate_usage(work_dir)
     builder.trajectory.extra.setdefault("ale_claw", {})["usage"] = aggregated
     builder.trajectory.extra["ale_claw"]["raw_transcript"] = str(transcripts[0])
+    _reconcile_final_metrics(builder, aggregated)
+
+
+def _reconcile_final_metrics(
+    builder: TrajectoryBuilder, aggregated: dict[str, Any]
+) -> None:
+    """Feed the authoritative aggregate into ``final_metrics`` via the builder.
+
+    The default per-step ``StepMetrics`` sum drops the prompt-cache split (the
+    transcript never carries it) and the final/helper turns (they bypass the
+    transcript writer), so ``final_metrics`` under-reports tokens, cache, and
+    cost. ``aggregated`` (from :func:`_aggregate_usage`: state.json tokens +
+    per-turn api_result cache/cost) is complete, so prefer it. No-op when there
+    is no authoritative input-token total (degraded run) — keeps the per-step
+    sum rather than zeroing it out.
+    """
+    if aggregated.get("overall_input_tokens", 0) <= 0:
+        return
+    builder.override_final_metrics(
+        total_input_tokens=aggregated.get("overall_input_tokens"),
+        total_output_tokens=aggregated.get("output_tokens"),
+        total_cache_read_tokens=aggregated.get("cache_read_input_tokens", 0),
+        total_cache_creation_tokens=aggregated.get("cache_write_input_tokens", 0),
+        # Only override cost when the aggregate has it; else keep per-step sum.
+        total_cost_usd=aggregated.get("total_cost_usd"),
+    )
 
 
 # =============================================================================
@@ -273,20 +299,24 @@ def _aggregate_usage(work_dir: Path) -> dict[str, Any]:
     overall_input_tokens is sourced from state.json (not transcript).
     """
     state_in, state_out = _aggregate_state_json_tokens(work_dir)
-    cache_read, cache_write = _aggregate_cache_tokens(work_dir)
+    cache_read, cache_write, api_cost = _aggregate_api_result_usage(work_dir)
     msg_in, msg_out, msg_cost = _aggregate_message_usage(work_dir)
 
     in_t = state_in or msg_in
     out_t = state_out or msg_out
     uncached_in = max(in_t - cache_read - cache_write, 0)
+    # Per-call api_result cost is authoritative — it includes the final/helper
+    # turns the transcript-message cost (msg_cost) drops. Fall back to msg_cost
+    # only when no api_result dumps are present.
+    cost = api_cost or msg_cost
 
     out: dict[str, Any] = {
         "uncached_input_tokens": uncached_in,
         "output_tokens": out_t,
         "overall_input_tokens": in_t,
     }
-    if msg_cost > 0:
-        out["total_cost_usd"] = round(msg_cost, 6)
+    if cost > 0:
+        out["total_cost_usd"] = round(cost, 6)
     if cache_read > 0:
         out["cache_read_input_tokens"] = cache_read
     if cache_write > 0:
@@ -311,12 +341,20 @@ def _aggregate_state_json_tokens(work_dir: Path) -> tuple[int, int]:
     return in_t, out_t
 
 
-def _aggregate_cache_tokens(work_dir: Path) -> tuple[int, int]:
-    """Sum cached_tokens / cache_write_tokens from per-turn API result dumps."""
+def _aggregate_api_result_usage(work_dir: Path) -> tuple[int, int, float]:
+    """Sum cache split + cost from per-turn API result dumps.
+
+    Returns ``(cache_read, cache_write, cost)``. Unlike the transcript-message
+    usage, these dumps cover EVERY provider call — including the final "done"
+    turn and helper/compaction/VLM calls that bypass the transcript writer — so
+    the cost here is the authoritative total. Usage lives under ``result.usage``
+    (NOT top-level ``usage``).
+    """
     trajectories_root = work_dir / _TRAJECTORIES_SUBDIR
     if not trajectories_root.is_dir():
-        return 0, 0
+        return 0, 0, 0.0
     cache_read = cache_write = 0
+    cost = 0.0
     for path in trajectories_root.glob("*/turn_*/[0-9]*_api_result.json"):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -326,7 +364,8 @@ def _aggregate_cache_tokens(work_dir: Path) -> tuple[int, int]:
         details = usage.get("prompt_tokens_details") or {}
         cache_read += int(details.get("cached_tokens") or 0)
         cache_write += int(details.get("cache_write_tokens") or 0)
-    return cache_read, cache_write
+        cost += float(usage.get("cost") or 0.0)
+    return cache_read, cache_write, cost
 
 
 def _aggregate_message_usage(work_dir: Path) -> tuple[int, int, float]:

--- a/ale_run/base_interface/trajectory.py
+++ b/ale_run/base_interface/trajectory.py
@@ -248,10 +248,38 @@ class TrajectoryBuilder:
         )
         self._next_step_id = 1
         self._t0 = time.monotonic()
+        self._final_metrics_override: dict[str, float] = {}
+
+    #: FinalMetrics fields a deployer may override in :meth:`finalize`.
+    _OVERRIDABLE_METRICS = frozenset({
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_cache_read_tokens",
+        "total_cache_creation_tokens",
+        "total_cost_usd",
+    })
 
     @property
     def trajectory(self) -> Trajectory:
         return self._traj
+
+    def override_final_metrics(self, **totals: float | None) -> None:
+        """Record authoritative trajectory totals to apply in :meth:`finalize`.
+
+        :meth:`finalize` defaults to summing per-step :class:`StepMetrics`, which
+        is lossy for some agents — e.g. ale_claw's transcript carries neither the
+        prompt-cache read/write split nor the final/helper turns, so the per-step
+        sum under-counts tokens and cost. A deployer that can compute exact totals
+        from richer artifacts records them here; finalize then prefers them over
+        the per-step sum for exactly the keys provided (others still come from the
+        sum). Passing ``None`` for a key is a no-op, so callers can offer a metric
+        only when they actually have it.
+        """
+        for key, value in totals.items():
+            if key not in self._OVERRIDABLE_METRICS:
+                raise ValueError(f"non-overridable FinalMetrics field: {key!r}")
+            if value is not None:
+                self._final_metrics_override[key] = value
 
     def add_step(
         self,
@@ -299,6 +327,10 @@ class TrajectoryBuilder:
             m.total_cache_creation_tokens += s.metrics.cache_creation_tokens or 0
             if s.metrics.cost_usd is not None:
                 m.total_cost_usd += s.metrics.cost_usd
+        # Authoritative deployer-supplied totals win over the per-step sum,
+        # per provided key (see :meth:`override_final_metrics`).
+        for key, value in self._final_metrics_override.items():
+            setattr(m, key, value)
         self._traj.final_metrics = m
         self._traj.ended_at = _now_iso()
         return self._traj

--- a/docs/investigations/ale-claw-token-cost-accounting.md
+++ b/docs/investigations/ale-claw-token-cost-accounting.md
@@ -1,0 +1,233 @@
+# Investigation: ale_claw `final_metrics` under-reports cost & drops the cache split
+
+**Date:** 2026-06-03
+**Status:** **Fixed & verified** in worktree `fix/ale-claw-cost-accounting` — branch `fix/ale-claw-cost-accounting`, tests passing, validated against 3 real runs (not yet committed/merged)
+**Component:** `ale_run` orchestration / ale_claw artifact normalization (NOT the `harness/` agent code)
+**Severity:** Medium — headline cost/token rollups are systematically wrong; correct data exists alongside them.
+
+> **Verification addendum (2026-06-03) — see [§ Verification findings](#verification-findings-2026-06-03) below.**
+> The token/cache diagnosis is confirmed. **But the proposed fix was incomplete on two
+> points:** (1) `extra.ale_claw.usage.total_cost_usd` is **also wrong** (same dropped turn) —
+> so Option A "copy from `extra.ale_claw.usage`" would leave cost ~9% under; (2) the
+> reconciliation must happen **inside `finalize()`**, not after `parse_transcripts_into`,
+> because of call ordering. Corrected fix recorded below.
+
+---
+
+## TL;DR
+
+For ale_claw runs, the **raw per-call provider data is correct** (OpenRouter/LiteLLM
+`api_result.json`): token identities hold, the prompt-cache read/write split is sane,
+and the cache **discount is applied** (cold step costs ~10× per prompt-token vs warm
+steps). 
+
+But the **normalized headline aggregate** that downstream cost rollups read —
+`trajectory.final_metrics` (mirrored into `run.json.usage`) — is wrong in two ways:
+
+1. **Drops the final API turn** (and any helper/compaction/VLM calls) → under-reports
+   total cost & tokens by one step every run (~7–8% on the demo).
+2. **Reports `cache_read`/`cache_creation` as 0** even on a ~98% cache-served run.
+
+The accurate aggregate already exists in `trajectory.extra["ale_claw"]["usage"]`. Both
+symptoms have the **same root cause**: `final_metrics` is summed from *transcript-derived
+per-step metrics*, which neither carry cache tokens nor include steps that bypass the
+transcript message writer.
+
+---
+
+## Why it matters
+
+Downstream cost/token aggregation reads `final_metrics`, not `extra.ale_claw.usage`.
+E.g. `ale_run/agents/terminus_2/deployer.py:528` ("Aggregate token + cost usage,
+**preferring `final_metrics`**") and `ale_run/orchestration/lifecycle.py:934` (dumps
+`final_metrics`). So every consumer that rolls up spend or cache-hit rate for ale_claw
+gets the under-counted numbers.
+
+---
+
+## Evidence (demo smoke, model `openrouter/anthropic/claude-sonnet-4.6`)
+
+Run dir:
+`.logs/smoke/smoke_ale_claw_hello/ale_claw_sonnet_or/openrouter-anthropic-claude-sonnet-4-6/demo__hello_win/v0/20260602_235107/`
+
+Ground truth = per-call `origin_log/ale-claw/trajectories/.../turn_00X/00YY_api_result.json`:
+
+| step | prompt | compl | cached | cache_write | cost |
+|------|--------|-------|--------|-------------|--------|
+| t0 | 7737 | 136 | 0 | 7734 | 0.0310515 |
+| t2 | 8062 | 104 | 7734 | 327 | 0.00510945 |
+| t3 | 8232 | 80 | 8061 | 170 | 0.0042588 |
+| t4 | 8386 | 140 | 8231 | 154 | 0.0051498 |
+| t5 | 8693 | 96 | 8385 | 307 | 0.00510975 |
+| **sum** | **41110** | **556** | **32411** | **8692** | **0.0506793** |
+
+Raw-layer checks (all PASS): `total == prompt+compl`; `cached ≤ prompt`,
+`cache_write ≤ prompt`; `cost == upstream_inference_cost == prompt_cost+compl_cost`
+(residual $0.00). Effective $/prompt-token: `3.75e-6 → 4.4e-7 → 3.7e-7 → 3.6e-7 → 4.2e-7`
+→ cache discount is applied.
+
+What `final_metrics` / `run.json.usage` report instead:
+- `total_cost ≈ 0.04556955` (only **4** of 5 calls — t5 missing) vs raw `0.0506793`.
+- `total_input_tokens = 32417` (sum of 4 prompts) vs raw 41110.
+- `total_cache_read_tokens = 0`, `total_cache_creation_tokens = 0` (raw: 32411 / 8692).
+
+Reproduces on the other two runs inspected (`20260602_234610`, `20260602_233543`) — same
+off-by-one-call under-report each time.
+
+Correct aggregate (already present): `trajectory.extra["ale_claw"]["usage"]` =
+`{overall_input_tokens: 41110, output_tokens: 556, cache_read_input_tokens: 32411,
+cache_write_input_tokens: 8692, uncached_input_tokens: 7, total_cost_usd: ...}` — internally
+consistent (`7 + 32411 + 8692 = 41110`).
+
+---
+
+## Root cause
+
+`final_metrics` is built by `TrajectoryBuilder` summing per-step `StepMetrics`
+(`ale_run/base_interface/trajectory.py:298-302`):
+
+```python
+m.total_cache_read_tokens     += s.metrics.cache_read_tokens or 0
+m.total_cache_creation_tokens += s.metrics.cache_creation_tokens or 0
+```
+
+Those per-step `StepMetrics` come from `ale_run/agents/ale_claw/transcript_to_trajectory.py`:
+
+- **`_metrics_from_message_usage()` (line 204)** maps the transcript's per-message usage —
+  `{"input", "output", "total", "cost"}` — into `StepMetrics`. It sets **only**
+  `input_tokens / output_tokens / cost_usd`; `cache_read_tokens` and
+  `cache_creation_tokens` are left `None` because **the transcript never carries them**.
+  → `final_metrics` cache totals sum to 0. (This is acknowledged in the module docstring,
+  lines 27-31.)
+
+- The per-step metrics exist **only for assistant turns written to the transcript message
+  log**. The final "done" assistant turn — and helper/compaction/VLM calls — are not
+  emitted as transcript message-usage rows, so they never become Steps and never enter the
+  `final_metrics` sum. → one (or more) calls dropped from the total.
+
+- The **correct** totals are computed separately by `_aggregate_usage()` (line 265), which
+  sources tokens from `state.json` ("incremented for EVERY yielded step … including
+  helper / compaction / VLM calls") and the cache split by walking every per-turn
+  `api_result.json`. Its output is parked in `extra["ale_claw"]["usage"]` — **never folded
+  back into `final_metrics`.**
+
+So: the accurate accounting is computed and stored; `final_metrics` just isn't populated
+from it.
+
+---
+
+## Suggested fix (pick one; option A preferred)
+
+**A. Reconcile `final_metrics` from `_aggregate_usage()` in `parse_artifacts`.** After
+`parse_transcripts_into(...)`, overwrite `builder.trajectory.final_metrics`'s
+total_input/output/cost and the two cache totals from `_aggregate_usage(work_dir)` (the
+same numbers already placed in `extra.ale_claw.usage`). Smallest change, single source of
+truth, fixes both symptoms at once. Touch points:
+`ale_run/agents/ale_claw/deployer.py:parse_artifacts` (~line 377) +
+`ale_run/agents/ale_claw/transcript_to_trajectory.py` (expose the aggregate / a setter).
+
+**B. Enrich per-step `StepMetrics` with cache + capture the final turn.** Have the
+translator read each turn's `api_result.json` and set `cache_read_tokens` /
+`cache_creation_tokens` on the corresponding Step, and emit a Step for the final
+assistant turn. More faithful per-step, but more code and still misses transcript-bypassing
+helper calls (which only `state.json` sees) — so A is more complete.
+
+Whatever the choice, keep `extra.ale_claw.usage` as the cross-check.
+
+---
+
+## Verification plan
+
+1. **Unit:** feed a synthetic `work_dir` (transcript missing the last turn + `state.json` /
+   `api_result.json` with cache split) to `parse_artifacts`; assert
+   `final_metrics.total_cost_usd == sum(api_result costs)` and
+   `final_metrics.total_cache_read_tokens == 32411` etc.
+2. **Runtime:** a real ale_claw run (the demo is fine — it caches). After the fix, assert
+   `final_metrics` == `extra.ale_claw.usage` on tokens/cost/cache, and that the per-call
+   `api_result.json` sum matches `final_metrics.total_cost_usd`.
+3. Re-run the read-only audit script (below) before/after.
+
+---
+
+## Scope / provenance
+
+- **Pre-existing**, independent of the `audit/ale-claw-readability` refactor branch. The bug
+  is in `ale_run` orchestration normalization (`deployer.parse_artifacts`,
+  `transcript_to_trajectory.py`, `base_interface/trajectory.py`), **not** in the `harness/`
+  agent code that the readability refactor touched. The Tier 1–3 refactors are
+  behavior-preserving and do not affect this path.
+- Raw provider accounting is **correct** — do not "fix" the api_result data or LiteLLM
+  layer; only the normalization that builds `final_metrics` needs changing.
+
+## Verification findings (2026-06-03)
+
+Re-ran the read-only audit against
+`.../demo__hello_win/v0/20260602_235107/` and read the live code. Results:
+
+| Metric | `final_metrics` / `run.json.usage` | `extra.ale_claw.usage` | Ground truth (Σ `api_result.result.usage`) |
+|--------|-----------------------------------|------------------------|---------------------------------------------|
+| input tokens | 32417 ❌ | **41110 ✓** | 41110 |
+| output tokens | 460 ❌ | **556 ✓** | 556 |
+| cache_read | 0 ❌ | **32411 ✓** | 32411 |
+| cache_creation | 0 ❌ | **8692 ✓** | 8692 |
+| **cost_usd** | 0.04556955 ❌ | **0.04557 ❌** | **0.0506793** |
+
+**New finding — `extra.ale_claw.usage` cost is also wrong.** The doc's Option A assumed
+`extra.ale_claw.usage` is fully correct and proposed copying it into `final_metrics`. But
+its `total_cost_usd` is sourced from `_aggregate_message_usage()`
+(`transcript_to_trajectory.py:332`), which sums cost over **transcript assistant messages** —
+the *same* source that drops the final turn. So both aggregates under-report cost by the
+same dropped call (0.04557 vs 0.0506793, ~9% low). The doc's TL;DR line that left
+`total_cost_usd: ...` blank was the tell — the cost value there was never pinned.
+**Tokens and the cache split in `extra.ale_claw.usage` are correct** (sourced from
+`state.json` + per-turn `api_result.json`); only its cost is wrong.
+
+**Correction — `api_result.json` shape.** Usage lives at `result.usage`, **not** top-level
+`usage`. The appendix repro below (`json.load(open(p))["usage"]`) therefore reads `{}` and
+reports all-zeros — it never actually validated ground truth. The live code is right:
+`_aggregate_cache_tokens` reads `data["result"]["usage"]` (`:325`). The corrected repro is
+in the appendix.
+
+**Correction — fix location.** `parse_artifacts` runs **before** `builder.finalize()`
+(`orchestration/lifecycle.py:458` then `:479`). So `final_metrics` does not exist during
+`parse_transcripts_into`, and `finalize()` rebuilds it from the per-step sum afterwards —
+clobbering anything set earlier. Reconciliation must be applied **inside `finalize()`**.
+
+### Corrected fix (supersedes Option A)
+
+1. **`transcript_to_trajectory.py`** — sum cost from the per-turn `api_result.json`
+   (`result.usage.cost`, the same files `_aggregate_cache_tokens` already walks) and prefer
+   it over the transcript-message cost in `_aggregate_usage()`. Fixes
+   `extra.ale_claw.usage.total_cost_usd` → 0.0506793.
+2. **`base_interface/trajectory.py`** — add a generic, agent-agnostic
+   `TrajectoryBuilder.override_final_metrics(**totals)` hook; `finalize()` applies the
+   recorded overrides over the per-step sum for whichever keys are provided. (Generic: any
+   deployer with richer artifacts than per-step `StepMetrics` can use it.)
+3. **`transcript_to_trajectory.py` / `parse_transcripts_into`** — after computing the
+   aggregate, call `builder.override_final_metrics(...)` mapping
+   `overall_input_tokens / output_tokens / cache_read_input_tokens /
+   cache_write_input_tokens / total_cost_usd` → the matching `FinalMetrics` fields. Guarded
+   to no-op when there is no authoritative aggregate (keeps per-step sums for degraded runs).
+
+Single source of truth (`_aggregate_usage`), fixes all three symptoms (cost, tokens, cache),
+and respects the real call order.
+
+## Appendix — repro (read-only)
+
+```bash
+cd <run_dir>/origin_log/ale-claw/trajectories/*/
+python3 - <<'PY'
+import json, glob
+# NOTE: usage lives under result.usage, NOT top-level usage (see verification addendum).
+calls=[(json.load(open(p)).get("result") or {}).get("usage") or {}
+       for p in sorted(glob.glob("turn_*/[0-9]*_api_result.json"))]
+tot=lambda k: sum(c.get(k,0) for c in calls)
+ptd=lambda k: sum((c.get("prompt_tokens_details") or {}).get(k,0) or 0 for c in calls)
+print("calls:", len(calls), "prompt:", tot("prompt_tokens"), "compl:", tot("completion_tokens"))
+print("cached:", ptd("cached_tokens"), "cache_write:", ptd("cache_write_tokens"))
+print("cost:", round(sum(c.get("cost",0) for c in calls),6))
+PY
+# Compare to: python -c "import json;d=json.load(open('<run_dir>/run.json'));print(d['usage'])"
+# Verified ground truth (20260602_235107): calls=5 prompt=41110 compl=556
+#                                            cached=32411 cache_write=8692 cost=0.0506793
+```

--- a/tests/ale_run/test_ale_claw_cost_accounting.py
+++ b/tests/ale_run/test_ale_claw_cost_accounting.py
@@ -1,0 +1,153 @@
+"""Regression tests for ale_claw token/cost accounting in ``final_metrics``.
+
+Covers the bug investigated in
+``docs/investigations/ale-claw-token-cost-accounting.md``: the per-step
+``StepMetrics`` sum that builds ``final_metrics`` drops the prompt-cache split
+(the transcript never carries it) and the final/helper turns (they bypass the
+transcript writer), so cost and tokens were under-reported. The fix reconciles
+``final_metrics`` from the authoritative aggregate (state.json tokens + per-turn
+``api_result.json`` cache/cost) via ``TrajectoryBuilder.override_final_metrics``.
+
+These modules are pure pydantic/stdlib — no harness / MLX imports — so this file
+does not depend on the top-level conftest shims.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ale_run.agents.ale_claw.transcript_to_trajectory import parse_transcripts_into
+from ale_run.base_interface import TrajectoryBuilder
+
+
+def _write(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _build_work_dir(tmp_path: Path) -> Path:
+    """Synthetic ale_claw work_dir mirroring the demo-smoke shape.
+
+    The transcript intentionally records only the FIRST of two assistant turns
+    (the final "done" turn bypasses the transcript writer) and carries no cache
+    split — exactly the lossy inputs the per-step sum sees. state.json holds the
+    true token totals; the two ``api_result.json`` dumps hold the cache split and
+    the true per-call cost (including the turn missing from the transcript).
+    """
+    wd = tmp_path / "ale-claw"
+    session = wd / "openclaw_sessions" / "sess0"
+
+    # Transcript: ONE assistant message only (missing the final turn), no cache.
+    transcript = session / "transcript.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "step 1"}],
+                    "usage": {"input": 100, "output": 10, "total": 110, "cost": 0.001},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # state.json: true totals across BOTH turns (the accumulator sees every step).
+    _write(
+        session / "state.json",
+        {"total_tokens": {"input_tokens": 300, "output_tokens": 25}},
+    )
+
+    # Per-turn api_result dumps: usage under result.usage, with the cache split
+    # and authoritative cost. Turn 1 is the one missing from the transcript.
+    traj = wd / "trajectories" / "traj0"
+    _write(
+        traj / "turn_000" / "0001_api_result.json",
+        {
+            "result": {
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 10,
+                    "cost": 0.001,
+                    "prompt_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 90},
+                }
+            }
+        },
+    )
+    _write(
+        traj / "turn_001" / "0002_api_result.json",
+        {
+            "result": {
+                "usage": {
+                    "prompt_tokens": 200,
+                    "completion_tokens": 15,
+                    "cost": 0.004,
+                    "prompt_tokens_details": {"cached_tokens": 100, "cache_write_tokens": 95},
+                }
+            }
+        },
+    )
+    return wd
+
+
+def test_final_metrics_reconciled_from_aggregate(tmp_path: Path) -> None:
+    wd = _build_work_dir(tmp_path)
+    builder = TrajectoryBuilder(agent_name="ale_claw", task_path="t", variant_index=0)
+    parse_transcripts_into(wd, builder)
+    fm = builder.finalize(reward=1.0, status="completed").final_metrics
+
+    # Totals from state.json (both turns), not the single transcript turn (input=100).
+    assert fm.total_input_tokens == 300
+    assert fm.total_output_tokens == 25
+    # Cache split from api_result (transcript carried none → would be 0 pre-fix).
+    assert fm.total_cache_read_tokens == 100
+    assert fm.total_cache_creation_tokens == 185  # 90 + 95
+    # Cost summed over per-call api_result, incl. the turn missing from transcript.
+    # Pre-fix this was 0.001 (transcript-message cost only).
+    assert fm.total_cost_usd == pytest.approx(0.005)
+
+
+def test_extra_usage_cost_uses_api_result_not_transcript(tmp_path: Path) -> None:
+    wd = _build_work_dir(tmp_path)
+    builder = TrajectoryBuilder(agent_name="ale_claw", task_path="t", variant_index=0)
+    parse_transcripts_into(wd, builder)
+    usage = builder.trajectory.extra["ale_claw"]["usage"]
+
+    assert usage["overall_input_tokens"] == 300
+    assert usage["cache_read_input_tokens"] == 100
+    assert usage["cache_write_input_tokens"] == 185
+    # The regression that the doc's Option A missed: extra-usage cost must also
+    # be the api_result total (0.005), not the transcript-message total (0.001).
+    assert usage["total_cost_usd"] == pytest.approx(0.005)
+
+
+def test_override_no_op_when_no_aggregate(tmp_path: Path) -> None:
+    """Degraded run (no sessions/state) keeps the per-step sum, not zeros."""
+    builder = TrajectoryBuilder(agent_name="ale_claw", task_path="t", variant_index=0)
+    parse_transcripts_into(tmp_path / "empty", builder)  # no transcript → system step
+    fm = builder.finalize(reward=None, status="failed").final_metrics
+    assert fm.total_input_tokens == 0
+    assert fm.total_cost_usd == 0.0
+
+
+def test_override_final_metrics_rejects_unknown_field() -> None:
+    builder = TrajectoryBuilder(agent_name="x", task_path="t", variant_index=0)
+    with pytest.raises(ValueError, match="non-overridable"):
+        builder.override_final_metrics(total_steps=5)
+
+
+def test_override_final_metrics_ignores_none_and_beats_step_sum() -> None:
+    builder = TrajectoryBuilder(agent_name="x", task_path="t", variant_index=0)
+    from ale_run.base_interface import StepMetrics
+
+    builder.add_step("agent", metrics=StepMetrics(input_tokens=10, cost_usd=0.01))
+    # None → no-op (output stays from step sum); provided keys win.
+    builder.override_final_metrics(total_input_tokens=999, total_output_tokens=None)
+    fm = builder.finalize(reward=None, status="completed").final_metrics
+    assert fm.total_input_tokens == 999  # overridden
+    assert fm.total_cost_usd == pytest.approx(0.01)  # untouched → from step sum


### PR DESCRIPTION
## Problem

For `ale_claw` runs, `trajectory.final_metrics` (mirrored to `run.json.usage`) is systematically wrong, while the correct raw per-call data sits right next to it:

- **cache_read / cache_creation reported as 0** even on ~98%-cache-served runs.
- **total tokens & cost under-counted by one (or more) calls every run (~7–9%)**.

Root cause: `final_metrics` is summed from per-step `StepMetrics`, which is lossy twice over — the transcript never carries the prompt-cache split, and the final "done" turn + helper/compaction/VLM calls bypass the transcript writer, so they never become steps.

The accurate aggregate already existed in `extra.ale_claw.usage` (tokens from `state.json`, cache split from per-turn `api_result.json`) but was never folded back into `final_metrics`. **Its `total_cost_usd` was also wrong** — sourced from transcript-message cost, it dropped the same final turn (the original investigation missed this).

## Fix

1. **`transcript_to_trajectory.py`** — sum authoritative per-call cost from `api_result.json` (`result.usage.cost`) and prefer it over transcript-message cost in `_aggregate_usage` (`_aggregate_cache_tokens` → `_aggregate_api_result_usage`). Fixes `extra.ale_claw.usage.total_cost_usd`.
2. **`base_interface/trajectory.py`** — add generic, agent-agnostic `TrajectoryBuilder.override_final_metrics(**totals)`; `finalize()` prefers recorded overrides over the per-step sum, per key. (Must live in `finalize()`: `parse_artifacts` runs *before* it, so anything written to `final_metrics` earlier would be clobbered.)
3. **`parse_transcripts_into`** — feeds the aggregate into the builder; no-op on degraded runs so the per-step sum is never zeroed.

## Verification

- `final_metrics` now matches `api_result.json` ground truth **exactly** (input/output/cache_read/cache_creation/cost) across the 3 cited smoke runs — e.g. demo: cost `0.0506793` ✓, cache_read `32411` ✓ (was `0.04557` / `0`).
- New unit tests: `tests/ale_run/test_ale_claw_cost_accounting.py` (5 tests, passing); ruff clean.

Full root-cause + verification writeup: `docs/investigations/ale-claw-token-cost-accounting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)