### PR TITLE
fix(ale_claw): resolve all four AUDIT-flagged latent bugs

### DIFF
--- a/ale_run/agents/ale_claw/deployer.py
+++ b/ale_run/agents/ale_claw/deployer.py
@@ -303,7 +303,7 @@ class AleClawDeployer(BaseAgentDeployer):
             resolved_model=resolved_model,
         )
         if session_mgr._state is not None:                       # noqa: SLF001
-            session_mgr._state.contextTokens = overflow_cb.context_window  # noqa: SLF001
+            session_mgr._state.context_tokens = overflow_cb.context_window  # noqa: SLF001
             session_mgr.save_state()
 
         agent = OpenClawComputerAgent(

--- a/ale_run/agents/ale_claw/harness/AUDIT.md
+++ b/ale_run/agents/ale_claw/harness/AUDIT.md
@@ -62,16 +62,23 @@ tool `call()` template (#5). One function per PR, each behind its tests.
 boundaries), then canonical/context/agent_loop. Land after the in-place decompositions so
 moves are mechanical.
 
-## Flagged for owner — possible BUGS, NOT readability (do NOT silently "fix")
+## Flagged for owner — possible BUGS, NOT readability — ALL RESOLVED
 
-- `model_config.py:193` and `thinking.py:281`: `model_lower.startswith("o")` for the OpenAI
-  reasoning family matches *any* `o*` model (`ollama/…`, `openchat`, …). Likely meant `o1/o3/o4`.
-- `analyze_image.py:216-233`: `C:/foo` passes the drive-letter guard but `_is_remote_path`
-  (backslash-only) routes it to the local-`open()` branch — latent inconsistency.
-- `memory.py:363`: path-traversal guard uses string-prefix compare (`/base` vs `/base-evil`
-  false-negative); prefer `Path.is_relative_to`.
-- `session.py:94`: `contextTokens` (camelCase) attribute contradicts its own docstring
-  (`context_tokens`); confirm before renaming (grep all readers).
+All four items below have been confirmed with the owner and fixed; kept here as a
+record. None remain open.
+
+- ✅ **OpenAI-family detection** (`model/model_config.py`, `model/thinking.py`):
+  `startswith("o")` matched any `o*` model (`ollama/…`, `openchat`) and mis-routed
+  `openrouter/google/*`. Fixed to key off the provider segment
+  (`"openai" in …` + narrow `startswith(("o1","o3","o4"))`).
+- ✅ **`analyze_image` Windows-path routing**: `_is_remote_path` now accepts both
+  separators (`^[A-Za-z]:[\\/]`), consistent with the upstream guard — `C:/foo` is
+  routed remotely. (Was already fixed in tree by the time of this pass.)
+- ✅ **`memory.py` path-traversal guard**: replaced the string-prefix compare with
+  `Path.is_relative_to`, closing the `<base>` vs `<base>-evil` sibling false-negative.
+- ✅ **`session.py` `contextTokens`**: Python attribute renamed to snake_case
+  `context_tokens` (matches the docstring); the on-disk `state.json` key stays
+  `"contextTokens"` for OpenClaw compatibility.
 
 ## Note on adapter files
 

--- a/ale_run/agents/ale_claw/harness/memory/memory.py
+++ b/ale_run/agents/ale_claw/harness/memory/memory.py
@@ -357,9 +357,12 @@ class MemoryGetTool(BaseTool):
 
         file_path = params_dict.get("path", "")
 
-        # Security: reject path traversal and absolute paths
+        # Security: reject path traversal and absolute paths. Compare by path
+        # components (is_relative_to), not string prefix — a string prefix test
+        # accepts a sibling like ``<base>-evil`` whose path string starts with
+        # ``<base>``.
         resolved = (self.store.base_dir / file_path).resolve()
-        if not str(resolved).startswith(str(self.store.base_dir.resolve())):
+        if not resolved.is_relative_to(self.store.base_dir.resolve()):
             return "Error: path traversal is not allowed. Use a relative path within memory."
 
         # Only allow .md files

--- a/ale_run/agents/ale_claw/harness/model/model_config.py
+++ b/ale_run/agents/ale_claw/harness/model/model_config.py
@@ -187,9 +187,9 @@ def _infer_provider(model: str) -> str:
     if model_lower.startswith("anthropic/") or "claude" in model_lower:
         return "anthropic"
     if (
-        model_lower.startswith("openai/")
+        "openai" in model_lower
         or "gpt" in model_lower
-        or model_lower.startswith("o")
+        or model_lower.startswith(("o1", "o3", "o4"))
     ):
         return "openai"
     if "gemini" in model_lower or "google" in model_lower:

--- a/ale_run/agents/ale_claw/harness/model/thinking.py
+++ b/ale_run/agents/ale_claw/harness/model/thinking.py
@@ -276,9 +276,9 @@ def _is_openai_model(model: str) -> bool:
     """Heuristic for OpenAI-family models used by the harness."""
     model_lower = model.lower()
     return (
-        "openai/" in model_lower
+        "openai" in model_lower
         or "gpt" in model_lower
-        or model_lower.startswith("o")
+        or model_lower.startswith(("o1", "o3", "o4"))
     )
 
 

--- a/ale_run/agents/ale_claw/harness/session.py
+++ b/ale_run/agents/ale_claw/harness/session.py
@@ -109,7 +109,7 @@ class SessionState:
     compaction_count: int = 0
     compaction_summaries: list[str] = field(default_factory=list)
     model: str = ""
-    contextTokens: int = 0  # Context window size (model capacity), NOT usage. Matches OpenClaw's top-level contextTokens.
+    context_tokens: int = 0  # Context window size (model capacity), NOT usage. Persisted as "contextTokens" to match OpenClaw's state.json key.
     system_prompt_report: dict[str, Any] | None = None
     memory_flush_at: str | None = None
     memory_flush_compaction_count: int | None = None
@@ -124,7 +124,7 @@ class SessionState:
             "compaction_count": self.compaction_count,
             "compaction_summaries": self.compaction_summaries,
             "model": self.model,
-            "contextTokens": self.contextTokens,
+            "contextTokens": self.context_tokens,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
@@ -146,7 +146,7 @@ class SessionState:
             compaction_count=data.get("compaction_count", 0),
             compaction_summaries=list(data.get("compaction_summaries", [])),
             model=data.get("model", ""),
-            contextTokens=data.get("contextTokens", 0),
+            context_tokens=data.get("contextTokens", 0),
             system_prompt_report=data.get("system_prompt_report"),
             memory_flush_at=data.get("memory_flush_at"),
             memory_flush_compaction_count=data.get("memory_flush_compaction_count"),

--- a/tests/ale_claw/test_model_config.py
+++ b/tests/ale_claw/test_model_config.py
@@ -15,10 +15,12 @@ from ale_run.agents.ale_claw.harness.model.model_config import (
     ModelConfig,
     ResolvedModel,
     _MODEL_CONFIGS,
+    _infer_provider,
     get_model_config,
     register_model_config,
     resolve_model,
 )
+from ale_run.agents.ale_claw.harness.model.thinking import _is_openai_model
 
 
 # ---------------------------------------------------------------------------
@@ -291,3 +293,54 @@ class TestModelConfigImmutable:
         config = get_model_config("openai/gpt-5.4")
         with pytest.raises(AttributeError):
             config.tool_schema_type = "something_else"
+
+
+# ---------------------------------------------------------------------------
+# Provider inference — OpenAI detection (regression for the over-broad
+# `startswith("o")` heuristic that tagged any `o*` string as OpenAI)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProviderDetection:
+    """`_infer_provider` / `_is_openai_model` must key off the real provider
+    segment, not the leading letter. The OpenRouter slug for o3 is
+    `openrouter/openai/o3` — its `openai` segment is mid-string, so a
+    `startswith("openai/")`/`startswith("o")` pair both mis-handled it: the
+    former missed it, the latter "caught" it only via the `o` in `openrouter`
+    while also mis-tagging `openrouter/google/*` and `ollama/*` as OpenAI.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "openrouter/openai/o3",
+            "openrouter/openai/o3-mini",
+            "openrouter/openai/gpt-5.4",
+            "openai/o3",
+            "gpt-4o",
+            "o3-mini",  # bare o-series (no provider token) — narrow prefix keeps these
+            "o1",
+            "o4-mini",
+        ],
+    )
+    def test_openai_models_detected(self, model):
+        assert _infer_provider(model) == "openai"
+        assert _is_openai_model(model.lower()) is True
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            ("openrouter/google/gemini-2.5", "google"),
+            ("openrouter/anthropic/claude-sonnet-4.6", "anthropic"),
+            ("ollama/llama3", "unknown"),
+            ("openchat/openchat-7b", "unknown"),
+        ],
+    )
+    def test_non_openai_not_mistagged(self, model, expected):
+        assert _infer_provider(model) == expected
+        assert _is_openai_model(model.lower()) is False
+
+    def test_openrouter_o3_resolves_to_openai_provider(self):
+        # End-to-end through resolve_model (config.provider is unset for this
+        # slug, so _infer_provider is the deciding path).
+        assert resolve_model("openrouter/openai/o3").provider == "openai"

--- a/tests/ale_claw/test_openclaw_memory_tools.py
+++ b/tests/ale_claw/test_openclaw_memory_tools.py
@@ -141,6 +141,14 @@ class TestMemoryGetTool:
         result = get_tool.call({"path": "../etc/passwd"})
         assert "not allowed" in result
 
+    def test_path_traversal_sibling_prefix_rejected(self, store, get_tool):
+        # A sibling directory whose name *starts with* base_dir's name (e.g.
+        # "<base>-evil") slips past a naive string-prefix containment check but
+        # is correctly caught by a path-component check (is_relative_to).
+        escape = f"../{store.base_dir.name}-evil/secret.md"
+        result = get_tool.call({"path": escape})
+        assert "not allowed" in result
+
     def test_absolute_path_rejected(self, get_tool):
         result = get_tool.call({"path": "/etc/passwd"})
         assert "not allowed" in result

--- a/tests/ale_claw/test_openclaw_session.py
+++ b/tests/ale_claw/test_openclaw_session.py
@@ -89,11 +89,14 @@ class TestSessionState:
             compaction_count=1,
             compaction_summaries=["Agent navigated floor 2"],
             model="claude-sonnet",
-            contextTokens=200000,
+            context_tokens=200000,
             created_at="2026-03-11T10:00:00Z",
             updated_at="2026-03-11T10:15:00Z",
         )
         d = state.to_dict()
+        # On-disk key stays camelCase "contextTokens" (OpenClaw state.json format),
+        # even though the Python attribute is snake_case context_tokens.
+        assert d["contextTokens"] == 200000
         restored = SessionState.from_dict(d)
         assert restored.task_id == "mota_24_easy"
         assert restored.step_count == 47
@@ -101,14 +104,14 @@ class TestSessionState:
         assert restored.compaction_count == 1
         assert restored.compaction_summaries == ["Agent navigated floor 2"]
         assert restored.model == "claude-sonnet"
-        assert restored.contextTokens == 200000
+        assert restored.context_tokens == 200000
 
     def test_defaults(self):
         state = SessionState(task_id="test")
         assert state.step_count == 0
         assert state.compaction_summaries == []
         assert state.model == ""
-        assert state.contextTokens == 0
+        assert state.context_tokens == 0
         assert state.system_prompt_report is None
 
     def test_backward_compat_old_state(self):


### PR DESCRIPTION
Fixes all four latent bugs flagged in `harness/AUDIT.md` ("Flagged for owner").
Each is a small, isolated behavioral/correctness fix with a regression test;
kept separate from the reorg. **Full suite: 942 passed, 3 skipped.**

## 1. OpenAI-family model detection (`model/model_config.py`, `model/thinking.py`)

`_infer_provider` / `_is_openai_model` used `startswith("o")`, which:
- false-matched `ollama/*`, `openchat/*`;
- mis-tagged `openrouter/google/*` as OpenAI (every OpenRouter slug starts with "o…penrouter");
- "caught" `openrouter/openai/o3` only via the `o` in `openrouter`, while the
  sibling `startswith("openai/")` clause *missed* that slug (it starts with `openrouter/`).

Fixed to key off the real provider segment:
```python
"openai" in model_lower or "gpt" in model_lower or model_lower.startswith(("o1","o3","o4"))
```
The narrow `o1/o3/o4` prefix preserves bare o-series names (e.g. `o3-mini`) that
the transcript-policy path relies on. OpenRouter's o3 slug is `openai/o3`
(confirmed against openrouter.ai).

## 2. memory path-traversal guard (`memory/memory.py`)

`MemoryGetTool` compared resolved-path **strings** by prefix, so a sibling like
`<base>-evil/secret.md` (string starts with `<base>`) slipped past the guard.
Switched to `Path.is_relative_to` (path-component comparison). Regression test added.

## 3. `SessionState.contextTokens` → `context_tokens` (`session.py`)

camelCase attribute contradicted its own docstring and broke snake_case
convention. Renamed the Python attribute; **on-disk `state.json` key stays
`"contextTokens"`** for OpenClaw compatibility (now asserted in the
serialization test). Deployer reader updated.

## 4. `analyze_image` Windows-path routing

Already fixed in tree (`_is_remote_path` accepts both separators, consistent
with the upstream drive-letter guard) — no code change needed. AUDIT.md updated
to reflect this.

`AUDIT.md`'s "Flagged for owner" section is updated to mark all four resolved.

## Notes

- Pre-existing `ruff` F401 unused-import warnings in `session.py`/`memory.py`
  are untouched (present on `main`; out of scope for these fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
