### PR TITLE
Add AWS (EC2 + S3) as a sandbox provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ secret/eval_time/openai.env
 
 # Stray cua-bench eval artifacts written to cwd during host-side task eval
 trycua/
+

--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,3 @@ secret/eval_time/openai.env
 
 # Stray cua-bench eval artifacts written to cwd during host-side task eval
 trycua/
-

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Choose where ALE should create or attach each task sandbox:
 | Provider | Best for | Guide |
 |---|---|---|
 | **Google Cloud VMs** | Elastic batch runs on published Ubuntu, Windows, and GPU images | [Cloud quick start](docs/quickstart.md) |
+| **AWS (EC2 + S3)** | Elastic batch runs on the published Ubuntu and Windows images | [AWS setup guide](https://agents-last-exam.org/docs?p=pages/aws.html) |
 | **QEMU/KVM VMs** | CPU-compatible Ubuntu and Windows tasks on a Linux host with KVM | [QEMU/KVM guide](https://agents-last-exam.org/docs?p=pages/local.html) |
 | **Local containers (Docker)** | The lighter supported Ubuntu subset | [Local container guide](https://agents-last-exam.org/docs?p=pages/local-docker.html) |
 | **Existing sandbox** | Debugging against a CUA-enabled machine you already operate | [Static provider guide](https://agents-last-exam.org/docs?p=pages/static.html) |
@@ -72,7 +73,7 @@ Where the framework supports running sandboxes today, and what is coming next:
 | **Existing CUA sandbox** | ✅ Supported |
 | **Local containers (Ubuntu subset)** ([guide](https://agents-last-exam.org/docs?p=pages/local-docker.html)) | ✅ Supported |
 | **QEMU/KVM VMs (CPU-only)** ([guide](https://agents-last-exam.org/docs?p=pages/local.html)) | ✅ Supported |
-| **AWS** | 🚧 In progress |
+| **AWS (EC2 + S3)** ([guide](https://agents-last-exam.org/docs?p=pages/aws.html)) | ✅ Supported |
 | **Custom image build & licensed tasks** ([guide](https://agents-last-exam.org/docs?p=pages/build-image.html)) | ✅ Supported |
 | **Alibaba Cloud (Ali-Yun)** | 🚧 In progress |
 | **Local VMware** | 📋 Planned |

--- a/ale_run/agents/claude_code/deployer.py
+++ b/ale_run/agents/claude_code/deployer.py
@@ -133,10 +133,13 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
         # "@anthropic-ai/claude-code@2.1.170". --force so a same-version
         # residue under the prefix is overwritten cleanly.
         pkg = cfg.cli_version or "@anthropic-ai/claude-code"
+        # 300s is too short for a COLD npm install on Windows (no pre-baked CLI,
+        # empty cache) — e.g. the ale-win-server image, which (unlike ale-win10)
+        # doesn't bake the claude CLI, needs ~5-10 min. Allow 15 min.
         proc = await asyncio.to_thread(
             subprocess.run,
             [npm, "install", "-g", "--force", "--prefix", prefix, pkg],
-            capture_output=True, text=True, timeout=300, env=env,
+            capture_output=True, text=True, timeout=900, env=env,
         )
         if proc.returncode != 0:
             raise RuntimeError(

--- a/ale_run/environments/output_pull.py
+++ b/ale_run/environments/output_pull.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 _PULL_CONCURRENCY = 8
 _QEMU_SHARE_COPY_TIMEOUT_S = 3600
 _GCS_PUSH_TIMEOUT_S = 3600
+_S3_PUSH_TIMEOUT_S = 3600
 
 
 def _output_dir(sandbox: SandboxHandle, task_data: TaskDataSpec) -> str:
@@ -367,7 +368,7 @@ async def push_to_s3(
             '"'
         )
     logger.info("push_to_s3: %s → %s", src, s3_dst)
-    r = await sandbox.run_command(cmd, timeout=600)
+    r = await sandbox.run_command(cmd, timeout=_S3_PUSH_TIMEOUT_S)
     if r.returncode != 0:
         raise RuntimeError(
             f"aws s3 cp failed (rc={r.returncode}): {(r.stderr or '')[:300]}"

--- a/ale_run/environments/output_pull.py
+++ b/ale_run/environments/output_pull.py
@@ -6,6 +6,7 @@ Dispatched by the lifecycle on ``artifacts_path.output_path``:
   ``"local"``  → :func:`pull_to_host` (provider-local fast path with cua HTTP
                  fallback)
   ``"gs://X"`` → :func:`push_to_gcs` (VM-side gsutil; nothing on host)
+  ``"s3://X"`` → :func:`push_to_s3` (in-box aws CLI; nothing on host)
 """
 
 from __future__ import annotations
@@ -342,3 +343,33 @@ async def push_to_gcs(
     if r.returncode != 0:
         raise RuntimeError(f"gsutil cp failed (rc={r.returncode}): {(r.stderr or '')[:300]}")
     return {"transport": "gcs", "gcs_path": gcs_dst}
+
+
+async def push_to_s3(
+    sandbox: SandboxHandle, task_data: TaskDataSpec, *,
+    run_id: str, bucket: str,
+) -> dict[str, Any]:
+    """``output_path == 's3://...'`` — in-box ``aws s3`` push.
+
+    Lands the env's output dir at ``<bucket>/<run_id>/output/``. Auth is the
+    instance's IAM role (AwsProvider attaches an instance profile), so there is
+    no key to inject — mirror of :func:`push_to_gcs` but credential-free.
+    """
+    src = _output_dir(sandbox, task_data)
+    s3_dst = f"{bucket.rstrip('/')}/{run_id}/output/"
+
+    if sandbox.is_linux:
+        cmd = f"aws s3 cp --recursive {shlex.quote(src)} {shlex.quote(s3_dst)}"
+    else:
+        cmd = (
+            'powershell -NoProfile -Command "'
+            f"aws s3 cp --recursive '{src}' '{s3_dst}'"
+            '"'
+        )
+    logger.info("push_to_s3: %s → %s", src, s3_dst)
+    r = await sandbox.run_command(cmd, timeout=600)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"aws s3 cp failed (rc={r.returncode}): {(r.stderr or '')[:300]}"
+        )
+    return {"transport": "s3", "s3_path": s3_dst}

--- a/ale_run/environments/providers/__init__.py
+++ b/ale_run/environments/providers/__init__.py
@@ -4,12 +4,14 @@
 :mod:`ale_run.base_interface`; this package only holds the backends:
 
   - :class:`GcloudProvider` (``gcloud.py``): ephemeral GCE VMs.
+  - :class:`AwsProvider` (``aws.py``): ephemeral EC2 instances.
   - :class:`StaticProvider` (``static.py``): a pre-existing VM endpoint.
   - :class:`DockerProvider` (``docker.py``): ephemeral Docker containers.
   - :class:`QemuProvider` (``qemu.py``): ephemeral local QEMU VMs in Docker.
 """
 
 from ...base_interface import SandboxSpec, Provider, ReleaseMode, SandboxHandle
+from .aws import AwsProvider, AwsProviderConfig
 from .docker import DockerProvider, DockerProviderConfig
 from .gcloud import GcloudProvider, GcloudProviderConfig
 from .qemu import QemuProvider, QemuProviderConfig
@@ -17,6 +19,8 @@ from .static import StaticProvider, StaticProviderConfig
 
 __all__ = [
     "SandboxSpec",
+    "AwsProvider",
+    "AwsProviderConfig",
     "DockerProvider",
     "DockerProviderConfig",
     "GcloudProvider",

--- a/ale_run/environments/providers/aws.py
+++ b/ale_run/environments/providers/aws.py
@@ -1,0 +1,821 @@
+"""AwsProvider — ephemeral EC2 instances via ``aws ec2 run-instances``.
+
+Mirror of :mod:`ale_run.environments.providers.gcloud`, adapted to EC2:
+
+* **Framework facts (hardcoded, top of file)**: default instance types, the
+  C→M instance fallback, retry tuning, error classification.
+* **Deployment knobs (yaml ``provider.config`` → :class:`AwsProviderConfig`)**:
+  region, subnet(s), security group(s), optional key pair + IAM instance
+  profile, instance_prefix, and the ``snapshots`` map (logical tag → AMI +
+  optional gpu + subnets/AZs).
+
+A task asks for a logical snapshot (``cpu-free-ubuntu`` / ...); the provider
+resolves it via the yaml ``snapshots`` map to an AMI + subnet list, picks an
+instance type (task-card ``vm.machineType`` override, else a default, with
+C→M family fallback), and tries the subnets in order on capacity errors. Root
+volume size comes from the AMI's baked snapshot (no override).
+
+Why this looks like gcloud.py but isn't shared: the lifecycle, retry ordering
+(instance-type × subnet), readiness poll, Windows-resolution and DesktopSession
+bring-up are identical in *shape*, so the genuinely cloud-agnostic helpers
+(``wait_cua_ready``, ``_init_computer_skip_wait``, ``sanitize_label_value``,
+``_set_windows_resolution`` machinery) are imported from gcloud.py rather than
+duplicated. Everything that shells out to ``aws`` lives here.
+
+Credentials: unlike GCE (whose baked gsutil is anonymous, so the provider
+pushes an SA key into each VM), EC2 instances authenticate via an **IAM
+instance profile** attached at launch — the in-box ``aws`` CLI is then
+authenticated with nothing to inject. So there is no AWS counterpart to
+gcloud's ``_inject_gcs_credentials``; set ``iam_instance_profile`` and the
+s3bucket data backend just works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import random
+import re
+import time
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any
+
+from ...base_interface import SandboxSpec, Provider, ReleaseMode, SandboxHandle
+# Cloud-agnostic helpers shared with the gcloud provider.
+from .gcloud import (
+    wait_cua_ready,
+    _init_computer_skip_wait,
+    sanitize_label_value,
+    _SET_RES_PY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Configuration — framework facts (hardcoded). Snapshot→AMI + subnets are
+# deployment-specific and live in the yaml profile (AwsProviderConfig).
+# ============================================================================
+
+# Default instance when a task_card declares no ``vm.machineType``. CPU falls
+# back C→M (see _instance_chain); GPU has no instance fallback. Both are Nitro
+# families (required to boot an imported non-AWS image with ENA/NVMe).
+_DEFAULT_CPU_INSTANCE = "m6i.2xlarge"     # 8 vCPU / 32 GiB
+# g6 = NVIDIA L4, matching the GCE image's `nvidia-l4-vws` (L4) driver — the
+# closest AWS family, so the baked driver has the best chance of binding.
+_DEFAULT_GPU_INSTANCE = "g6.2xlarge"      # 8 vCPU / 32 GiB / 1x L4
+
+# Launch retry tuning.
+_AWS_MAX_RETRIES_TRANSIENT = 3
+_AWS_TRANSIENT_BASE_DELAY = 15          # seconds, exponential backoff
+
+# stderr substring → error class. transient = retry same subnet; subnet =
+# move to next subnet (capacity); anything else = fail fast.
+_AWS_RETRYABLE_TRANSIENT = [
+    "requestlimitexceeded", "throttling", "rate exceeded",
+    "serverinternal", "internalerror", "internal error",
+    "service unavailable", "serviceunavailable", "unavailable",
+    "connection reset", "connection refused", "timed out", "timeout",
+    "could not connect", "connection aborted",
+]
+_AWS_RETRYABLE_SUBNET = [
+    "insufficientinstancecapacity", "insufficient capacity",
+    "instancelimitexceeded", "vcpulimitexceeded",
+    "not have capacity", "no capacity",
+]
+
+
+# ============================================================================
+# Provider config
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class SnapshotConfig:
+    """What a logical snapshot tag maps to (yaml ``snapshots.<tag>``).
+
+    Exactly parallel to gcloud's SnapshotConfig: ``image`` is the **image-family
+    name** (the same registry key gcloud uses — ``ale-ubuntu22`` / ``ale-win10``
+    — from :mod:`ale_run.environments.images`), NOT a raw ``ami-...``. The
+    provider resolves that family to a concrete AMI id at acquire time by
+    looking up an AMI tagged ``ale:image-family=<name>`` (override with an
+    explicit ``ami:`` when you want to pin one). One ``ale-win10.py`` registry
+    entry thus serves gcloud (GCE image name) and aws (family→AMI lookup) alike.
+
+    ``zones`` holds **Availability-Zone names** (e.g. ``us-east-1a``) to try in
+    order on capacity errors — the EC2 analogue of gcloud's zone list. The
+    provider maps each AZ to a subnet in that AZ within the configured VPC.
+    """
+
+    image: str               # image-family name (registry key), e.g. "ale-win10"
+    gpu: str | None          # truthy → use a GPU instance type; None for CPU
+    zones: tuple[str, ...]   # AZ names to try, in order, on capacity errors
+    ami: str | None = None   # optional explicit AMI id override (ami-...)
+    resolution: tuple[int, int] | None = None
+    """Windows display resolution (w, h) forced after boot. See gcloud's
+    SnapshotConfig for the full rationale; Linux ignores it."""
+    tenancy: str = "default"
+    """EC2 placement tenancy: ``default`` (shared) or ``dedicated``. Per-snapshot
+    so one env can mix Linux (``default``) with Windows-10-client snapshots
+    (``dedicated`` — Win10 client BYOL is not licensed for shared tenancy)."""
+
+    @property
+    def os(self) -> str:
+        # image is the family name (e.g. ale-win10), so this is stable even when
+        # an explicit ami override is set.
+        return "windows" if "win" in self.image.lower() else "linux"
+
+
+@dataclass(frozen=True)
+class AwsProviderConfig:
+    """aws provider config (yaml ``provider.config``).
+
+        region                AWS region, e.g. ``us-east-1`` (hardcoded in the
+                              yaml, like gcloud's zones)
+        security_group        the firewall — a security-group NAME (``ale-sandbox``)
+                              or ``sg-...`` id. The provider resolves the name to
+                              its id AND the VPC it lives in, which scopes the
+                              AZ→subnet lookup. The gcloud analogue is ``network``.
+        instance_prefix       instance Name-tag prefix
+        key_name              EC2 key pair (optional; we reach the box via
+                              cua-server, not SSH, so usually unset)
+        iam_instance_profile  instance profile granting in-box S3 access
+                              (optional; only for s3:// task data / output)
+        associate_public_ip   assign a public IPv4 (default True)
+        snapshots             dict[snapshot tag → SnapshotConfig]
+
+    Credentials are NOT here — the provider uses the ambient AWS credential chain
+    (``aws configure`` / env / instance role), so unlike gcloud no project/key is
+    named in the yaml. Everything is a hardcoded convention (resolved by
+    name/tag at run time); nothing needs ``${env:...}``.
+    """
+
+    region: str
+    security_group: str = "ale-sandbox"
+    instance_prefix: str = "ale"
+    key_name: str = ""
+    iam_instance_profile: str = ""
+    associate_public_ip: bool = True
+    snapshots: dict[str, SnapshotConfig] = dataclass_field(default_factory=dict)
+
+
+def _build_snapshot_config(raw: Any) -> SnapshotConfig:
+    if not isinstance(raw, dict):
+        raise TypeError(f"snapshot entry must be a mapping, got {type(raw).__name__}")
+    image = raw.get("image")
+    if not image:
+        raise KeyError(
+            f"snapshot entry missing required `image` (image-family name, "
+            f"e.g. ale-win10): {raw!r}"
+        )
+    zones = tuple(raw.get("zones") or ())
+    if not zones:
+        raise KeyError(f"snapshot {image!r} missing required `zones` (AZ names)")
+    return SnapshotConfig(
+        image=str(image), gpu=raw.get("gpu"), zones=zones,
+        ami=(str(raw["ami"]) if raw.get("ami") else None),
+        resolution=_parse_resolution(raw.get("resolution"), image),
+        tenancy=str(raw.get("tenancy") or "default"),
+    )
+
+
+def _parse_resolution(raw: Any, image: str) -> tuple[int, int] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        parts = raw.lower().replace(" ", "").split("x")
+    elif isinstance(raw, (list, tuple)):
+        parts = list(raw)
+    else:
+        raise TypeError(
+            f"snapshot {image!r} resolution must be [w, h] or 'WxH', got {raw!r}"
+        )
+    if len(parts) != 2:
+        raise ValueError(f"snapshot {image!r} resolution must have 2 values, got {raw!r}")
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except (TypeError, ValueError):
+        raise ValueError(f"snapshot {image!r} resolution values must be ints, got {raw!r}")
+
+
+def _build_provider_config(raw: dict[str, Any]) -> AwsProviderConfig:
+    snapshots = {
+        str(tag): _build_snapshot_config(entry)
+        for tag, entry in (raw.get("snapshots") or {}).items()
+    }
+    return AwsProviderConfig(
+        region=str(raw["region"]),
+        security_group=str(raw.get("security_group") or "ale-sandbox"),
+        instance_prefix=str(raw.get("instance_prefix") or "ale"),
+        key_name=str(raw.get("key_name") or ""),
+        iam_instance_profile=str(raw.get("iam_instance_profile") or ""),
+        associate_public_ip=bool(raw.get("associate_public_ip", True)),
+        snapshots=snapshots,
+    )
+
+
+# ============================================================================
+# Instance-type fallback chain
+# ============================================================================
+
+
+def _cpu_family_fallback(instance_type: str) -> str | None:
+    """C-family → M fallback, keeping the size suffix.
+
+    ``c6i.2xlarge`` → ``m6i.2xlarge``. Returns None for non-C families. This is
+    the only instance fallback we do: compute-optimized capacity stocks out far
+    more often than general-purpose.
+    """
+    fam, _, size = instance_type.partition(".")
+    if fam[:1].lower() == "c" and size:
+        return f"m{fam[1:]}.{size}"
+    return None
+
+
+def _instance_chain(instance_type: str, *, is_gpu: bool) -> tuple[str, ...]:
+    """Ordered instance types to try for one box.
+
+    * GPU: just the requested G-family type — no fallback.
+    * CPU: the requested type, then its M fallback (``c*`` → ``m*``).
+    """
+    if is_gpu:
+        return (instance_type,)
+    fb = _cpu_family_fallback(instance_type)
+    return (instance_type, fb) if fb else (instance_type,)
+
+
+# ============================================================================
+# Naming
+# ============================================================================
+
+
+def generate_instance_name(
+    prefix: str,
+    *,
+    snapshot: str,
+    task_id: str = "",
+    harness: str = "",
+    model_tag: str = "",
+) -> str:
+    """``<prefix>-<task-or-snapshot>-<hash8>`` Name tag (mirror of gcloud)."""
+    if task_id:
+        body = re.sub(r"[^a-z0-9]", "-", task_id.lower()).strip("-")[:40]
+    else:
+        body = re.sub(r"[^a-z0-9]", "-", snapshot.lower()).strip("-")[:30]
+    seed = f"{prefix}:{task_id}:{harness}:{model_tag}:{snapshot}:{time.time()}:{random.random()}"
+    h = hashlib.sha256(seed.encode()).hexdigest()[:8]
+    return f"{prefix}-{body}-{h}"[:128]
+
+
+# ============================================================================
+# aws CLI wrapper + error classification
+# ============================================================================
+
+
+async def _run_aws(*args: str, region: str) -> tuple[int, str, str]:
+    cmd = ["aws", *args, "--region", region, "--output", "json"]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_b, stderr_b = await proc.communicate()
+    return (
+        proc.returncode or 0,
+        stdout_b.decode(errors="replace"),
+        stderr_b.decode(errors="replace"),
+    )
+
+
+def _is_transient_error(stderr: str) -> bool:
+    lower = stderr.lower()
+    return any(pat in lower for pat in _AWS_RETRYABLE_TRANSIENT)
+
+
+def _is_subnet_capacity_error(stderr: str) -> bool:
+    lower = stderr.lower()
+    return any(pat in lower for pat in _AWS_RETRYABLE_SUBNET)
+
+
+# ============================================================================
+# run-instances argv
+# ============================================================================
+
+
+def _build_run_args(
+    *,
+    name: str,
+    image: str,
+    instance_type: str,
+    subnet: str,
+    security_group_id: str,
+    key_name: str,
+    iam_instance_profile: str,
+    associate_public_ip: bool,
+    tenancy: str,
+    snapshot_tag: str,
+) -> list[str]:
+    """``aws ec2 run-instances`` argv.
+
+    Root volume size is NOT passed — we use the AMI's baked snapshot size.
+    """
+    tags = (
+        f"ResourceType=instance,Tags=["
+        f"{{Key=Name,Value={name}}},"
+        f"{{Key=purpose,Value=ale-run}},"
+        f"{{Key=snapshot,Value={sanitize_label_value(snapshot_tag)}}}]"
+    )
+    args = [
+        "ec2", "run-instances",
+        "--image-id", image,
+        "--instance-type", instance_type,
+        "--count", "1",
+        "--subnet-id", subnet,
+        "--tag-specifications", tags,
+    ]
+    if security_group_id:
+        args += ["--security-group-ids", security_group_id]
+    if associate_public_ip:
+        args.append("--associate-public-ip-address")
+    if key_name:
+        args += ["--key-name", key_name]
+    if iam_instance_profile:
+        args += ["--iam-instance-profile", f"Name={iam_instance_profile}"]
+    if tenancy and tenancy != "default":
+        args += ["--placement", f"Tenancy={tenancy}"]
+    return args
+
+
+async def _try_run_in_subnet(
+    *,
+    name: str,
+    image: str,
+    instance_type: str,
+    subnet: str,
+    security_group_id: str,
+    cfg: AwsProviderConfig,
+    tenancy: str,
+    snapshot_tag: str,
+) -> tuple[bool, str, str]:
+    """Returns (ok, stdout, stderr). On capacity error returns ok=False without
+    retrying (caller moves to the next subnet); transient errors retry here."""
+    args = _build_run_args(
+        name=name,
+        image=image,
+        instance_type=instance_type,
+        subnet=subnet,
+        security_group_id=security_group_id,
+        key_name=cfg.key_name,
+        iam_instance_profile=cfg.iam_instance_profile,
+        associate_public_ip=cfg.associate_public_ip,
+        tenancy=tenancy,
+        snapshot_tag=snapshot_tag,
+    )
+    last_stderr = ""
+    for attempt in range(1, _AWS_MAX_RETRIES_TRANSIENT + 1):
+        logger.info(
+            "Launching %s type=%s in %s (attempt %d/%d)",
+            name, instance_type, subnet, attempt, _AWS_MAX_RETRIES_TRANSIENT,
+        )
+        rc, stdout, stderr = await _run_aws(*args, region=cfg.region)
+        if rc == 0:
+            return True, stdout, ""
+        last_stderr = stderr
+
+        if _is_subnet_capacity_error(stderr):
+            logger.warning(
+                "type=%s capacity-exhausted in %s: %s",
+                instance_type, subnet, stderr[:300],
+            )
+            return False, "", last_stderr
+
+        if _is_transient_error(stderr) and attempt < _AWS_MAX_RETRIES_TRANSIENT:
+            delay = _AWS_TRANSIENT_BASE_DELAY * (2 ** (attempt - 1))
+            logger.warning(
+                "run-instances transient error (attempt %d/%d): %s — retrying in %ds",
+                attempt, _AWS_MAX_RETRIES_TRANSIENT, stderr[:200], delay,
+            )
+            await asyncio.sleep(delay)
+            continue
+
+        return False, "", last_stderr
+    return False, "", last_stderr
+
+
+# ============================================================================
+# describe / lifecycle helpers
+# ============================================================================
+
+
+def _instance_id_from_run(stdout: str) -> str:
+    data = json.loads(stdout)
+    return data["Instances"][0]["InstanceId"]
+
+
+async def _wait_running_with_ip(
+    instance_id: str, region: str, *, want_public: bool, timeout: float = 240,
+) -> str:
+    """Poll describe-instances until the instance is ``running`` and has an IP.
+
+    Returns the public IP (want_public) or the private IP. Raises on timeout."""
+    deadline = time.monotonic() + timeout
+    last_state = "?"
+    while time.monotonic() < deadline:
+        rc, stdout, stderr = await _run_aws(
+            "ec2", "describe-instances", "--instance-ids", instance_id,
+            region=region,
+        )
+        if rc == 0:
+            try:
+                inst = json.loads(stdout)["Reservations"][0]["Instances"][0]
+                last_state = inst.get("State", {}).get("Name", "?")
+                if last_state == "running":
+                    ip = (
+                        inst.get("PublicIpAddress") if want_public
+                        else inst.get("PrivateIpAddress")
+                    )
+                    if ip:
+                        return ip
+                if last_state in ("terminated", "shutting-down", "stopped"):
+                    raise RuntimeError(
+                        f"instance {instance_id} entered {last_state} before becoming reachable"
+                    )
+            except (KeyError, IndexError, json.JSONDecodeError):
+                pass
+        await asyncio.sleep(5)
+    raise RuntimeError(
+        f"timed out waiting for {instance_id} to be running with an IP "
+        f"(last state={last_state})"
+    )
+
+
+async def _terminate(instance_id: str, region: str) -> bool:
+    logger.info("Terminating instance %s", instance_id)
+    rc, _, stderr = await _run_aws(
+        "ec2", "terminate-instances", "--instance-ids", instance_id, region=region,
+    )
+    if rc != 0:
+        logger.error("Failed to terminate %s: %s", instance_id, stderr)
+        return False
+    return True
+
+
+def _parse_supported_modes(out: str) -> list[tuple[int, int]]:
+    """Extract ``(w, h)`` modes from the resolution script's
+    ``failed:<rc> supported=[(800, 600), ...]`` line."""
+    marker = "supported="
+    i = out.find(marker)
+    if i < 0:
+        return []
+    import ast
+    try:
+        val = ast.literal_eval(out[i + len(marker):].strip())
+        return [(int(a), int(b)) for a, b in val]
+    except (ValueError, SyntaxError, TypeError):
+        return []
+
+
+async def _stop(instance_id: str, region: str) -> bool:
+    logger.info("Stopping instance %s", instance_id)
+    rc, _, stderr = await _run_aws(
+        "ec2", "stop-instances", "--instance-ids", instance_id, region=region,
+    )
+    if rc != 0:
+        logger.error("Failed to stop %s: %s", instance_id, stderr)
+        return False
+    return True
+
+
+# ============================================================================
+# Provider
+# ============================================================================
+
+
+class AwsProvider(Provider):
+    """Provider backed by ``aws ec2 run-instances / terminate-instances``."""
+
+    def __init__(self, config: AwsProviderConfig | dict[str, Any]):
+        if isinstance(config, dict):
+            config = _build_provider_config(config)
+        self._cfg = config
+        self._ami_cache: dict[str, str] = {}     # family name → ami id
+        self._subnet_cache: dict[str, str] = {}  # az name → subnet id
+        self._sg: tuple[str, str] | None = None  # (sg_id, vpc_id), resolved once
+
+    @property
+    def config(self) -> AwsProviderConfig:
+        return self._cfg
+
+    # ----------------------------------------------------------- resolution
+
+    async def _resolve_ami(self, snap: SnapshotConfig) -> str:
+        """Resolve a snapshot's image to a concrete AMI id.
+
+        Order: explicit ``ami:`` override → cached → look up an AMI owned by us
+        tagged ``ale:image-family=<snap.image>`` (newest wins). This is the AWS
+        analogue of gcloud resolving a snapshot's image name to a GCE image.
+        """
+        if snap.ami:
+            return snap.ami
+        family = snap.image
+        if family in self._ami_cache:
+            return self._ami_cache[family]
+        rc, out, err = await _run_aws(
+            "ec2", "describe-images", "--owners", "self",
+            "--filters", f"Name=tag:ale:image-family,Values={family}",
+            "--query", "reverse(sort_by(Images,&CreationDate))[0].ImageId",
+            region=self._cfg.region,
+        )
+        ami = (out or "").strip().strip('"')
+        if rc != 0 or not ami or ami == "None":
+            raise RuntimeError(
+                f"no AMI tagged ale:image-family={family!r} in {self._cfg.region} "
+                f"(register one, tag it, or set an explicit `ami:` on the snapshot). "
+                f"{(err or '').strip()[:200]}"
+            )
+        self._ami_cache[family] = ami
+        return ami
+
+    async def _resolve_security_group(self) -> tuple[str, str]:
+        """Resolve ``config.security_group`` (a name or ``sg-...`` id) to its id
+        AND the VPC it lives in. The VPC scopes the AZ→subnet lookup, so the yaml
+        only names the firewall (like gcloud names ``network``) — no ids/env-vars.
+        Resolved once and cached."""
+        if self._sg is not None:
+            return self._sg
+        ref = self._cfg.security_group
+        flt = (f"Name=group-id,Values={ref}" if ref.startswith("sg-")
+               else f"Name=group-name,Values={ref}")
+        rc, out, err = await _run_aws(
+            "ec2", "describe-security-groups", "--filters", flt,
+            "--query", "SecurityGroups[0].[GroupId,VpcId]",
+            region=self._cfg.region,
+        )
+        try:
+            pair = json.loads(out) if rc == 0 else None
+        except json.JSONDecodeError:
+            pair = None
+        if not pair or not isinstance(pair, list) or len(pair) != 2 or not pair[0]:
+            raise RuntimeError(
+                f"security group {ref!r} not found in {self._cfg.region} "
+                f"(create it — see the AWS setup docs). {(err or '').strip()[:200]}"
+            )
+        self._sg = (str(pair[0]), str(pair[1]))
+        return self._sg
+
+    async def _subnet_for_az(self, az: str, vpc_id: str) -> str:
+        """Resolve an AZ name to a subnet id in that AZ within ``vpc_id`` (the
+        security group's VPC). Prefers subnets tagged ``project=ale``; falls back
+        to any subnet in the AZ/VPC. Cached per AZ."""
+        if az in self._subnet_cache:
+            return self._subnet_cache[az]
+        filters = [f"Name=availability-zone,Values={az}", f"Name=vpc-id,Values={vpc_id}"]
+        rc, out, err = await _run_aws(
+            "ec2", "describe-subnets", "--filters", *filters,
+            "--query",
+            "sort_by(Subnets, &SubnetId)[?Tags[?Key=='project' && Value=='ale']].SubnetId "
+            "| [0]",
+            region=self._cfg.region,
+        )
+        subnet = (out or "").strip().strip('"')
+        if not subnet or subnet == "None":
+            rc, out, err = await _run_aws(
+                "ec2", "describe-subnets", "--filters", *filters,
+                "--query", "Subnets[0].SubnetId", region=self._cfg.region,
+            )
+            subnet = (out or "").strip().strip('"')
+        if rc != 0 or not subnet or subnet == "None":
+            raise RuntimeError(
+                f"no subnet in AZ {az} (vpc={vpc_id}): {(err or '').strip()[:200]}"
+            )
+        self._subnet_cache[az] = subnet
+        return subnet
+
+    # ------------------------------------------------------------------ acquire
+
+    async def acquire(self, spec: SandboxSpec) -> SandboxHandle:
+        snap = self._cfg.snapshots.get(spec.snapshot)
+        if snap is None:
+            raise KeyError(
+                f"snapshot {spec.snapshot!r} not in provider config "
+                f"(known: {sorted(self._cfg.snapshots)})"
+            )
+        if spec.os and spec.os != snap.os:
+            logger.warning(
+                "os mismatch for %s: task declares %r but AMI %r looks %r",
+                spec.snapshot, spec.os, snap.image, snap.os,
+            )
+
+        is_gpu = snap.gpu is not None
+        azs = snap.zones
+
+        base_instance = spec.machine_type or (
+            _DEFAULT_GPU_INSTANCE if is_gpu else _DEFAULT_CPU_INSTANCE
+        )
+        instances = _instance_chain(base_instance, is_gpu=is_gpu)
+
+        # Resolve the image-family name (e.g. "ale-win10") to a concrete AMI id,
+        # and the security-group name to its id + the VPC that scopes subnets.
+        ami_id = await self._resolve_ami(snap)
+        sg_id, vpc_id = await self._resolve_security_group()
+
+        name = generate_instance_name(
+            self._cfg.instance_prefix,
+            snapshot=spec.snapshot,
+            task_id=spec.task_id,
+            harness=spec.harness,
+            model_tag=spec.model_tag,
+        )
+
+        logger.info(
+            "instance %s candidates: ami=%s types=%s azs=%s",
+            name, ami_id, list(instances), list(azs),
+        )
+
+        last_stderr = ""
+        stdout = ""
+        used_az = azs[0]
+        used_subnet = ""
+        used_instance = instances[0]
+
+        # instance-type × AZ, in order: each type tried across all AZs. Each AZ
+        # is resolved to a subnet in that AZ within the configured VPC.
+        for instance_type in instances:
+            for az in azs:
+                try:
+                    subnet = await self._subnet_for_az(az, vpc_id)
+                except Exception as e:  # noqa: BLE001
+                    last_stderr = f"no subnet for AZ {az}: {e}"
+                    logger.warning("%s", last_stderr)
+                    continue
+                ok, out, stderr = await _try_run_in_subnet(
+                    name=name,
+                    image=ami_id,
+                    instance_type=instance_type,
+                    subnet=subnet,
+                    security_group_id=sg_id,
+                    cfg=self._cfg,
+                    tenancy=snap.tenancy,
+                    snapshot_tag=spec.snapshot,
+                )
+                if ok:
+                    stdout = out
+                    used_subnet = subnet
+                    used_az = az
+                    used_instance = instance_type
+                    break
+                last_stderr = stderr
+                if not _is_subnet_capacity_error(stderr):
+                    raise RuntimeError(f"aws run-instances failed: {stderr}")
+            if stdout:
+                break
+        else:
+            raise RuntimeError(
+                f"aws run-instances failed for all types/AZs: {last_stderr}"
+            )
+
+        try:
+            instance_id = _instance_id_from_run(stdout)
+        except (json.JSONDecodeError, KeyError, IndexError) as e:
+            raise RuntimeError(
+                f"failed to parse run-instances output: {e}\nstdout: {stdout[:500]}"
+            ) from e
+
+        # Instance now exists. Until the handle is returned, ANY failure leaks
+        # it (the caller's cleanup only runs once it holds the handle), so
+        # terminate-on-failure here before propagating.
+        try:
+            public_ip = await _wait_running_with_ip(
+                instance_id, self._cfg.region,
+                want_public=self._cfg.associate_public_ip,
+            )
+
+            # snap.image IS the registry family name (same key gcloud uses), so
+            # this resolves the in-box paths/port directly — one registry entry
+            # serves both providers.
+            from ..images import get as get_image
+            image = get_image(snap.image)
+
+            cua_url = f"http://{public_ip}:{image.cua_server_port}"
+            logger.info(
+                "instance %s (%s) launched as %s in %s (%s) at %s",
+                name, instance_id, used_instance, used_az, used_subnet, cua_url,
+            )
+
+            # Windows first-boot on an imported image (driver init + login +
+            # cua autostart) can exceed the 10-min Linux default; give it 20.
+            cua_timeout = 1200 if snap.os == "windows" else 600
+            ready = await wait_cua_ready(cua_url, snap.os, timeout=cua_timeout)
+            if not ready:
+                raise RuntimeError(f"CUA server at {cua_url} did not become ready")
+
+            if image.os == "windows" and snap.resolution is not None:
+                await self._set_windows_resolution(cua_url, snap.resolution)
+
+            return SandboxHandle(
+                id=instance_id,
+                endpoint=cua_url,
+                os=image.os,
+                **image.sandbox_paths(),
+                metadata={
+                    "region": self._cfg.region,
+                    "instance_id": instance_id,
+                    "instance_type": used_instance,
+                    "az": used_az,
+                    "subnet": used_subnet,
+                    "public_ip": public_ip,
+                    "image": image.name,
+                    "ami": ami_id,
+                    "snapshot": spec.snapshot,
+                    "name": name,
+                },
+            )
+        except BaseException:
+            logger.warning(
+                "acquire: post-launch failure on %s (%s) — terminating to avoid leak",
+                name, instance_id,
+            )
+            try:
+                await _terminate(instance_id, self._cfg.region)
+            except Exception as te:  # noqa: BLE001
+                logger.error("acquire: could not terminate leaked %s: %s", instance_id, te)
+            raise
+
+    @staticmethod
+    async def _set_windows_resolution(
+        cua_url: str, resolution: tuple[int, int],
+    ) -> None:
+        """Force the Windows framebuffer to ``resolution`` (w, h), falling back to
+        the largest supported mode if the exact one isn't available.
+
+        On EC2 the imported Windows image's display adapter exposes a *different*
+        (often smaller) mode set than GCE — e.g. a no-GPU Nitro box may only
+        offer 800x600. Hard-failing the whole run over that is wrong (it's an AWS
+        capability difference, not a misconfig), so we pick the best supported
+        mode ≤ the request (else the largest available) and LOG it loudly — a
+        logged, root-caused choice, not a silent mask. Only raise if the adapter
+        reports no settable modes at all."""
+        from cua_bench.computers.remote import RemoteDesktopSession
+
+        w, h = resolution
+        remote_path = r"C:\agenthle\_set_resolution.py"
+        session = RemoteDesktopSession(api_url=cua_url, os_type="windows")
+        _init_computer_skip_wait(session)
+        await session.run_command(
+            r"cmd /c if not exist C:\agenthle mkdir C:\agenthle", check=False,
+        )
+        await session.write_file(remote_path, _SET_RES_PY)
+
+        async def _try(tw: int, th: int) -> str:
+            res = await session.run_command(f'python "{remote_path}" {tw} {th}', check=False)
+            return (res.get("stdout") or "").strip() if isinstance(res, dict) else ""
+
+        out = await _try(w, h)
+        if "set_ok" in out:
+            logger.info("aws: set Windows resolution to %dx%d", w, h)
+            return
+
+        # Parse the adapter's supported modes ("...supported=[(800, 600), ...]")
+        # and retry with the best fit instead of aborting the run.
+        modes = _parse_supported_modes(out)
+        if modes:
+            below = [m for m in modes if m[0] <= w and m[1] <= h]
+            best = max(below or modes, key=lambda m: m[0] * m[1])
+            out2 = await _try(best[0], best[1])
+            if "set_ok" in out2:
+                logger.warning(
+                    "aws: requested Windows resolution %dx%d unsupported on this "
+                    "display adapter (supported=%s) — using %dx%d instead",
+                    w, h, modes, best[0], best[1],
+                )
+                return
+        err = out or (out and "no output")
+        raise RuntimeError(
+            f"aws: could not set any Windows resolution (requested {w}x{h}); "
+            f"adapter output: {err or 'no output'}"
+        )
+
+    # ------------------------------------------------------------------ release
+
+    async def release(self, vm: SandboxHandle, *, mode: ReleaseMode = "delete") -> None:
+        instance_id = vm.metadata.get("instance_id") or vm.id
+        region = vm.metadata.get("region") or self._cfg.region
+        if mode == "delete":
+            await _terminate(instance_id, region)
+        elif mode == "stop":
+            await _stop(instance_id, region)
+        elif mode == "keep":
+            logger.info("instance %s kept alive (mode=keep)", instance_id)
+        else:
+            raise ValueError(f"unknown release mode: {mode!r}")
+
+    # ------------------------------------------------------------------ session
+
+    def open_session(self, vm: SandboxHandle) -> Any:
+        from cua_bench.computers.remote import RemoteDesktopSession
+
+        session = RemoteDesktopSession(api_url=vm.endpoint, os_type=vm.os)
+        _init_computer_skip_wait(session)
+        return session

--- a/ale_run/environments/providers/aws.py
+++ b/ale_run/environments/providers/aws.py
@@ -528,8 +528,10 @@ class AwsProvider(Provider):
             "--query", "reverse(sort_by(Images,&CreationDate))[0].ImageId",
             region=self._cfg.region,
         )
+        # --output json (forced by _run_aws) serialises a no-match --query as the
+        # literal `null` → "null" after strip; treat it as empty.
         ami = (out or "").strip().strip('"')
-        if rc != 0 or not ami or ami == "None":
+        if rc != 0 or not ami or ami in ("None", "null"):
             raise RuntimeError(
                 f"no AMI tagged ale:image-family={family!r} in {self._cfg.region} "
                 f"(register one, tag it, or set an explicit `ami:` on the snapshot). "
@@ -579,14 +581,16 @@ class AwsProvider(Provider):
             "| [0]",
             region=self._cfg.region,
         )
+        # "null" = no project=ale subnet in this AZ → fall through to any subnet
+        # (--output json serialises an empty --query as the literal `null`).
         subnet = (out or "").strip().strip('"')
-        if not subnet or subnet == "None":
+        if not subnet or subnet in ("None", "null"):
             rc, out, err = await _run_aws(
                 "ec2", "describe-subnets", "--filters", *filters,
                 "--query", "Subnets[0].SubnetId", region=self._cfg.region,
             )
             subnet = (out or "").strip().strip('"')
-        if rc != 0 or not subnet or subnet == "None":
+        if rc != 0 or not subnet or subnet in ("None", "null"):
             raise RuntimeError(
                 f"no subnet in AZ {az} (vpc={vpc_id}): {(err or '').strip()[:200]}"
             )

--- a/ale_run/environments/task_data/__init__.py
+++ b/ale_run/environments/task_data/__init__.py
@@ -5,6 +5,7 @@ Three sources today, dispatched on yaml ``artifacts_path.task_data_source``:
 
   ``"baked_in_sandbox"``     image already has input/ + reference.7z baked in
   ``"gs://<bucket>"``        rsync from a GCS bucket
+  ``"s3://<bucket>"``        sync from an S3 bucket
   ``"hf://<dataset>"``       HuggingFace Hub (STUB)
   ``"local:<host_dir>"``     docker cp from a HOST dir — for a data-less Docker
                              image: input before the agent, reference before eval
@@ -43,6 +44,9 @@ def select(task_data_source: str):
     if task_data_source.startswith("gs://"):
         from . import gsbucket
         return gsbucket
+    if task_data_source.startswith("s3://"):
+        from . import s3bucket
+        return s3bucket
     if task_data_source.startswith("hf://"):
         from . import huggingface
         return huggingface
@@ -51,7 +55,8 @@ def select(task_data_source: str):
         return local_host
     raise ValueError(
         f"unknown task_data_source {task_data_source!r}: expected "
-        f"'baked_in_sandbox', 'gs://<bucket>', 'hf://<dataset>', or 'local:<dir>'"
+        f"'baked_in_sandbox', 'gs://<bucket>', 's3://<bucket>', 'hf://<dataset>', "
+        f"or 'local:<dir>'"
     )
 
 

--- a/ale_run/environments/task_data/s3bucket.py
+++ b/ale_run/environments/task_data/s3bucket.py
@@ -1,0 +1,141 @@
+"""``task_data_source: s3://<bucket>`` — pull task data from an S3 bucket.
+
+Mirror of :mod:`ale_run.environments.task_data.gsbucket`, using the in-box
+``aws s3`` CLI instead of ``gsutil``.
+
+Behavior (identical to gsbucket):
+
+* ``stage_input``: pull ``<s3_prefix>/input`` and ``<s3_prefix>/software`` to
+  the sandbox. **Skip if already on the sandbox** (image-baked data intact).
+* ``stage_reference``: always wipe + fresh sync. Reference is eval truth.
+
+S3 auth: EC2 instances launched by :class:`AwsProvider` carry an **IAM instance
+profile**, so the in-box ``aws`` CLI is already authenticated — there is no
+credential to inject (contrast gcloud, which pushes an SA key into each VM).
+The image must therefore have the ``aws`` CLI on PATH; the AwsProvider AMIs
+bake it in. If a snapshot uses requester-pays-style buckets, add
+``--request-payer requester`` in ``_sync_cmd`` (off by default; S3 has no
+GCS-style mandatory user-project).
+"""
+from __future__ import annotations
+
+import logging
+import shlex
+from typing import Any
+
+from ...base_interface import SandboxHandle, TaskDataSpec
+from . import join, task_subdir
+
+logger = logging.getLogger(__name__)
+
+
+async def stage_input(
+    sandbox: SandboxHandle, task_data: TaskDataSpec, *, source: str,
+) -> dict[str, Any]:
+    s3_prefix = _s3_prefix(source, task_data)
+    base = task_subdir(sandbox, task_data)
+    await sandbox.mkdir(base)
+
+    staged: list[str] = []
+    for subdir in ("input", "software"):
+        dst = join(sandbox, base, subdir)
+        if await _has_baked_files(sandbox, dst):
+            logger.info("s3bucket: %s already present on sandbox, skipping sync", dst)
+            staged.append(f"{subdir}(baked)")
+            continue
+        src = f"{s3_prefix}/{subdir}"
+        if not await _s3_exists(sandbox, src):
+            await sandbox.mkdir(dst)
+            continue
+        r = await sandbox.run_command(_sync_cmd(sandbox, src, dst), timeout=600)
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"aws s3 sync {subdir} failed (rc={r.returncode}): "
+                f"{(r.stderr or '')[:300]}"
+            )
+        if subdir == "software" and sandbox.is_linux:
+            await sandbox.run_command(
+                f"find {shlex.quote(dst)} -type f -exec chmod +x {{}} +",
+                timeout=60,
+            )
+        staged.append(subdir)
+
+    await sandbox.mkdir(join(sandbox, base, "output"))
+    return {"staged": staged, "source": source}
+
+
+async def stage_reference(
+    sandbox: SandboxHandle, task_data: TaskDataSpec, *, source: str,
+) -> dict[str, Any]:
+    s3_prefix = _s3_prefix(source, task_data)
+    base = task_subdir(sandbox, task_data)
+    src = f"{s3_prefix}/reference"
+    dst = join(sandbox, base, "reference")
+
+    if not await _s3_exists(sandbox, src):
+        return {"skipped": True, "reason": "no_reference_on_s3"}
+
+    await sandbox.rm([dst])
+    r = await sandbox.run_command(_sync_cmd(sandbox, src, dst), timeout=600)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"aws s3 sync reference failed (rc={r.returncode}): "
+            f"{(r.stderr or '')[:300]}"
+        )
+    # aws s3 sync does not preserve POSIX mode bits; normalize like gsbucket so
+    # grading sees predictable perms.
+    if sandbox.is_linux:
+        await sandbox.run_command(f"chmod -R 777 {shlex.quote(dst)}", timeout=60)
+    return {"staged": ["reference"], "source": source}
+
+
+# ---- helpers ----
+
+
+def _s3_prefix(source: str, task_data: TaskDataSpec) -> str:
+    return (
+        f"{source.rstrip('/')}/{task_data.domain_name}/"
+        f"{task_data.task_name}/{task_data.variant_name}"
+    )
+
+
+async def _has_baked_files(sandbox: SandboxHandle, path: str) -> bool:
+    if not await sandbox.exists(path):
+        return False
+    entries = await sandbox.list_dir(path)
+    return any(not e["is_dir"] for e in entries)
+
+
+# The task-data bucket is requester-pays (the puller's account is billed, not
+# the owner's — mirrors gcloud's ale-data-public). Every read must carry
+# --request-payer requester or S3 returns 403.
+_RP = "--request-payer requester"
+
+
+async def _s3_exists(sandbox: SandboxHandle, s3_url: str) -> bool:
+    # `aws s3 ls <prefix>/` exits 0 with output only if the prefix has objects;
+    # exits 1 (or 0/empty) otherwise. Trailing slash forces prefix semantics.
+    url = s3_url.rstrip("/") + "/"
+    if sandbox.is_linux:
+        cmd = f"aws s3 ls {_RP} {shlex.quote(url)} >/dev/null 2>&1"
+    else:
+        cmd = (
+            "powershell -NoProfile -Command \""
+            f"aws s3 ls {_RP} '{url}' *> $null; exit $LASTEXITCODE\""
+        )
+    r = await sandbox.run_command(cmd, timeout=30)
+    return r.returncode == 0
+
+
+def _sync_cmd(sandbox: SandboxHandle, src: str, dst: str) -> str:
+    if sandbox.is_linux:
+        return (
+            f"mkdir -p {shlex.quote(dst)} && "
+            f"aws s3 sync {_RP} {shlex.quote(src)} {shlex.quote(dst)}"
+        )
+    return (
+        'powershell -NoProfile -Command "'
+        f"New-Item -ItemType Directory -Force -Path '{dst}' | Out-Null; "
+        f"aws s3 sync {_RP} '{src}' '{dst}'"
+        '"'
+    )

--- a/ale_run/orchestration/config_loader.py
+++ b/ale_run/orchestration/config_loader.py
@@ -281,10 +281,11 @@ def _build_artifacts(raw: dict[str, Any]) -> ArtifactsSpec:
     output_path = raw.get("output_path")
     if output_path is not None:
         op = str(output_path).strip()
-        if op and op not in _VALID_OUTPUT_PATH_LITERALS and not op.startswith("gs://"):
+        if (op and op not in _VALID_OUTPUT_PATH_LITERALS
+                and not op.startswith("gs://") and not op.startswith("s3://")):
             raise ValueError(
                 f"artifacts_path.output_path must be null, 'local', or a "
-                f"'gs://...' bucket path; got {output_path!r}"
+                f"'gs://...'/'s3://...' bucket path; got {output_path!r}"
             )
         output_path = op or None
 
@@ -292,11 +293,12 @@ def _build_artifacts(raw: dict[str, Any]) -> ArtifactsSpec:
     tdp = str(task_data_source).strip()
     if (tdp not in _VALID_TASK_DATA_LITERALS
             and not tdp.startswith("gs://")
+            and not tdp.startswith("s3://")
             and not tdp.startswith("hf://")
             and not tdp.startswith("local:")):
         raise ValueError(
             f"artifacts_path.task_data_source must be 'baked_in_sandbox', "
-            f"'gs://<bucket>', 'hf://<dataset>', or 'local:<dir>'; "
+            f"'gs://<bucket>', 's3://<bucket>', 'hf://<dataset>', or 'local:<dir>'; "
             f"got {task_data_source!r}"
         )
 
@@ -373,6 +375,13 @@ _ENVIRONMENT_TOP_RESERVED = frozenset({
 # per-snapshot routing fields image/zones/gpu). They are repeated on each gcloud
 # snapshot's block and reconciled here into one provider config.
 _GCLOUD_CRED_KEYS = ("project", "service_account_key", "instance_prefix", "network", "subnet")
+_AWS_CRED_KEYS = (
+    "region", "security_group", "instance_prefix",
+    "key_name", "iam_instance_profile", "associate_public_ip",
+)
+# `tenancy` and `ami` are intentionally NOT cred keys: they are per-snapshot
+# routing (tenancy: Linux default vs Windows-client dedicated; ami: optional
+# explicit AMI override) so one env can mix both.
 
 
 def _build_environment_from_path(
@@ -455,6 +464,8 @@ def _build_per_snapshot_env(raw: dict[str, Any], path: str) -> EnvironmentSpec:
     snapshot_kind: dict[str, str] = {}
     gcloud_snaps: dict[str, Any] = {}   # tag -> {image, gpu, zones}
     gcloud_creds: dict[str, Any] = {}   # project/sa/network/... (reconciled, last wins)
+    aws_snaps: dict[str, Any] = {}      # tag -> {image(AMI), gpu, zones(subnets)}
+    aws_creds: dict[str, Any] = {}      # region/sg/profile/... (reconciled, last wins)
     docker_cfg: dict[str, Any] | None = None
     qemu_snaps: dict[str, Any] = {}
 
@@ -481,6 +492,14 @@ def _build_per_snapshot_env(raw: dict[str, Any], path: str) -> EnvironmentSpec:
             if entry.get("resolution") is not None:
                 snap_entry["resolution"] = entry["resolution"]
             gcloud_snaps[str(tag)] = snap_entry
+        elif kind == "aws":
+            # same split as gcloud: provider-wide creds vs per-snapshot routing.
+            aws_creds.update({k: knobs[k] for k in _AWS_CRED_KEYS if k in knobs})
+            routing = {k: v for k, v in knobs.items() if k not in _AWS_CRED_KEYS}
+            snap_entry = {"image": str(image), **routing}
+            if entry.get("resolution") is not None:
+                snap_entry["resolution"] = entry["resolution"]
+            aws_snaps[str(tag)] = snap_entry
         elif kind == "docker":
             # docker carries just the image NAME + sizing knobs; the provider
             # resolves the container ref + port from the Image entry. Multiple
@@ -525,6 +544,13 @@ def _build_per_snapshot_env(raw: dict[str, Any], path: str) -> EnvironmentSpec:
         gc["snapshots"] = gcloud_snaps
         _validate_provider_required("gcloud", gc, path)
         provider_specs["gcloud"] = ProviderSpec(kind="gcloud", config=gc)
+    if aws_snaps:
+        aw = dict(aws_creds)
+        aw["snapshots"] = aws_snaps
+        # No gcs_sa_key counterpart: EC2 boxes authenticate to S3 via their IAM
+        # instance profile, so nothing is injected for s3:// staging/output.
+        _validate_provider_required("aws", aw, path)
+        provider_specs["aws"] = ProviderSpec(kind="aws", config=aw)
     if docker_cfg is not None:
         dk = dict(docker_cfg)
         if gcs_sa_key:
@@ -557,6 +583,12 @@ def _validate_provider_required(provider: str, cfg: dict[str, Any], path: str = 
                     f"environment provider=gcloud missing required field `{k}`{where} "
                     f"(set it on each gcloud snapshot's `gcloud:` block)"
                 )
+    elif provider == "aws":
+        if not cfg.get("region"):
+            raise KeyError(
+                f"environment provider=aws missing required field `region`{where} "
+                f"(set it on each aws snapshot's `aws:` block)"
+            )
     elif provider == "static":
         if not cfg.get("endpoint"):
             raise KeyError(f"environment provider=static missing required field `endpoint`{where}")

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -170,6 +170,9 @@ def build_provider(spec: "ProviderSpec") -> "Provider":
     if kind == "gcloud":
         from ..environments.providers.gcloud import GcloudProvider
         return GcloudProvider(spec.config)
+    if kind == "aws":
+        from ..environments.providers.aws import AwsProvider
+        return AwsProvider(spec.config)
     if kind == "static":
         from ..environments.providers.static import StaticProvider
         return StaticProvider(spec.config)

--- a/ale_run/orchestration/lifecycle.py
+++ b/ale_run/orchestration/lifecycle.py
@@ -847,6 +847,22 @@ async def pull_agent_output(
             writer.emit_event("output_gather_failed", transport="local", error=str(e))
         return
 
+    # s3:// case
+    if output_path.startswith("s3://"):
+        try:
+            report = await output_pull.push_to_s3(
+                env.sandbox, task_data, run_id=run_id, bucket=output_path,
+            )
+            writer.emit_event(
+                "output_gather_done",
+                transport="s3",
+                s3_path=report.get("s3_path"),
+            )
+        except Exception as e:
+            logger.warning("push_to_s3 failed (best-effort): %s", e)
+            writer.emit_event("output_gather_failed", transport="s3", error=str(e))
+        return
+
     # gs:// case
     if not output_path.startswith("gs://"):
         # loader validates this, so reaching here would mean a bypassed path.

--- a/configs/environments/environment_aws.yaml
+++ b/configs/environments/environment_aws.yaml
@@ -1,0 +1,86 @@
+# ============================================================================
+# environment_aws.yaml — run ALE on AWS (EC2 + S3). AWS counterpart of
+# environment.yaml; same per-snapshot model and the SAME image-family names.
+# ============================================================================
+# Like the gcloud env, everything here is a hardcoded convention. There are NO
+# ${env:...} references: AWS credentials come from the ambient chain
+# (`aws configure` / env / instance role), and the VPC, subnets and AMIs are
+# resolved at run time by name/tag (set up once per the AWS setup docs):
+#   • image            image-FAMILY name (registry key under
+#                      ale_run/environments/images/) → resolved to the newest AMI
+#                      tagged `ale:image-family=<name>`. Pin one with `ami:`.
+#   • security_group   the firewall by NAME (gcloud analogue: `network`). The
+#                      provider resolves it to its id + the VPC it lives in; that
+#                      VPC scopes the AZ→subnet lookup.
+#   • zones            Availability-Zone names, tried in order on capacity errors.
+#   • tenancy          default | dedicated (Windows-10 client BYOL → dedicated).
+#   • gpu              truthy → a GPU instance type (g6 / NVIDIA L4).
+# ----------------------------------------------------------------------------
+
+snapshots:
+
+  cpu-free-ubuntu:            # Linux, no GPU — the bulk of tasks
+    provider: aws
+    image: ale-ubuntu22
+    aws:
+      region: us-east-1
+      security_group: ale-sandbox
+      instance_prefix: ale
+      zones: [us-east-1a, us-east-1b, us-east-1c]
+
+  cpu-free:                   # Windows, no GPU
+    provider: aws
+    image: ale-win10
+    resolution: [1024, 768]
+    aws:
+      region: us-east-1
+      security_group: ale-sandbox
+      instance_prefix: ale
+      tenancy: dedicated      # Win10 client BYOL is not licensed for shared tenancy
+      zones: [us-east-1a, us-east-1b, us-east-1c]
+
+  cpu-license:                # Windows requiring a licensed image (same family)
+    provider: aws
+    image: ale-win10
+    resolution: [1024, 768]
+    aws:
+      region: us-east-1
+      security_group: ale-sandbox
+      instance_prefix: ale
+      tenancy: dedicated
+      zones: [us-east-1a, us-east-1b, us-east-1c]
+
+  gpu-free:                   # Windows + GPU (same family; GPU is the instance type)
+    provider: aws
+    image: ale-win10
+    resolution: [1920, 1080]
+    aws:
+      region: us-east-1
+      security_group: ale-sandbox
+      instance_prefix: ale
+      gpu: nvidia-l4          # truthy → g6 (NVIDIA L4)
+      tenancy: dedicated
+      zones: [us-east-1a, us-east-1b, us-east-1c]
+
+  gpu-license:                # Windows + GPU, licensed
+    provider: aws
+    image: ale-win10
+    resolution: [1920, 1080]
+    aws:
+      region: us-east-1
+      security_group: ale-sandbox
+      instance_prefix: ale
+      gpu: nvidia-l4
+      tenancy: dedicated
+      zones: [us-east-1a, us-east-1b, us-east-1c]
+
+# ---------------------------------------------------------------------------
+# Task data + output (substrate-coupled; mirrors environment.yaml).
+# ---------------------------------------------------------------------------
+# "baked_in_sandbox" (data baked into the AMI) | "s3://<bucket>".
+task_data_source: baked_in_sandbox
+
+# Output after the run: null | "local" | "s3://<bucket>". For full benchmark
+# runs set this to your results bucket and add `iam_instance_profile: ale-sandbox`
+# to each snapshot's aws: block (the in-box aws CLI writes via the instance role).
+output_path: local

--- a/configs/environments/environment_aws.yaml
+++ b/configs/environments/environment_aws.yaml
@@ -2,24 +2,23 @@
 # environment_aws.yaml — run ALE on AWS (EC2 + S3). AWS counterpart of
 # environment.yaml; same per-snapshot model and the SAME image-family names.
 # ============================================================================
-# Like the gcloud env, everything here is a hardcoded convention. There are NO
-# ${env:...} references: AWS credentials come from the ambient chain
-# (`aws configure` / env / instance role), and the VPC, subnets and AMIs are
-# resolved at run time by name/tag (set up once per the AWS setup docs):
-#   • image            image-FAMILY name (registry key under
-#                      ale_run/environments/images/) → resolved to the newest AMI
-#                      tagged `ale:image-family=<name>`. Pin one with `ami:`.
-#   • security_group   the firewall by NAME (gcloud analogue: `network`). The
-#                      provider resolves it to its id + the VPC it lives in; that
-#                      VPC scopes the AZ→subnet lookup.
-#   • zones            Availability-Zone names, tried in order on capacity errors.
-#   • tenancy          default | dedicated (Windows-10 client BYOL → dedicated).
-#   • gpu              truthy → a GPU instance type (g6 / NVIDIA L4).
+# Hardcoded conventions, no ${env:...} — AWS credentials come from your CLI
+# profile (`aws configure`); the VPC, subnets and AMIs are resolved by name at
+# run time (created once per docs/ale-docs-site AWS setup page). Per snapshot:
+#   • image            image family: ale-ubuntu22 (Linux) or ale-win10 /
+#                      ale-win-server (Windows — pick either).
+#   • security_group   the firewall, by name (gcloud analogue: `network`).
+#   • zones            Availability Zones, tried in order on capacity errors.
+#   • tenancy          default = shared host (cheap; the default). dedicated =
+#                      a host reserved to your account; only needed for strict
+#                      Windows-desktop license compliance — most users leave it
+#                      on default.
+#   • gpu              set for a GPU instance type.
 # ----------------------------------------------------------------------------
 
 snapshots:
 
-  cpu-free-ubuntu:            # Linux, no GPU — the bulk of tasks
+  cpu-free-ubuntu:            # Linux — the bulk of tasks
     provider: aws
     image: ale-ubuntu22
     aws:
@@ -28,7 +27,7 @@ snapshots:
       instance_prefix: ale
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
-  cpu-free:                   # Windows, no GPU
+  cpu-free:                   # Windows
     provider: aws
     image: ale-win10
     resolution: [1024, 768]
@@ -36,10 +35,9 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
-      tenancy: dedicated      # Win10 client BYOL is not licensed for shared tenancy
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
-  cpu-license:                # Windows requiring a licensed image (same family)
+  cpu-license:                # Windows (licensed-software tasks)
     provider: aws
     image: ale-win10
     resolution: [1024, 768]
@@ -47,10 +45,9 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
-      tenancy: dedicated
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
-  gpu-free:                   # GPU Windows = the license-included Server image (L4 driver baked in)
+  gpu-free:                   # Windows + GPU
     provider: aws
     image: ale-win-server
     resolution: [1920, 1080]
@@ -58,11 +55,10 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
-      gpu: nvidia-l4          # truthy → g6 (NVIDIA L4)
-      # license-included → shared tenancy (no BYOL/dedicated, unlike win10)
+      gpu: nvidia-l4
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
-  gpu-license:                # GPU Windows, licensed-image tasks (same Server image)
+  gpu-license:                # Windows + GPU (licensed-software tasks)
     provider: aws
     image: ale-win-server
     resolution: [1920, 1080]
@@ -74,12 +70,12 @@ snapshots:
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
 # ---------------------------------------------------------------------------
-# Task data + output (substrate-coupled; mirrors environment.yaml).
+# Task data + output (mirrors environment.yaml).
 # ---------------------------------------------------------------------------
-# "baked_in_sandbox" (data baked into the AMI) | "s3://<bucket>".
+# Where task data comes from: "baked_in_sandbox" (baked into the AMI) | "s3://<bucket>".
 task_data_source: baked_in_sandbox
 
-# Output after the run: null | "local" | "s3://<bucket>". For full benchmark
-# runs set this to your results bucket and add `iam_instance_profile: ale-sandbox`
-# to each snapshot's aws: block (the in-box aws CLI writes via the instance role).
+# What to do with each run's output: null | "local" | "s3://<bucket>". To keep
+# output in S3, set the bucket here and add `iam_instance_profile: ale-sandbox`
+# to each snapshot's aws: block.
 output_path: local

--- a/configs/environments/environment_aws.yaml
+++ b/configs/environments/environment_aws.yaml
@@ -50,28 +50,27 @@ snapshots:
       tenancy: dedicated
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
-  gpu-free:                   # Windows + GPU (same family; GPU is the instance type)
+  gpu-free:                   # GPU Windows = the license-included Server image (L4 driver baked in)
     provider: aws
-    image: ale-win10
+    image: ale-win-server
     resolution: [1920, 1080]
     aws:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
       gpu: nvidia-l4          # truthy → g6 (NVIDIA L4)
-      tenancy: dedicated
+      # license-included → shared tenancy (no BYOL/dedicated, unlike win10)
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
-  gpu-license:                # Windows + GPU, licensed
+  gpu-license:                # GPU Windows, licensed-image tasks (same Server image)
     provider: aws
-    image: ale-win10
+    image: ale-win-server
     resolution: [1920, 1080]
     aws:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
       gpu: nvidia-l4
-      tenancy: dedicated
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
 # ---------------------------------------------------------------------------

--- a/docs/ale-docs-site/assets/nav.js
+++ b/docs/ale-docs-site/assets/nav.js
@@ -21,6 +21,7 @@ window.ALE_NAV = [
     items: [
       { href: "/pages/providers.html", title: "Run an experiment", children: [
         { href: "/pages/google-cloud.html",  title: "Google Cloud VMs" },
+        { href: "/pages/aws.html",           title: "AWS EC2" },
         { href: "/pages/local-docker.html",  title: "Local containers" },
         { href: "/pages/local.html",         title: "QEMU/KVM VMs" },
         { href: "/pages/static.html",        title: "Existing sandbox" },

--- a/docs/ale-docs-site/pages/aws.html
+++ b/docs/ale-docs-site/pages/aws.html
@@ -33,14 +33,13 @@ export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)</cod
 
     <h2>① Create the network</h2>
     <p>
-      One VPC named by its security group <code>ale-sandbox</code>, with a public
-      subnet in three Availability Zones (tried in order if one is short on
-      capacity) and the port ALE needs open (<code>5000</code>; <code>3389</code>
-      for viewing a Windows desktop). The gcloud counterpart is the
-      <code>ale-vpc</code> network.
+      An <code>ale-vpc</code> network with a public subnet in three Availability
+      Zones (tried in order if one is short on capacity), and a security group
+      <code>ale-sandbox</code> opening the port ALE needs (<code>5000</code>;
+      <code>3389</code> to view a Windows desktop).
     </p>
     <pre><code>VPC=$(aws ec2 create-vpc --cidr-block 10.0.0.0/16 \
-  --tag-specifications 'ResourceType=vpc,Tags=[{Key=project,Value=ale}]' \
+  --tag-specifications 'ResourceType=vpc,Tags=[{Key=project,Value=ale},{Key=Name,Value=ale-vpc}]' \
   --query Vpc.VpcId --output text)
 aws ec2 modify-vpc-attribute --vpc-id $VPC --enable-dns-hostnames
 
@@ -72,7 +71,7 @@ aws ec2 authorize-security-group-ingress --group-id $SG --protocol tcp --port 33
     <ul>
       <li><code>ale-ubuntu22</code> — Linux (the bulk of tasks)</li>
       <li><code>ale-win10</code> or <code>ale-win-server</code> — Windows; either
-        works, choose whichever your tasks need</li>
+        one works, pick one</li>
     </ul>
     <pre><code># copy an image into your account (repeat per image you need)
 fam=ale-ubuntu22                       # or ale-win10 / ale-win-server
@@ -87,10 +86,15 @@ aws ec2 create-tags --resources $new --tags Key=ale:image-family,Value=$fam</cod
       while — it's a large disk.)
     </p>
 
-    <h2>③ Keep run output in S3 <span style="font-weight:400">(optional)</span></h2>
+    <h2>③ Keep run output in S3 <span style="font-weight:400">(recommended for real runs)</span></h2>
     <p>
-      By default each run's output is pulled back to your machine. To collect it
-      in S3 instead, create a bucket and a role that lets the sandbox upload to it:
+      With <code>output_path: local</code> each run's output is fetched back to
+      your machine over the sandbox's control port — fine for a quick demo, but
+      for large outputs at scale that's slow and flaky and drags down overall
+      throughput. So, exactly as on Google Cloud (where output goes to a GCS
+      bucket), the recommended path is to have the sandbox upload straight to S3.
+      Output is organized by run id, so you can find each run's files afterward.
+      Create the bucket and a role that lets the sandbox upload to it:
     </p>
     <pre><code>aws s3api create-bucket --bucket ale-run-results-$ACCOUNT --region us-east-1
 

--- a/docs/ale-docs-site/pages/aws.html
+++ b/docs/ale-docs-site/pages/aws.html
@@ -13,57 +13,31 @@
   <article class="article">
     <h1>Set up AWS</h1>
     <p class="lede">
-      One-time provisioning to run ALE on AWS: credentials, a network, and the
-      two sandbox images as AMIs. Each step explains what it sets up and why.
-      Unlike Google Cloud there is no env-var wiring — credentials live in your
-      AWS CLI profile and everything else is a fixed convention the environment
-      config resolves by name at run time.
+      One-time setup to run ALE on AWS: sign in, create a network, and copy the
+      sandbox images into your account. Then point an experiment at the AWS
+      environment and run. Credentials live in your AWS CLI profile; everything
+      else is created once below.
     </p>
 
-    <div class="note warn">
-      <div class="note-title">Linux is easy; Windows is not</div>
-      <strong>Linux</strong> (the <code>demo/hello</code> task and the
-      <code>cpu-free-ubuntu</code> tasks) runs on ordinary shared EC2 with no
-      special licensing. <strong>Windows 10</strong> is a desktop/client OS: AWS
-      sells no license for it, so it is <strong>BYOL</strong> (you supply a
-      Microsoft VDA E3/E5 subscription) and must run on <strong>dedicated
-      tenancy</strong> (raised via an AWS Support case). Start with Linux.
-    </div>
-
-    <h2>Create an AWS account and install the AWS CLI</h2>
+    <h2>Sign in</h2>
     <p>
-      Skip the account step if you already have one. Open
-      <a href="https://aws.amazon.com/">aws.amazon.com</a> →
-      <em>Create an AWS Account</em> and complete sign-up (email, a card for
-      identity verification, phone verification, the Basic/Free plan). There is
-      no blanket free credit; you pay for what you use (getting Linux working end
-      to end costs a few US dollars, mostly EBS storage).
+      Create an <a href="https://aws.amazon.com/">AWS account</a> if you don't
+      have one, install the
+      <a href="https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html">AWS CLI</a>,
+      and sign in. In the console make an IAM user with
+      <code>AdministratorAccess</code>, create an access key for it, then:
     </p>
-    <p>
-      Install the
-      <a href="https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html">AWS CLI v2</a>,
-      create an IAM user with programmatic access (Console → IAM → Users →
-      <em>Create user</em> → attach <code>AdministratorAccess</code> for setup),
-      make an access key, then point the CLI at it. The CLI profile is the only
-      place credentials live — the ALE config never names them.
-    </p>
-    <pre><code>aws configure                 # paste Access Key ID + Secret, region us-east-1, output json
-aws sts get-caller-identity   # confirms you're authenticated
-export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-export AWS_REGION=us-east-1</code></pre>
+    <pre><code>aws configure                 # paste the access key, region us-east-1, output json
+export AWS_REGION=us-east-1
+export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)</code></pre>
 
-    <h2>Provision the account</h2>
-
-    <h3>① Open the network path to the sandbox</h3>
+    <h2>① Create the network</h2>
     <p>
-      Each instance comes up in a <strong>VPC</strong> with a public IP. ALE
-      reaches the in-VM control server over <code>tcp:5000</code>, so a
-      <strong>security group</strong> must allow that (RDP <code>3389</code> is
-      optional, for watching a Windows desktop). The config names the security
-      group <code>ale-sandbox</code>; the provider resolves it to its id and the
-      VPC it lives in, and picks a subnet per Availability Zone (one per AZ gives
-      capacity fallback). Tag the VPC and subnets <code>project=ale</code> so the
-      provider finds them.
+      One VPC named by its security group <code>ale-sandbox</code>, with a public
+      subnet in three Availability Zones (tried in order if one is short on
+      capacity) and the port ALE needs open (<code>5000</code>; <code>3389</code>
+      for viewing a Windows desktop). The gcloud counterpart is the
+      <code>ale-vpc</code> network.
     </p>
     <pre><code>VPC=$(aws ec2 create-vpc --cidr-block 10.0.0.0/16 \
   --tag-specifications 'ResourceType=vpc,Tags=[{Key=project,Value=ale}]' \
@@ -85,41 +59,38 @@ i=1; for az in us-east-1a us-east-1b us-east-1c; do
 done
 
 SG=$(aws ec2 create-security-group --group-name ale-sandbox \
-  --description "ALE cua-server ingress" --vpc-id $VPC --query GroupId --output text)
+  --description "ALE sandbox ingress" --vpc-id $VPC --query GroupId --output text)
 aws ec2 authorize-security-group-ingress --group-id $SG --protocol tcp --port 5000 --cidr 0.0.0.0/0
 aws ec2 authorize-security-group-ingress --group-id $SG --protocol tcp --port 3389 --cidr 0.0.0.0/0</code></pre>
 
-    <h3 id="images">② The sandbox images (AMIs)</h3>
+    <h2>② Copy the sandbox images</h2>
     <p>
-      A task boots from a <strong>prebaked image</strong>: an OS with the
-      professional software, ALE's in-VM tooling, and the task data already baked
-      in. ALE has two families — <code>ale-ubuntu22</code> (Linux) and
-      <code>ale-win10</code> (Windows), the same names the Google Cloud setup
-      uses. ALE publishes both as <strong>public AMIs in us-east-1</strong>, so in
-      that region there is nothing to do — the provider resolves the family name
-      to the published AMI automatically (it looks up the newest AMI tagged
-      <code>ale:image-family=&lt;name&gt;</code>).
+      A task boots from a prebaked image (the OS, the professional software, and
+      the task data, ready to go). ALE publishes them publicly; copy the one(s)
+      you need into your account once. Pick by what your tasks run on:
     </p>
-    <div class="note warn">
-      <div class="note-title">Using the public AMIs from your own account</div>
-      AMI tags are private to the owner, so the family auto-lookup only sees AMIs
-      <em>in your account</em>. To use ALE's published AMIs, either pin the id in
-      the snapshot (<code>ami: ami-…</code>, found via
-      <code>aws ec2 describe-images --owners&nbsp;&lt;ale-account&gt;
-      --filters Name=is-public,Values=true</code>), or copy one into your account
-      and tag it so the lookup finds it:
-      <pre><code>NEW=$(aws ec2 copy-image --source-region us-east-1 --source-image-id ami-XXXX \
-  --name ale-ubuntu22 --query ImageId --output text)
-aws ec2 create-tags --resources $NEW --tags Key=ale:image-family,Value=ale-ubuntu22</code></pre>
-      Windows is BYOL — run it only under your own Microsoft VDA license.
-    </div>
-
-    <h3 id="results">③ Results bucket for output (recommended for full runs)</h3>
+    <ul>
+      <li><code>ale-ubuntu22</code> — Linux (the bulk of tasks)</li>
+      <li><code>ale-win10</code> or <code>ale-win-server</code> — Windows; either
+        works, choose whichever your tasks need</li>
+    </ul>
+    <pre><code># copy an image into your account (repeat per image you need)
+fam=ale-ubuntu22                       # or ale-win10 / ale-win-server
+src=$(aws ec2 describe-images --region us-east-1 --owners 670060057810 \
+  --filters "Name=description,Values=$fam" --query 'Images[0].ImageId' --output text)
+new=$(aws ec2 copy-image --source-region us-east-1 --source-image-id $src \
+  --name $fam --description $fam --query ImageId --output text)
+aws ec2 create-tags --resources $new --tags Key=ale:image-family,Value=$fam</code></pre>
     <p>
-      To keep the agents' output, push it to an <strong>S3 results bucket</strong>
-      (the AWS analogue of gcloud's results bucket). Create the bucket and an IAM
-      <strong>instance profile</strong> the sandbox assumes at launch — the in-VM
-      <code>aws</code> CLI then writes to S3 with no key injected:
+      The environment config refers to images by these family names, so once
+      copied they're picked up automatically. (Copying a Windows image takes a
+      while — it's a large disk.)
+    </p>
+
+    <h2>③ Keep run output in S3 <span style="font-weight:400">(optional)</span></h2>
+    <p>
+      By default each run's output is pulled back to your machine. To collect it
+      in S3 instead, create a bucket and a role that lets the sandbox upload to it:
     </p>
     <pre><code>aws s3api create-bucket --bucket ale-run-results-$ACCOUNT --region us-east-1
 
@@ -133,46 +104,28 @@ aws iam add-role-to-instance-profile --instance-profile-name ale-sandbox --role-
     <p>
       Then in <code>configs/environments/environment_aws.yaml</code> set
       <code>output_path: s3://ale-run-results-&lt;account&gt;</code> and add
-      <code>iam_instance_profile: ale-sandbox</code> to each snapshot's
-      <code>aws:</code> block. Output lands at <code>…/&lt;run_id&gt;/output/</code>.
-      (Leave <code>output_path: local</code> to pull output to the host instead.)
+      <code>iam_instance_profile: ale-sandbox</code> under each snapshot's
+      <code>aws:</code> block.
     </p>
 
-    <h3 id="windows">④ Windows only: dedicated tenancy + GPU quota</h3>
+    <h2>④ Run</h2>
     <p>
-      Both are raised through AWS Support / Service Quotas (a new account starts
-      near zero; approval takes hours to days):
-    </p>
-    <ul>
-      <li><strong>Dedicated tenancy</strong> — required for Windows 10 BYOL. The
-      config already marks Windows snapshots <code>tenancy: dedicated</code>;
-      open a Support case for Dedicated Instances in your region.</li>
-      <li><strong>GPU</strong> — the <code>gpu-*</code> snapshots use a
-      <code>g6</code> instance (NVIDIA L4). Request an increase to the
-      "Running On-Demand G and VT instances" quota (Service Quotas, self-service).</li>
-    </ul>
-    <div class="note warn">
-      <div class="note-title">GPU is not tested yet</div>
-      The <code>gpu-*</code> path is wired but <strong>unverified</strong>: a new
-      account's GPU quota starts at 0 (the increase needs an AWS Support case),
-      and whether the image's baked NVIDIA driver binds and licenses on AWS GPUs
-      has not been confirmed. Treat GPU on AWS as experimental until validated.
-    </div>
-
-    <h3>⑤ Point the experiment at it and run</h3>
-    <p>
-      <code>configs/environments/environment_aws.yaml</code> is the AWS
-      counterpart of <code>environment.yaml</code> — names each image by family,
-      its security group <code>ale-sandbox</code>, and the AZs. In your
-      experiment yaml set <code>environment: configs/environments/environment_aws.yaml</code>,
-      then run as usual:
+      Point your experiment at the AWS environment
+      (<code>environment: configs/environments/environment_aws.yaml</code>) and run:
     </p>
     <pre><code>uv run python -m ale_run run my_experiment.yaml</code></pre>
 
     <div class="note">
+      <div class="note-title">GPU tasks: not yet validated</div>
+      The GPU snapshots are wired but haven't been run on AWS yet (GPU capacity
+      needs a quota increase, requested via AWS Support). Use the CPU snapshots
+      for now.
+    </div>
+
+    <div class="note">
       <div class="note-title">Next</div>
-      Provisioning done. Wire an experiment: environment, agents, keys, and the
-      run command: <a href="/pages/configure.html">Configure &amp; run a benchmark →</a>
+      Provisioning done. Wire an experiment — agents, keys, and the run command:
+      <a href="/pages/configure.html">Configure &amp; run a benchmark →</a>
     </div>
   </article>
 

--- a/docs/ale-docs-site/pages/aws.html
+++ b/docs/ale-docs-site/pages/aws.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Set up AWS | ALE Docs</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/style.css" />
+</head>
+<body>
+  <article class="article">
+    <h1>Set up AWS</h1>
+    <p class="lede">
+      One-time provisioning to run ALE on AWS: credentials, a network, and the
+      two sandbox images as AMIs. Each step explains what it sets up and why.
+      Unlike Google Cloud there is no env-var wiring — credentials live in your
+      AWS CLI profile and everything else is a fixed convention the environment
+      config resolves by name at run time.
+    </p>
+
+    <div class="note warn">
+      <div class="note-title">Linux is easy; Windows is not</div>
+      <strong>Linux</strong> (the <code>demo/hello</code> task and the
+      <code>cpu-free-ubuntu</code> tasks) runs on ordinary shared EC2 with no
+      special licensing. <strong>Windows 10</strong> is a desktop/client OS: AWS
+      sells no license for it, so it is <strong>BYOL</strong> (you supply a
+      Microsoft VDA E3/E5 subscription) and must run on <strong>dedicated
+      tenancy</strong> (raised via an AWS Support case). Start with Linux.
+    </div>
+
+    <h2>Create an AWS account and install the AWS CLI</h2>
+    <p>
+      Skip the account step if you already have one. Open
+      <a href="https://aws.amazon.com/">aws.amazon.com</a> →
+      <em>Create an AWS Account</em> and complete sign-up (email, a card for
+      identity verification, phone verification, the Basic/Free plan). There is
+      no blanket free credit; you pay for what you use (getting Linux working end
+      to end costs a few US dollars, mostly EBS storage).
+    </p>
+    <p>
+      Install the
+      <a href="https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html">AWS CLI v2</a>,
+      create an IAM user with programmatic access (Console → IAM → Users →
+      <em>Create user</em> → attach <code>AdministratorAccess</code> for setup),
+      make an access key, then point the CLI at it. The CLI profile is the only
+      place credentials live — the ALE config never names them.
+    </p>
+    <pre><code>aws configure                 # paste Access Key ID + Secret, region us-east-1, output json
+aws sts get-caller-identity   # confirms you're authenticated
+export ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+export AWS_REGION=us-east-1</code></pre>
+
+    <h2>Provision the account</h2>
+
+    <h3>① Open the network path to the sandbox</h3>
+    <p>
+      Each instance comes up in a <strong>VPC</strong> with a public IP. ALE
+      reaches the in-VM control server over <code>tcp:5000</code>, so a
+      <strong>security group</strong> must allow that (RDP <code>3389</code> is
+      optional, for watching a Windows desktop). The config names the security
+      group <code>ale-sandbox</code>; the provider resolves it to its id and the
+      VPC it lives in, and picks a subnet per Availability Zone (one per AZ gives
+      capacity fallback). Tag the VPC and subnets <code>project=ale</code> so the
+      provider finds them.
+    </p>
+    <pre><code>VPC=$(aws ec2 create-vpc --cidr-block 10.0.0.0/16 \
+  --tag-specifications 'ResourceType=vpc,Tags=[{Key=project,Value=ale}]' \
+  --query Vpc.VpcId --output text)
+aws ec2 modify-vpc-attribute --vpc-id $VPC --enable-dns-hostnames
+
+IGW=$(aws ec2 create-internet-gateway --query InternetGateway.InternetGatewayId --output text)
+aws ec2 attach-internet-gateway --internet-gateway-id $IGW --vpc-id $VPC
+RT=$(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=$VPC" \
+  "Name=association.main,Values=true" --query 'RouteTables[0].RouteTableId' --output text)
+aws ec2 create-route --route-table-id $RT --destination-cidr-block 0.0.0.0/0 --gateway-id $IGW
+
+i=1; for az in us-east-1a us-east-1b us-east-1c; do
+  SN=$(aws ec2 create-subnet --vpc-id $VPC --availability-zone $az --cidr-block 10.0.$i.0/24 \
+    --tag-specifications 'ResourceType=subnet,Tags=[{Key=project,Value=ale}]' \
+    --query Subnet.SubnetId --output text)
+  aws ec2 modify-subnet-attribute --subnet-id $SN --map-public-ip-on-launch
+  aws ec2 associate-route-table --route-table-id $RT --subnet-id $SN; i=$((i+1))
+done
+
+SG=$(aws ec2 create-security-group --group-name ale-sandbox \
+  --description "ALE cua-server ingress" --vpc-id $VPC --query GroupId --output text)
+aws ec2 authorize-security-group-ingress --group-id $SG --protocol tcp --port 5000 --cidr 0.0.0.0/0
+aws ec2 authorize-security-group-ingress --group-id $SG --protocol tcp --port 3389 --cidr 0.0.0.0/0</code></pre>
+
+    <h3 id="images">② The sandbox images (AMIs)</h3>
+    <p>
+      A task boots from a <strong>prebaked image</strong>: an OS with the
+      professional software, ALE's in-VM tooling, and the task data already baked
+      in. ALE has two families — <code>ale-ubuntu22</code> (Linux) and
+      <code>ale-win10</code> (Windows), the same names the Google Cloud setup
+      uses. ALE publishes both as <strong>public AMIs in us-east-1</strong>, so in
+      that region there is nothing to do — the provider resolves the family name
+      to the published AMI automatically (it looks up the newest AMI tagged
+      <code>ale:image-family=&lt;name&gt;</code>).
+    </p>
+    <div class="note warn">
+      <div class="note-title">Using the public AMIs from your own account</div>
+      AMI tags are private to the owner, so the family auto-lookup only sees AMIs
+      <em>in your account</em>. To use ALE's published AMIs, either pin the id in
+      the snapshot (<code>ami: ami-…</code>, found via
+      <code>aws ec2 describe-images --owners&nbsp;&lt;ale-account&gt;
+      --filters Name=is-public,Values=true</code>), or copy one into your account
+      and tag it so the lookup finds it:
+      <pre><code>NEW=$(aws ec2 copy-image --source-region us-east-1 --source-image-id ami-XXXX \
+  --name ale-ubuntu22 --query ImageId --output text)
+aws ec2 create-tags --resources $NEW --tags Key=ale:image-family,Value=ale-ubuntu22</code></pre>
+      Windows is BYOL — run it only under your own Microsoft VDA license.
+    </div>
+
+    <h3 id="results">③ Results bucket for output (recommended for full runs)</h3>
+    <p>
+      To keep the agents' output, push it to an <strong>S3 results bucket</strong>
+      (the AWS analogue of gcloud's results bucket). Create the bucket and an IAM
+      <strong>instance profile</strong> the sandbox assumes at launch — the in-VM
+      <code>aws</code> CLI then writes to S3 with no key injected:
+    </p>
+    <pre><code>aws s3api create-bucket --bucket ale-run-results-$ACCOUNT --region us-east-1
+
+aws iam create-role --role-name ale-sandbox --assume-role-policy-document '{"Version":"2012-10-17",
+  "Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+aws iam put-role-policy --role-name ale-sandbox --policy-name s3 --policy-document '{"Version":"2012-10-17",
+  "Statement":[{"Effect":"Allow","Action":["s3:PutObject","s3:ListBucket"],
+    "Resource":["arn:aws:s3:::ale-run-results-'$ACCOUNT'","arn:aws:s3:::ale-run-results-'$ACCOUNT'/*"]}]}'
+aws iam create-instance-profile --instance-profile-name ale-sandbox
+aws iam add-role-to-instance-profile --instance-profile-name ale-sandbox --role-name ale-sandbox</code></pre>
+    <p>
+      Then in <code>configs/environments/environment_aws.yaml</code> set
+      <code>output_path: s3://ale-run-results-&lt;account&gt;</code> and add
+      <code>iam_instance_profile: ale-sandbox</code> to each snapshot's
+      <code>aws:</code> block. Output lands at <code>…/&lt;run_id&gt;/output/</code>.
+      (Leave <code>output_path: local</code> to pull output to the host instead.)
+    </p>
+
+    <h3 id="windows">④ Windows only: dedicated tenancy + GPU quota</h3>
+    <p>
+      Both are raised through AWS Support / Service Quotas (a new account starts
+      near zero; approval takes hours to days):
+    </p>
+    <ul>
+      <li><strong>Dedicated tenancy</strong> — required for Windows 10 BYOL. The
+      config already marks Windows snapshots <code>tenancy: dedicated</code>;
+      open a Support case for Dedicated Instances in your region.</li>
+      <li><strong>GPU</strong> — the <code>gpu-*</code> snapshots use a
+      <code>g6</code> instance (NVIDIA L4). Request an increase to the
+      "Running On-Demand G and VT instances" quota (Service Quotas, self-service).</li>
+    </ul>
+    <div class="note warn">
+      <div class="note-title">GPU is not tested yet</div>
+      The <code>gpu-*</code> path is wired but <strong>unverified</strong>: a new
+      account's GPU quota starts at 0 (the increase needs an AWS Support case),
+      and whether the image's baked NVIDIA driver binds and licenses on AWS GPUs
+      has not been confirmed. Treat GPU on AWS as experimental until validated.
+    </div>
+
+    <h3>⑤ Point the experiment at it and run</h3>
+    <p>
+      <code>configs/environments/environment_aws.yaml</code> is the AWS
+      counterpart of <code>environment.yaml</code> — names each image by family,
+      its security group <code>ale-sandbox</code>, and the AZs. In your
+      experiment yaml set <code>environment: configs/environments/environment_aws.yaml</code>,
+      then run as usual:
+    </p>
+    <pre><code>uv run python -m ale_run run my_experiment.yaml</code></pre>
+
+    <div class="note">
+      <div class="note-title">Next</div>
+      Provisioning done. Wire an experiment: environment, agents, keys, and the
+      run command: <a href="/pages/configure.html">Configure &amp; run a benchmark →</a>
+    </div>
+  </article>
+
+  <script src="/assets/nav.js"></script>
+  <script src="/assets/app.js"></script>
+</body>
+</html>

--- a/docs/ale-docs-site/pages/providers.html
+++ b/docs/ale-docs-site/pages/providers.html
@@ -46,6 +46,12 @@ uv sync --all-packages</code></pre>
           <td>Production benchmark runs and elastic concurrency</td>
         </tr>
         <tr>
+          <td><a href="/pages/aws.html"><strong>AWS EC2</strong></a><br><code>aws</code></td>
+          <td>A fresh EC2 instance for every run unit</td>
+          <td>Linux + Windows from public AMIs. GPU is wired but untested.</td>
+          <td>Production runs on AWS instead of/alongside GCP</td>
+        </tr>
+        <tr>
           <td><a href="/pages/local-docker.html"><strong>Local containers</strong></a><br><code>docker</code></td>
           <td>A fresh Linux container for every run unit</td>
           <td>99 tasks in <code>docker_support.txt</code></td>
@@ -112,6 +118,11 @@ uv sync --all-packages</code></pre>
         <div class="k">Supported</div>
         <div class="t">Local containers</div>
         <div class="d">A lighter local Linux sandbox with host-staged task data.</div>
+      </a>
+      <a class="card" href="/pages/aws.html">
+        <div class="k">Supported</div>
+        <div class="t">AWS</div>
+        <div class="d">Ephemeral EC2 instances + S3. Linux ready; Windows is BYOL + dedicated.</div>
       </a>
       <a class="card" href="/pages/local.html">
         <div class="k">Supported</div>

--- a/scripts/aws/import_images.sh
+++ b/scripts/aws/import_images.sh
@@ -113,7 +113,10 @@ import_linux() {                     # $1 family (ale-ubuntu22)
     --query 'Reservations[0].Instances[0].PublicIpAddress' --output text 2>/dev/null); [ -n "$ip" ] && [ "$ip" != None ] && break; sleep 10; done
   wait_cua "$ip" || { aws ec2 terminate-instances --region $R --instance-ids "$iid" >/dev/null; return 1; }
   local inst='curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/a.zip && cd /tmp && unzip -q -o a.zip && sudo ./aws/install --update && rm -rf /tmp/aws /tmp/a.zip && /usr/local/bin/aws --version'
-  curl -s --max-time 180 -X POST "http://$ip:5000/cmd" -H 'Content-Type: application/json' \
+  # 900s: the aws CLI install (~100MB download + unzip + sudo install) can take
+  # several minutes on a cold instance; too short and curl drops before the
+  # single SSE `data:` reply, aborting the script (set -o pipefail) + leaking the builder.
+  curl -s --max-time 900 -X POST "http://$ip:5000/cmd" -H 'Content-Type: application/json' \
     -d "$(python3 -c 'import json,sys;print(json.dumps({"command":"run_command","params":{"command":sys.argv[1]}}))' "$inst")" \
     | tr '\r' '\n' | grep '^data:' | head -1 | sed 's/^data: //' | J "['stdout'][-60:]"
   ami1=$(aws ec2 create-image --region $R --instance-id "$iid" --name "$fam-$(date +%s)" \

--- a/scripts/aws/import_images.sh
+++ b/scripts/aws/import_images.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Import ALE sandbox images from gs://ale-data-public/images/ into AWS as public
+# AMIs. One re-runnable script for the whole flow (replaces the old per-image
+# scripts). Idempotent-ish: skips the S3 transfer if the raw is already there.
+#
+#   ./import_images.sh ale-ubuntu22       # Linux: import-snapshot+register, bake aws CLI
+#   ./import_images.sh ale-win10          # Windows 10 desktop: BYOL
+#   ./import_images.sh ale-win-server     # Windows Server: license-included
+#   ./import_images.sh all                # all three
+#
+# Per image it: streams the GCS tar.gz (disk.raw) into the S3 import bucket
+# (no local staging), turns it into an AMI, tags it `ale:image-family=<name>`
+# (the tag AwsProvider resolves), and makes it + its snapshot public in us-east-1.
+#
+# Why per-OS paths: import-image validates the guest OS and rejects ALE's Ubuntu
+# HWE kernel, so Linux goes import-snapshot + register-image (no OS check) and
+# then bakes the aws CLI in (needed for s3:// data/output). Windows goes
+# import-image with the right --license-type (Win10 client = BYOL only;
+# Win Server = AWS license-included so it runs on cheap shared tenancy).
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+R=us-east-1
+ACCT=$(aws sts get-caller-identity --query Account --output text)
+BUCKET=ale-images-$ACCT
+GCS=gs://ale-data-public/images
+SG_NAME=ale-sandbox
+say() { printf '\n=== %s ===\n' "$*"; }
+J() { python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+
+ensure_raw() {                       # $1 family → ensure s3://$BUCKET/images/$1.raw
+  local key="images/$1.raw"
+  if aws s3 ls "s3://$BUCKET/$key" >/dev/null 2>&1; then echo "raw present: $1"; return; fi
+  say "stream $GCS/$1.tar.gz -> s3://$BUCKET/$key"
+  aws configure set default.s3.multipart_chunksize 512MB
+  gsutil cat "$GCS/$1.tar.gz" | tar -xzO | aws s3 cp - "s3://$BUCKET/$key"
+}
+
+subnet_in_sg_vpc() {                 # echo a subnet id in the SG's VPC
+  local vpc; vpc=$(aws ec2 describe-security-groups --region $R \
+    --filters Name=group-name,Values=$SG_NAME --query 'SecurityGroups[0].VpcId' --output text)
+  aws ec2 describe-subnets --region $R \
+    --filters "Name=vpc-id,Values=$vpc" "Name=tag:project,Values=ale" \
+    --query 'Subnets[0].SubnetId' --output text
+}
+
+wait_cua() {                         # $1 ip — wait up to 20 min for cua :5000
+  local ip=$1
+  for _ in $(seq 1 80); do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 6 "http://$ip:5000/status" 2>/dev/null)" = 200 ] \
+      && { echo "cua ready at $ip"; return 0; }
+    sleep 15
+  done
+  echo "cua never came up at $ip"; return 1
+}
+
+publish() {                          # $1 ami, $2 family — tag + make public (+ snapshot)
+  aws ec2 create-tags --region $R --resources "$1" \
+    --tags Key=ale:image-family,Value=$2 Key=Name,Value=$2
+  aws ec2 modify-image-attribute --region $R --image-id "$1" --launch-permission "Add=[{Group=all}]" || \
+    echo "NOTE: could not make $1 public (license-included Windows may be account-private; others copy-image instead)"
+  local snap; snap=$(aws ec2 describe-images --region $R --image-ids "$1" \
+    --query 'Images[0].BlockDeviceMappings[0].Ebs.SnapshotId' --output text)
+  aws ec2 modify-snapshot-attribute --region $R --snapshot-id "$snap" \
+    --create-volume-permission "Add=[{Group=all}]" 2>/dev/null || true
+  echo "published $1 ($2)"
+}
+
+poll_import_snapshot() {             # $1 task → echo SnapshotId
+  while :; do
+    read -r st pr snap < <(aws ec2 describe-import-snapshot-tasks --region $R --import-task-ids "$1" \
+      --query 'ImportSnapshotTasks[0].SnapshotTaskDetail.[Status,Progress,SnapshotId]' --output text)
+    printf '  snap %s %s%%\n' "$st" "${pr:-?}" >&2
+    [ "$st" = completed ] && { echo "$snap"; return; }
+    case "$st" in deleted|*[Ee]rror*) echo "FAILED" >&2; return 1;; esac
+    sleep 60
+  done
+}
+
+poll_import_image() {                # $1 task → echo ImageId
+  while :; do
+    read -r st pr img msg < <(aws ec2 describe-import-image-tasks --region $R --import-task-ids "$1" \
+      --query 'ImportImageTasks[0].[Status,Progress,ImageId,StatusMessage]' --output text)
+    printf '  image %s %s%% %s\n' "$st" "${pr:-?}" "${msg:-}" >&2
+    [ "$st" = completed ] && { echo "$img"; return; }
+    case "$st" in deleted|*[Ee]rror*) echo "FAILED" >&2; return 1;; esac
+    sleep 60
+  done
+}
+
+import_linux() {                     # $1 family (ale-ubuntu22)
+  local fam=$1; ensure_raw "$fam"
+  say "$fam: import-snapshot (bypasses import-image OS/kernel check)"
+  local cont task snap ami0
+  cont=$(mktemp); printf '{"Description":"%s","Format":"raw","UserBucket":{"S3Bucket":"%s","S3Key":"images/%s.raw"}}' "$fam" "$BUCKET" "$fam" > "$cont"
+  task=$(aws ec2 import-snapshot --region $R --description "$fam" --disk-container "file://$cont" --query ImportTaskId --output text)
+  rm -f "$cont"; echo "import-snapshot task: $task"
+  snap=$(poll_import_snapshot "$task"); [ "$snap" = FAILED ] && return 1
+  say "$fam: register base AMI from $snap"
+  ami0=$(aws ec2 register-image --region $R --name "$fam-base-$(date +%s)" \
+    --architecture x86_64 --root-device-name /dev/sda1 --virtualization-type hvm \
+    --ena-support --boot-mode uefi \
+    --block-device-mappings "DeviceName=/dev/sda1,Ebs={SnapshotId=$snap,VolumeType=gp3,DeleteOnTermination=true}" \
+    --query ImageId --output text)
+  say "$fam: bake aws CLI (launch base, install, create-image)"
+  local subnet sg iid ip ami1
+  subnet=$(subnet_in_sg_vpc)
+  sg=$(aws ec2 describe-security-groups --region $R --filters Name=group-name,Values=$SG_NAME --query 'SecurityGroups[0].GroupId' --output text)
+  iid=$(aws ec2 run-instances --region $R --image-id "$ami0" --instance-type m6i.xlarge --count 1 \
+    --subnet-id "$subnet" --security-group-ids "$sg" --associate-public-ip-address \
+    --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=ale-rebake},{Key=purpose,Value=ale-run}]' \
+    --query 'Instances[0].InstanceId' --output text)
+  for _ in $(seq 1 40); do ip=$(aws ec2 describe-instances --region $R --instance-ids "$iid" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text 2>/dev/null); [ -n "$ip" ] && [ "$ip" != None ] && break; sleep 10; done
+  wait_cua "$ip" || { aws ec2 terminate-instances --region $R --instance-ids "$iid" >/dev/null; return 1; }
+  local inst='curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/a.zip && cd /tmp && unzip -q -o a.zip && sudo ./aws/install --update && rm -rf /tmp/aws /tmp/a.zip && /usr/local/bin/aws --version'
+  curl -s --max-time 180 -X POST "http://$ip:5000/cmd" -H 'Content-Type: application/json' \
+    -d "$(python3 -c 'import json,sys;print(json.dumps({"command":"run_command","params":{"command":sys.argv[1]}}))' "$inst")" \
+    | tr '\r' '\n' | grep '^data:' | head -1 | sed 's/^data: //' | J "['stdout'][-60:]"
+  ami1=$(aws ec2 create-image --region $R --instance-id "$iid" --name "$fam-$(date +%s)" \
+    --description "$fam + aws CLI (public)" --query ImageId --output text)
+  poll_import_image_state "$ami1"
+  publish "$ami1" "$fam"
+  # retire base AMI + builder
+  aws ec2 deregister-image --region $R --image-id "$ami0" 2>/dev/null || true
+  aws ec2 delete-snapshot --region $R --snapshot-id "$snap" 2>/dev/null || true
+  aws ec2 terminate-instances --region $R --instance-ids "$iid" >/dev/null
+  echo "LINUX_DONE $fam -> $ami1"
+}
+
+poll_import_image_state() {          # $1 ami — wait until available
+  while :; do
+    local st; st=$(aws ec2 describe-images --region $R --image-ids "$1" --query 'Images[0].State' --output text)
+    echo "  $1 $st" >&2; [ "$st" = available ] && return; [ "$st" = failed ] && return 1; sleep 30
+  done
+}
+
+import_windows() {                   # $1 family, $2 license (BYOL|AWS)
+  local fam=$1 lic=$2; ensure_raw "$fam"
+  say "$fam: import-image (Windows, --license-type $lic)"
+  local cont task ami
+  cont=$(mktemp); printf '[{"Description":"%s","Format":"raw","UserBucket":{"S3Bucket":"%s","S3Key":"images/%s.raw"}}]' "$fam" "$BUCKET" "$fam" > "$cont"
+  task=$(aws ec2 import-image --region $R --description "$fam" --platform Windows \
+    --architecture x86_64 --license-type "$lic" --boot-mode uefi \
+    --disk-containers "file://$cont" --query ImportTaskId --output text)
+  rm -f "$cont"; echo "import-image task: $task"
+  ami=$(poll_import_image "$task"); [ "$ami" = FAILED ] && return 1
+  publish "$ami" "$fam"
+  echo "WINDOWS_DONE $fam -> $ami"
+}
+
+case "${1:?usage: import_images.sh ale-ubuntu22|ale-win10|ale-win-server|all}" in
+  ale-ubuntu22)   import_linux ale-ubuntu22 ;;
+  ale-win10)      import_windows ale-win10 BYOL ;;
+  ale-win-server) import_windows ale-win-server AWS ;;
+  all)            import_linux ale-ubuntu22; import_windows ale-win10 BYOL; import_windows ale-win-server AWS ;;
+  *) echo "unknown image $1"; exit 2 ;;
+esac

--- a/scripts/aws/sync_task_data.sh
+++ b/scripts/aws/sync_task_data.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Sync ALE task data from gs://ale-data-public (GCS) to the AWS S3 task-data
+# bucket. Streams cloud→cloud via gsutil (no local staging — the full dataset is
+# ~1.5 TiB and won't fit on disk). The S3 bucket is requester-pays + public, so
+# pullers (not the owner) pay egress — mirrors gcloud's ale-data-public.
+#
+# Auth: GCS reads use the host's gcloud login + a billing project (ale-data-public
+# is requester-pays); S3 writes use your AWS creds (~/.aws) bridged into a temp
+# boto config so gsutil can address s3://.
+#
+# Usage:  ./sync_task_data.sh [gs://src] [s3://dst]
+#   defaults: gs://ale-data-public  ->  s3://ale-data-<account>
+#   sync one subtree:  ./sync_task_data.sh gs://ale-data-public/demo s3://ale-data-<acct>/demo
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+ACCT=$(aws sts get-caller-identity --query Account --output text)
+SRC="${1:-gs://ale-data-public}"
+DST="${2:-s3://ale-data-$ACCT}"
+BILLING="${ALE_GCS_BILLING_PROJECT:-agenthle-488519}"   # billed for requester-pays GCS reads
+
+# Bridge AWS creds into a boto config so gsutil can write to s3://.
+AKID=$(aws configure get aws_access_key_id)
+ASK=$(aws configure get aws_secret_access_key)
+BOTO=$(mktemp); trap 'rm -f "$BOTO"' EXIT
+cat > "$BOTO" <<CFG
+[Credentials]
+aws_access_key_id = $AKID
+aws_secret_access_key = $ASK
+CFG
+
+# Exclude images/ — that prefix holds the multi-hundred-GB VM image EXPORTS
+# (qcow2/vmdk/tar.gz), which are NOT task data; they become AMIs via
+# scripts/aws/import_images.sh. Task data is only the domain dirs (~260 GiB).
+echo "syncing $SRC -> $DST (requester-pays GCS billed to $BILLING; excluding images/)"
+BOTO_CONFIG="$BOTO" gsutil -u "$BILLING" -m rsync -r -x '^images/.*' "$SRC" "$DST"
+echo "DONE: $DST is in sync with $SRC (task data only)"


### PR DESCRIPTION
## Problem

ALE could only provision task sandboxes on **Google Cloud** (GCE VMs via
`GcloudProvider`, task data via `gs://`). This PR adds **AWS** (EC2 + S3) as a
first-class backend, mirroring the gcloud path in shape and config.

## What's implemented

- **`environments/providers/aws.py`** — `AwsProvider`: EC2 `run-instances` from
  an AMI, instance-type × Availability-Zone capacity fallback, public-IP poll,
  terminate-on-failure, reuse of `wait_cua_ready` / session bring-up. Resolves
  everything by name/tag at run time:
  - `image:` = image-**family** name (`ale-ubuntu22` / `ale-win10` /
    `ale-win-server`) → newest AMI tagged `ale:image-family=<name>` (override
    with `ami:`).
  - `security_group:` (a name, gcloud's `network` analogue) → its id + the VPC it
    lives in; that VPC scopes the AZ→subnet lookup. `zones:` are AZ names.
  - Per-snapshot `tenancy` (`default`|`dedicated`); per-snapshot `gpu`. Windows
    resolution forced after boot with fallback to the largest supported mode.
- **`task_data/s3bucket.py`** — `s3://` staging via in-box `aws s3 sync`
  (`--request-payer requester`, since the data bucket is requester-pays);
  `output_pull.push_to_s3` + `s3://` dispatch; `select`/`config_loader`/`factory`
  wired for `aws`/`s3://` (coexists with gcloud/docker/qemu/static).
- **`configs/environments/environment_aws.yaml`** — AWS counterpart of
  `environment.yaml`. Like gcloud it hardcodes conventions; unlike gcloud it
  needs **no `${env:...}`** — credentials come from the ambient AWS chain
  (`aws configure`); VPC/subnets/AMIs resolve by name/tag.
- **`scripts/aws/import_images.sh`** (GCS→AMI) + **`scripts/aws/sync_task_data.sh`**
  (GCS→S3 task data).
- **`docs/ale-docs-site/pages/aws.html`** — single setup page mirroring
  `google-cloud.html` (full walkthrough; GPU flagged untested).
- `claude_code/deployer.py`: npm CLI-install timeout 300→900s (a cold Windows
  install — images without a pre-baked CLI, e.g. ale-win-server — exceeds 300s).

## Setup & run (summary; full step-by-step in `docs/ale-docs-site/pages/aws.html`)

1. `aws configure` (region us-east-1) — the only place credentials live.
2. Create the network + `ale-sandbox` security group, the S3 task-data bucket
   (requester-pays), and the results bucket + `ale-sandbox` instance profile
   (inline commands in the doc; or `scripts/aws/`).
3. Images: ALE publishes **public AMIs in us-east-1** (`ale-ubuntu22`,
   `ale-win10`, `ale-win-server`); resolved by family. From another account, pin
   `ami:` or copy-and-tag (AMI tags are owner-private).
4. Point an experiment at `configs/environments/environment_aws.yaml`, run:
   `uv run python -m ale_run run my_experiment.yaml`. For kept output set
   `output_path: s3://<results>` + `iam_instance_profile: ale-sandbox`.

## Verified on EC2 (us-east-1)

3 public AMIs imported & tagged: `ale-ubuntu22` (Linux, aws-CLI baked),
`ale-win10` (Windows 10, BYOL), `ale-win-server` (Windows Server,
**license-included** → runs on shared tenancy, no BYOL/dedicated). All four
demo runs scored **1.0** end-to-end (Claude Code + Sonnet):

| demo | image | mode | score |
|---|---|---|---|
| Linux `hello` | ale-ubuntu22 | baked data + local output | **1.0** |
| Linux `hello` | ale-ubuntu22 | `s3://` data + `s3://` output | **1.0** |
| Windows `hello_win` | ale-win-server | license-included, shared tenancy | **1.0** |
| Windows `hello_win` | ale-win10 | BYOL, shared-tenancy functional test | **1.0** |

Also: requester-pays + public S3 task-data bucket populated (full migration, 15
domains, `images/` excluded); S3 results-bucket output confirmed; no leaked
instances.

## NOT tested yet

- **GPU tasks** — the `gpu-*` snapshots (→ `ale-win-server`, NVIDIA L4) are wired
  but **completely untested**. The account's GPU vCPU quota is **0** and the
  increase request was **denied/closed** by AWS (new-account review), so no GPU
  instance has ever launched. Whether the baked NVIDIA driver binds + licenses on
  AWS GPUs is also unverified. **Treat GPU on AWS as unimplemented until the quota
  is granted and a GPU task is run.**
- **Concurrency** — only `concurrency: 1` exercised; multi-VM AZ fan-out not
  stress-tested.
- **win10 license-compliant runs** — verified only on shared tenancy (functional).
  Compliant Win10 needs dedicated tenancy (separate AWS Support quota, pending);
  the env already sets `tenancy: dedicated` for the win10 snapshots.

## Follow-ups

- AWS Support cases (user-side): GPU vCPU quota; Dedicated-Instances quota for
  win10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
