### PR TITLE
Add car agent (Common Agent Runtime)

### DIFF
--- a/ale_run/agents/car/README.md
+++ b/ale_run/agents/car/README.md
@@ -1,0 +1,86 @@
+# CAR (Common Agent Runtime)
+
+This deployer runs the [Common Agent Runtime](https://github.com/Parslee-ai/car-releases)
+as the system under test on Agents' Last Exam. CAR is a deterministic execution
+layer: the model proposes actions, and the runtime validates (preconditions,
+policy, dependencies) and executes them. The benchmark measures CAR driving a
+real OS sandbox over a long-horizon task.
+
+## How it works
+
+CAR runs **out-of-sandbox** (host-side, like `ale_claw`). The deployer:
+
+1. Installs the `vm` (shell/fs) and, optionally, `cua` (GUI) stdio MCP bridges on
+   the host (the same `_assets` bridges the other native agents use). Each bridge
+   reaches the eval VM's cua-server via `CUA_SERVER_URL`.
+2. Writes an MCP config and subprocesses the CAR headless runner:
+   `car run-task --goal-file ... --mcp-config ... --transcript ... --model ...`.
+3. CAR connects those bridges as tools through its connector manager, so every
+   tool call is routed through CAR's validator / policy / eventlog, then drives
+   its own propose -> validate -> execute loop until a done signal (a model turn
+   with no tool calls) or `--max-turns`.
+4. The runner writes a JSONL **transcript** (full per-turn content) which the
+   deployer converts to an ATIF trajectory in `parse_artifacts`.
+
+Why a transcript and not CAR's eventlog: CAR's engine eventlog is metadata-only
+(action ids + durations, not tool names / parameters / outputs), so the runner
+emits a separate content-rich transcript.
+
+## Requirements
+
+- The `car` CLI binary on PATH (or set `config.car_bin`). It must support
+  `car run-task` (CAR >= the version that added the headless runner).
+- An LLM API key in the operator's shell env, read by CAR directly:
+  `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`.
+- A pinned `model:` (CAR's own catalog id, e.g. `claude-sonnet-4-6` — **not** the
+  LiteLLM `provider/model` form the other harnesses use).
+
+## Running it
+
+```yaml
+harness: car
+model: claude-sonnet-4-6
+config:
+  max_turns: 100
+  gui: true
+```
+
+```bash
+export ANTHROPIC_API_KEY=...
+uv run python -m ale_run run experiments/my_experiment.yaml   # agents: [ configs/agents/car.yaml ]
+```
+
+## The config knobs
+
+The full surface is in `config.py`; the ones most users touch:
+
+- `model`: CAR catalog model id (required)
+- `max_turns`: hard cap on CAR's agent loop
+- `car_bin`: path to the `car` binary if not on PATH
+- `gui`: wire the cua GUI bridge in addition to the vm bridge
+- `eventlog`: also write CAR's (metadata-only) engine journal for debugging
+
+## The transcript schema
+
+`car run-task` emits newline-delimited JSON, discriminated by `type`:
+
+| `type`        | fields |
+|---------------|--------|
+| `run_start`   | `goal, model, max_turns, servers, tool_count` |
+| `agent_turn`  | `turn, text, tool_calls:[{id,name,arguments}], usage:{input_tokens,output_tokens}` |
+| `observation` | `turn, results:[{tool_call_id, content, is_error}]` |
+| `run_end`     | `status, turns, answer, error` |
+
+`transcript_to_trajectory.py` maps `agent_turn` -> `source="agent"` steps and
+`observation` -> `source="environment"` steps; `run_start` / `run_end` land on
+`trajectory.extra["car"]`.
+
+## Where to read the code
+
+- `deployer.py`: ALE entry point (install / launch / parse_artifacts)
+- `config.py`: runtime knobs
+- `transcript_to_trajectory.py`: transcript -> ATIF translator
+
+The headless runner itself ships in the `car` CLI binary (the `car run-task`
+subcommand), distributed via
+[Parslee-ai/car-releases](https://github.com/Parslee-ai/car-releases).

--- a/ale_run/agents/car/__init__.py
+++ b/ale_run/agents/car/__init__.py
@@ -1,0 +1,12 @@
+"""Common Agent Runtime (CAR) agent — out-of-sandbox harness over stdio MCP.
+
+CAR is a deterministic execution layer for AI agents: models propose, the runtime
+validates and executes. This deployer runs CAR as the system under test by
+launching the ``car run-task`` headless runner against the eval VM via the vm
+(shell/fs) and cua (GUI) MCP bridges, then converts CAR's transcript to ATIF.
+"""
+
+from .config import CarConfig
+from .deployer import CarDeployer
+
+__all__ = ["CarConfig", "CarDeployer"]

--- a/ale_run/agents/car/config.py
+++ b/ale_run/agents/car/config.py
@@ -1,0 +1,51 @@
+"""CarConfig: per-episode knobs for the Common Agent Runtime (CAR) deployer.
+
+Standalone config (no shared base), per the ALE convention. Declares the model
+and turn budget plus the few CAR-specific knobs the deployer consumes.
+
+CAR is driven out-of-sandbox: the deployer launches the `car run-task` headless
+runner on the host, hands it stdio MCP bridges that reach the eval VM's
+cua-server, and CAR runs its own propose -> validate -> execute loop. The runner
+emits a JSONL transcript the deployer converts to an ATIF trajectory.
+
+**API keys live in the operator's shell env**, not in this config. CAR reads
+``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``GOOGLE_API_KEY`` from the process
+env (the deployer passes ``os.environ`` straight through to the runner).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+
+@dataclass
+class CarConfig:
+    """Tunables for :class:`CarDeployer`."""
+
+    name: ClassVar[str] = "car"
+
+    model: str | None = None
+    """CAR model id, resolved by CAR's own registry/router (e.g.
+    ``claude-sonnet-4-6``). NOTE: this is CAR's catalog id, NOT the LiteLLM
+    ``provider/model`` form the other ALE harnesses use. Required: ``install``
+    raises if unset, since a benchmark run must pin its model. Passed verbatim to
+    ``car run-task --model``."""
+
+    max_turns: int = 100
+    """Hard ceiling on CAR's agent loop, passed to ``--max-turns``."""
+
+    car_bin: str = "car"
+    """Path to the ``car`` CLI binary. Override if it is not on PATH."""
+
+    gui: bool = True
+    """Wire the cua (GUI) MCP bridge in addition to the vm (shell/fs) bridge, so
+    CAR can drive the desktop. Set False for shell/file-only tasks."""
+
+    eventlog: bool = True
+    """Also write CAR's engine event journal alongside the transcript. The
+    journal is metadata-only (action ids + durations); the transcript carries the
+    content. Useful for debugging validator/policy decisions."""
+
+    extra_env: dict[str, str] = field(default_factory=dict)
+    """Extra environment variables to inject into the ``car run-task`` process
+    (merged over ``os.environ``)."""

--- a/ale_run/agents/car/deployer.py
+++ b/ale_run/agents/car/deployer.py
@@ -1,0 +1,221 @@
+"""CarDeployer — Common Agent Runtime (CAR) native deployer.
+
+Runs out-of-sandbox on the host (``local``) or in a docker container
+(``docker``). CAR is the system under test: the deployer launches the
+``car run-task`` headless runner, hands it stdio MCP bridges that reach the eval
+VM's cua-server, and CAR drives its own propose -> validate -> execute loop.
+
+The deployer's surface:
+
+  install():          check the ``car`` binary, an API key env var, and a pinned
+                      model; mkdir work_dir.
+  launch(prompt):     install the vm (+ optional cua) MCP bridges, write the
+                      runner's MCP config, subprocess ``car run-task``, and return
+                      an AgentRunResult. The transcript lands in work_dir for
+                      parse_artifacts.
+  parse_artifacts():  read the CAR transcript JSONL -> ATIF Steps via the in-tree
+                      translator.
+
+Why a transcript and not CAR's eventlog: CAR's engine eventlog is metadata-only
+(it records action ids + durations, not tool names / parameters / outputs), so
+the runner emits a separate content-rich transcript that this deployer converts.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any, ClassVar
+
+from ale_run.base_interface import (
+    AgentRunResult,
+    BaseAgentDeployer,
+    TrajectoryBuilder,
+)
+
+from ale_run.agents._bootstrap import (
+    cua_bridge_env,
+    ensure_cua_mcp_server_at,
+    ensure_node_npm,
+    ensure_vm_mcp_server,
+    vm_bridge_env,
+)
+
+from .config import CarConfig
+from .transcript_to_trajectory import parse_transcript_into
+
+logger = logging.getLogger(__name__)
+
+
+class CarDeployer(BaseAgentDeployer):
+    """Common Agent Runtime deployer. Runs on host or in a docker container."""
+
+    default_executor: ClassVar[str] = "local"
+    supported_executors: ClassVar[frozenset[str]] = frozenset({"local", "docker"})
+
+    # At least one of these env vars must be set or ``install`` raises.
+    _api_key_alternatives: ClassVar[tuple[str, ...]] = (
+        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY",
+    )
+
+    # =========================================================================
+    # install
+    # =========================================================================
+
+    async def install(self) -> None:
+        cfg: CarConfig = self.config  # type: ignore[assignment]
+        if shutil.which(cfg.car_bin) is None and not Path(cfg.car_bin).is_file():
+            raise RuntimeError(
+                f"{type(self).__name__}: car binary {cfg.car_bin!r} not found on "
+                "PATH — install the CAR CLI or set config.car_bin to its path."
+            )
+        if not cfg.model:
+            raise RuntimeError(
+                f"{type(self).__name__}: config.model is unset — pin a CAR model "
+                "id (e.g. an Anthropic/OpenAI catalog id) for the benchmark run."
+            )
+        if not any(os.environ.get(k) for k in self._api_key_alternatives):
+            raise RuntimeError(
+                f"{type(self).__name__}: no LLM API key in env — set one of "
+                f"{', '.join(self._api_key_alternatives)}"
+            )
+        Path(self.executor.work_dir).mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "%s: install ok (model=%s, work_dir=%s, executor=%s)",
+            type(self).__name__, cfg.model, self.executor.work_dir, self.executor.type,
+        )
+
+    # =========================================================================
+    # launch
+    # =========================================================================
+
+    async def launch(self, prompt: str) -> AgentRunResult:
+        cfg: CarConfig = self.config  # type: ignore[assignment]
+        work_dir = Path(self.executor.work_dir)
+        car_dir = work_dir / "car"
+        car_dir.mkdir(parents=True, exist_ok=True)
+
+        goal_path = car_dir / "goal.txt"
+        mcp_config_path = car_dir / "mcp.json"
+        transcript_path = car_dir / "transcript.jsonl"
+        eventlog_path = car_dir / "eventlog.jsonl"
+        goal_path.write_text(prompt, encoding="utf-8")
+
+        # ---- 1. Install the stdio MCP bridges that reach the eval cua-server ----
+        # Native (host) agents run the bridge on the host; it points at the host
+        # endpoint the executor exposes (cua_bridge_url == sb.endpoint here).
+        node_path, _ = await ensure_node_npm()
+        servers: list[dict[str, Any]] = []
+
+        vm_bridge_dir = await ensure_vm_mcp_server(str(car_dir / "mcp" / "vm"))
+        servers.append({
+            "name": "vm",
+            "command": node_path,
+            "args": [os.path.join(vm_bridge_dir, "src", "index.js")],
+            "env": vm_bridge_env(self.executor),
+        })
+        if cfg.gui:
+            cua_bridge_dir = await ensure_cua_mcp_server_at(str(car_dir / "mcp" / "cua"))
+            servers.append({
+                "name": "cua",
+                "command": node_path,
+                "args": [os.path.join(cua_bridge_dir, "src", "index.js")],
+                "env": cua_bridge_env(self.executor),
+            })
+
+        import json
+        mcp_config_path.write_text(json.dumps({"servers": servers}, indent=2), encoding="utf-8")
+        logger.info("car: launch — work_dir=%s servers=%s", work_dir, [s["name"] for s in servers])
+
+        # ---- 2. Subprocess the headless runner ----
+        argv = [
+            cfg.car_bin, "run-task",
+            "--goal-file", str(goal_path),
+            "--mcp-config", str(mcp_config_path),
+            "--transcript", str(transcript_path),
+            "--max-turns", str(cfg.max_turns),
+            "--model", str(cfg.model),
+        ]
+        if cfg.eventlog:
+            argv += ["--eventlog", str(eventlog_path)]
+
+        env = {**os.environ, **cfg.extra_env}
+        t0 = time.monotonic()
+        # The episode wall budget is orchestration-owned: the executor wraps
+        # launch() in asyncio.wait_for(timeout=timeout_s). On cancellation we
+        # reap the child and re-raise so the framework records a timeout.
+        proc = await asyncio.create_subprocess_exec(
+            *argv, env=env,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await proc.communicate()
+        except asyncio.CancelledError:
+            logger.info("car: launch cancelled (wall budget) — terminating runner")
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=10)
+            except asyncio.TimeoutError:
+                proc.kill()
+            raise
+
+        duration_s = time.monotonic() - t0
+        if stderr:
+            logger.info("car run-task stderr:\n%s", stderr.decode("utf-8", "replace")[-4000:])
+
+        # run-task exits 0 on a done signal, 1 on max-turns / error. A non-zero
+        # exit is not necessarily a hard failure (max-turns still produced work),
+        # so map by whether a transcript exists; parse_artifacts reads the detail.
+        if transcript_path.exists():
+            status = "completed" if proc.returncode == 0 else "failed"
+            error = None if proc.returncode == 0 else "runner exited non-zero (see transcript run_end)"
+        else:
+            status = "failed"
+            error = f"car run-task produced no transcript (exit={proc.returncode})"
+
+        return AgentRunResult(
+            status=status,
+            duration_s=duration_s,
+            transcript_path=str(transcript_path) if transcript_path.exists() else None,
+            exit_code=proc.returncode,
+            error=error,
+        )
+
+    # =========================================================================
+    # parse_artifacts
+    # =========================================================================
+
+    @classmethod
+    def parse_artifacts(
+        cls,
+        *,
+        work_dir: Path,
+        config: CarConfig,
+        run_result: AgentRunResult,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        if not work_dir.exists():
+            builder.add_step(
+                source="system",
+                message=f"car: work_dir missing {work_dir}",
+                extra={"reason": "no_work_dir"},
+            )
+            return
+        try:
+            parse_transcript_into(work_dir, builder)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("car: parse_artifacts failed")
+            builder.add_step(
+                source="system",
+                message=f"transcript parse failed: {type(exc).__name__}: {exc}",
+                extra={"reason": "parse_error"},
+            )
+        builder.trajectory.extra.setdefault("car", {}).update({
+            "work_dir": str(work_dir),
+            "transcript_path": run_result.transcript_path,
+            "run_status": run_result.status,
+            "exit_code": run_result.exit_code,
+        })

--- a/ale_run/agents/car/pyproject.toml
+++ b/ale_run/agents/car/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "ale-car"
+version = "0.1.0"
+description = "Common Agent Runtime (CAR) deployer for Agents' Last Exam."
+requires-python = ">=3.12,<3.14"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = []
+sources = {}
+bypass-selection = true

--- a/ale_run/agents/car/transcript_to_trajectory.py
+++ b/ale_run/agents/car/transcript_to_trajectory.py
@@ -1,0 +1,135 @@
+"""Translate a CAR ``run-task`` transcript (JSONL) into ATIF Steps.
+
+The transcript is a stream of newline-delimited JSON records, one per event,
+discriminated by ``type``:
+
+  - ``run_start``   {goal, model, max_turns, servers, tool_count}
+  - ``agent_turn``  {turn, text, tool_calls:[{id,name,arguments}], usage:{input_tokens,output_tokens}}
+  - ``observation`` {turn, results:[{tool_call_id, content, is_error}]}
+  - ``run_end``     {status, turns, answer, error}
+
+Mapping to ATIF:
+  agent_turn  -> source="agent"        (message=text, tool_calls, metrics)
+  observation -> source="environment"  (observation.results -> ToolResult[])
+  run_start / run_end -> recorded on trajectory.extra (run_end also a system step)
+
+The framework seeds the leading ``user`` instruction step and calls
+``builder.finalize`` with the grader's reward; this translator only appends steps.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from ale_run.base_interface import (
+    ContentPart,
+    Observation,
+    StepMetrics,
+    ToolCall,
+    ToolResult,
+    TrajectoryBuilder,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _find_transcript(work_dir: Path) -> Path | None:
+    """Canonical location first, then a shallow scan as a fallback."""
+    canonical = work_dir / "car" / "transcript.jsonl"
+    if canonical.is_file():
+        return canonical
+    matches = sorted(work_dir.rglob("transcript.jsonl"))
+    return matches[0] if matches else None
+
+
+def _read_records(path: Path) -> list[dict]:
+    records: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            logger.warning("car transcript: skipping malformed line in %s", path)
+    return records
+
+
+def parse_transcript_into(work_dir: Path, builder: TrajectoryBuilder) -> None:
+    """Append ATIF Steps to ``builder`` from the CAR transcript in ``work_dir``."""
+    path = _find_transcript(work_dir)
+    if path is None:
+        builder.add_step(
+            source="system",
+            message=f"car: no transcript.jsonl under {work_dir}",
+            extra={"reason": "no_transcript"},
+        )
+        return
+
+    for rec in _read_records(path):
+        kind = rec.get("type")
+        if kind == "run_start":
+            builder.trajectory.extra.setdefault("car", {})["run_start"] = {
+                "model": rec.get("model"),
+                "servers": rec.get("servers"),
+                "tool_count": rec.get("tool_count"),
+                "max_turns": rec.get("max_turns"),
+            }
+        elif kind == "agent_turn":
+            _agent_turn(builder, rec)
+        elif kind == "observation":
+            _observation(builder, rec)
+        elif kind == "run_end":
+            builder.trajectory.extra.setdefault("car", {})["run_end"] = {
+                "status": rec.get("status"),
+                "turns": rec.get("turns"),
+                "answer": rec.get("answer"),
+                "error": rec.get("error"),
+            }
+            if rec.get("error"):
+                builder.add_step(
+                    source="system",
+                    message=f"car run ended: {rec.get('status')} — {rec.get('error')}",
+                    extra={"reason": "run_end_error"},
+                )
+
+
+def _agent_turn(builder: TrajectoryBuilder, rec: dict) -> None:
+    tool_calls = [
+        ToolCall(
+            id=call.get("id") or f"call_{rec.get('turn')}_{i}",
+            name=call.get("name", ""),
+            arguments=call.get("arguments") or {},
+        )
+        for i, call in enumerate(rec.get("tool_calls") or [])
+    ]
+    usage = rec.get("usage") or {}
+    metrics = StepMetrics(
+        input_tokens=usage.get("input_tokens"),
+        output_tokens=usage.get("output_tokens"),
+    )
+    text = rec.get("text") or None
+    builder.add_step(
+        source="agent",
+        message=text,
+        tool_calls=tool_calls,
+        metrics=metrics,
+        extra={"turn": rec.get("turn")},
+    )
+
+
+def _observation(builder: TrajectoryBuilder, rec: dict) -> None:
+    results = [
+        ToolResult(
+            tool_call_id=r.get("tool_call_id", ""),
+            content=[ContentPart(type="text", text=str(r.get("content", "")))],
+            is_error=bool(r.get("is_error")),
+        )
+        for r in rec.get("results") or []
+    ]
+    builder.add_step(
+        source="environment",
+        observation=Observation(results=results),
+        extra={"turn": rec.get("turn")},
+    )

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -42,6 +42,7 @@ _AGENT_FQNS: dict[str, str] = {
     "hermes": "ale_run.agents.hermes.deployer.HermesDeployer",
     "terminus_2": "ale_run.agents.terminus_2.deployer.Terminus2Deployer",
     "dummy": "ale_run.agents.dummy.deployer.DummyDeployer",
+    "car": "ale_run.agents.car.deployer.CarDeployer",
 }
 
 

--- a/configs/agents/car.yaml
+++ b/configs/agents/car.yaml
@@ -1,0 +1,39 @@
+# car — Common Agent Runtime as the system under test. Host-side agent: the
+# deployer launches the `car run-task` headless runner, hands it the vm
+# (shell/fs) and cua (GUI) MCP bridges that reach the eval VM's cua-server, and
+# CAR drives its own propose -> validate -> execute loop. The runner emits a
+# JSONL transcript the deployer converts to ATIF.
+#
+# Auth: API keys live in the operator's shell env, read by CAR directly —
+# ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY. The `car` binary must be
+# on PATH (or set config.car_bin).
+#
+# Consolidated preset; every `config:` key is the dataclass default
+# (ale_run/agents/car/config.py). Reference as:  agents: [ configs/agents/car.yaml ]
+
+harness: car
+# Executor: deployer default is "local" (host-side); "docker" adds isolation via
+# the same code path. Supported: local | docker.
+executor: local
+
+# CAR model id (CAR's own catalog id, NOT the LiteLLM "provider/model" form the
+# other harnesses use). REQUIRED — pin it for the run. Example (change to a model
+# your CAR build + API keys can serve):
+model: claude-sonnet-4-6
+
+config:
+  # Hard ceiling on CAR's agent loop (--max-turns).
+  max_turns: 100
+
+  # Path to the `car` CLI binary. Override if not on PATH.
+  car_bin: car
+
+  # Wire the cua (GUI) MCP bridge in addition to the vm (shell/fs) bridge so CAR
+  # can drive the desktop. Set false for shell/file-only tasks.
+  gui: true
+
+  # Also write CAR's engine event journal (metadata-only) next to the transcript.
+  eventlog: true
+
+  # Extra env vars injected into the car run-task process (merged over os.environ).
+  extra_env: {}

--- a/tests/smoke_car_transcript.py
+++ b/tests/smoke_car_transcript.py
@@ -1,0 +1,82 @@
+"""Offline smoke: CAR run-task transcript -> ATIF Steps.
+
+No VM, no `car` binary, no API key. Feeds a synthetic transcript through the
+translator and asserts the resulting ATIF trajectory shape. Run:
+
+    uv run python tests/smoke_car_transcript.py
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from ale_run.agents.car.transcript_to_trajectory import parse_transcript_into
+from ale_run.base_interface import TrajectoryBuilder
+
+TRANSCRIPT = [
+    {"type": "run_start", "goal": "list /tmp then write done.txt",
+     "model": "anthropic/claude-sonnet-4.6", "max_turns": 100,
+     "servers": ["vm", "cua"], "tool_count": 9},
+    {"type": "agent_turn", "turn": 1, "text": "Listing the directory.",
+     "tool_calls": [{"id": "call_0_0", "name": "mcp_vm_exec",
+                     "arguments": {"command": "ls /tmp"}}],
+     "usage": {"input_tokens": 1200, "output_tokens": 40}},
+    {"type": "observation", "turn": 1,
+     "results": [{"tool_call_id": "call_0_0", "content": "a.txt\nb.txt", "is_error": False}]},
+    {"type": "agent_turn", "turn": 2, "text": "Writing the marker file.",
+     "tool_calls": [{"id": "call_1_0", "name": "mcp_vm_write",
+                     "arguments": {"path": "/tmp/done.txt", "content": "ok"}}],
+     "usage": {"input_tokens": 1300, "output_tokens": 30}},
+    {"type": "observation", "turn": 2,
+     "results": [{"tool_call_id": "call_1_0", "content": "[FAILED] permission denied", "is_error": True}]},
+    {"type": "agent_turn", "turn": 3, "text": "Done.", "tool_calls": [],
+     "usage": {"input_tokens": 1400, "output_tokens": 5}},
+    {"type": "run_end", "status": "completed", "turns": 3, "answer": "Done.", "error": None},
+]
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        work_dir = Path(td)
+        tpath = work_dir / "car" / "transcript.jsonl"
+        tpath.parent.mkdir(parents=True)
+        tpath.write_text("\n".join(json.dumps(r) for r in TRANSCRIPT), encoding="utf-8")
+
+        builder = TrajectoryBuilder(
+            agent_name="car", model="anthropic/claude-sonnet-4.6",
+            task_path="demo/helloworld", variant_index=0,
+            instruction="list /tmp then write done.txt",
+        )
+        parse_transcript_into(work_dir, builder)
+        traj = builder.finalize(reward=1.0, status="completed")
+
+        steps = traj.steps
+        sources = [s.source for s in steps]
+        assert sources == ["agent", "environment", "agent", "environment", "agent"], sources
+
+        # First agent step: one tool call, token metrics captured.
+        assert steps[0].tool_calls[0].name == "mcp_vm_exec"
+        assert steps[0].tool_calls[0].arguments == {"command": "ls /tmp"}
+        assert steps[0].metrics.input_tokens == 1200
+
+        # Observations correlate by tool_call_id and carry the error flag.
+        obs1 = steps[1].observation.results[0]
+        assert obs1.tool_call_id == "call_0_0" and obs1.is_error is False
+        assert obs1.content[0].text == "a.txt\nb.txt"
+        obs2 = steps[3].observation.results[0]
+        assert obs2.is_error is True
+
+        # Final agent step is the done signal: text, no tool calls.
+        assert steps[4].message == "Done." and steps[4].tool_calls == []
+
+        # Token totals summed across agent turns; run metadata on extra.
+        assert traj.final_metrics.total_input_tokens == 3900
+        assert traj.extra["car"]["run_end"]["status"] == "completed"
+        assert traj.extra["car"]["run_start"]["servers"] == ["vm", "cua"]
+
+    print("smoke_car_transcript: OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a `car` agent deployer that runs the [Common Agent Runtime](https://github.com/Parslee-ai/car-releases) (CAR) as the system under test.

CAR is a deterministic execution layer for AI agents: the model proposes actions and the runtime validates (preconditions, policy, dependencies) and executes them.

## How it works

Out-of-sandbox, like `ale_claw`. The deployer:

1. Installs the `vm` (shell/fs) and optional `cua` (GUI) stdio MCP bridges on the host (the shared `_assets` bridges), each reaching the eval VM's cua-server via `CUA_SERVER_URL`.
2. Subprocesses CAR's headless runner: `car run-task --goal-file ... --mcp-config ... --transcript ... --model ...`.
3. CAR connects those bridges as tools through its connector manager (so every call is routed through CAR's validator/policy/eventlog) and drives its own propose -> validate -> execute loop until a done signal (a model turn with no tool calls) or `--max-turns`.
4. The runner writes a JSONL transcript that `parse_artifacts` converts to ATIF.

Why a transcript and not CAR's eventlog: CAR's engine eventlog is metadata-only (action ids + durations, not tool names/parameters/outputs), so the runner emits a separate content-rich transcript (`run_start`/`agent_turn`/`observation`/`run_end`).

## Files

- `ale_run/agents/car/` — `config.py`, `deployer.py`, `transcript_to_trajectory.py`, `__init__.py`, `pyproject.toml`, `README.md`
- `ale_run/orchestration/factory.py` — register `"car"` in `_AGENT_FQNS`
- `configs/agents/car.yaml` — preset (every `config:` key at its dataclass default)
- `tests/smoke_car_transcript.py` — offline transcript -> ATIF converter smoke

## Requirements

- The `car` CLI on PATH (a build supporting `car run-task`), distributed via [Parslee-ai/car-releases](https://github.com/Parslee-ai/car-releases).
- An LLM API key in the operator's shell env: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`.
- A pinned `model:` (CAR's own catalog id, e.g. `claude-sonnet-4-6` — not the LiteLLM `provider/model` form the other harnesses use).

## Testing

- `ruff check` clean on the new files.
- `uv run python tests/smoke_car_transcript.py` passes (offline; no VM/binary/key): a synthetic transcript maps to the expected ATIF Steps (agent/environment sources, tool-call/observation correlation by id, summed token metrics, run metadata on `trajectory.extra`).
- A live end-to-end VM run requires GCP + an API key and is not part of this offline check.
