### PR TITLE
Add computing_math cluster: vuln_audit (Last-Exam security) + agentcore_repair & incident_rca (near-term)

### DIFF
--- a/tasks/computing_math/agentcore_repair/main.py
+++ b/tasks/computing_math/agentcore_repair/main.py
@@ -1,0 +1,144 @@
+"""ALE task: computing_math/agentcore_repair.
+
+A SWE-bench-style repo-edit task, patterned on tasks/demo/hello/main.py. start() makes a writable
+copy of the package the agent edits in place (the framework auto-stages input/); evaluate() reads
+the edited modules via the session, runs the hidden conformance suite host-side, and gate-and-scores
+it (scripts/score_agentcore_repair.py). No LLM judge.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import cua_bench as cb
+
+from tasks.linux_runtime import LinuxTaskConfig
+
+SCRIPTS_DIR = Path(__file__).parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from score_agentcore_repair import score_submission  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_NAME = "computing_math"
+TASK_NAME = "agentcore_repair"
+VARIANT_NAME = "base"
+AGENTCORE_MODULES = ["__init__.py", "agent.py", "tools.py", "model.py", "types.py", "errors.py", "adapters.py"]
+
+
+@dataclass
+class TaskConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = DOMAIN_NAME
+    TASK_NAME: str = TASK_NAME
+    VARIANT_NAME: str = VARIANT_NAME
+
+    @property
+    def agentcore_dir(self) -> str:
+        # Writable working copy of the package the agent edits in place (made by start()).
+        return f"{self.task_dir}/agentcore"
+
+    @property
+    def tests_visible_dir(self) -> str:
+        return f"{self.task_dir}/tests_visible"
+
+    @property
+    def readme_file(self) -> str:
+        return f"{self.input_dir}/README.md"
+
+    @property
+    def conformance_reference(self) -> str:
+        return f"{self.reference_dir}/conformance_runner.py"
+
+    @property
+    def task_description(self) -> str:
+        return (
+            "You are a senior engineer working on an Ubuntu machine.\n\n"
+            f"`{self.agentcore_dir}` is a partially-working Python tool-calling agent runtime. The "
+            f"happy path works, but several behaviors in `{self.readme_file}` are broken or "
+            "unimplemented. Repair the bugs and implement the missing loop-detection feature so the "
+            "runtime conforms to the spec. Edit the source in place (e.g. agentcore/agent.py and "
+            "agentcore/tools.py); do NOT change the public API or the exported names.\n\n"
+            f"Check progress with `cd {self.task_dir} && python -m pytest tests_visible/ -q`. Your "
+            f"repaired `{self.agentcore_dir}` package is the deliverable."
+        )
+
+    def to_metadata(self) -> dict:
+        m = super().to_metadata()
+        m.update(
+            {
+                "agentcore_dir": self.agentcore_dir,
+                "tests_visible_dir": self.tests_visible_dir,
+                "readme_file": self.readme_file,
+                "conformance_reference": self.conformance_reference,
+                "modules": AGENTCORE_MODULES,
+            }
+        )
+        return m
+
+
+@cb.tasks_config(split="train")
+def load():
+    cfg = TaskConfig()
+    return [
+        cb.Task(
+            description=cfg.task_description,
+            metadata=cfg.to_metadata(),
+            computer={"provider": "computer", "setup_config": {"os_type": cfg.OS_TYPE}},
+        )
+    ]
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    meta = task_cfg.metadata
+    # Make a writable copy of the package + visible tests the agent works on (framework staged input/).
+    await session.run_command(f"rm -rf {meta['agentcore_dir']!r}", check=False)
+    await session.run_command(f"cp -r {meta['input_dir']!r}/agentcore {meta['agentcore_dir']!r}", check=False)
+    await session.run_command(f"cp -r {meta['input_dir']!r}/tests_visible {meta['tests_visible_dir']!r}", check=False)
+    try:
+        await session.read_file(f"{meta['agentcore_dir']}/__init__.py")
+    except Exception as exc:
+        raise RuntimeError(f"staged agentcore missing ({exc})")
+    logger.info("[agentcore_repair] writable package staged at %s", meta["agentcore_dir"])
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    meta = task_cfg.metadata
+    try:
+        base = meta["agentcore_dir"]
+        # Enumerate the package tree at eval time so a correct fix that ADDS a module or
+        # subpackage is graded in full -- not just the originally-seeded module list.
+        try:
+            res = await session.run_command(f"cd {base!r} && find . -name '*.py' -type f", check=False)
+            listing = res if isinstance(res, str) else (getattr(res, "stdout", "") or "")
+            rels = [
+                (ln.strip()[2:] if ln.strip().startswith("./") else ln.strip())
+                for ln in listing.splitlines()
+                if ln.strip().endswith(".py")
+            ]
+        except Exception:
+            rels = []
+        if not rels:  # fallback: the originally-seeded top-level modules
+            rels = list(meta["modules"])
+        modules: dict[str, bytes] = {}
+        for rel in rels:
+            try:
+                modules[rel] = await session.read_bytes(f"{base}/{rel}")
+            except Exception:
+                continue
+        if "__init__.py" not in modules:
+            logger.info("[agentcore_repair] package missing from workspace")
+            return [0.0]
+        runner_bytes = await session.read_bytes(meta["conformance_reference"])
+        score, report = score_submission(modules, runner_bytes)
+    except Exception as exc:
+        logger.exception("[agentcore_repair] evaluation failed: %s", exc)
+        return [0.0]
+    logger.info("[agentcore_repair] eval_report=%s", json.dumps(report, sort_keys=True))
+    return [score]

--- a/tasks/computing_math/agentcore_repair/scripts/score_agentcore_repair.py
+++ b/tasks/computing_math/agentcore_repair/scripts/score_agentcore_repair.py
@@ -16,13 +16,22 @@ import tempfile
 from pathlib import Path
 
 TIER_CHECKS = [
-    "step_budget",
-    "arg_coercion",
-    "error_recovery",
-    "retry_budget",
-    "unknown_tool",
-    "final_answer",
-    "loop_detection",
+    "step_budget",          # B1
+    "arg_coercion",         # B2
+    "error_recovery",       # B3
+    "retry_budget",         # B4
+    "unknown_tool",         # B5
+    "final_answer",         # B6
+    "loop_detection",       # B7
+    "batch",                # B8
+    "strict_coercion",      # B9
+    "truncation",           # B10
+    "idempotent_retry",     # B11
+    "oscillation",          # B12
+    "batch_loop_semantics", # B13
+    "coercion_corners",     # B14
+    "budget_corners",       # B15
+    "history_integrity",    # B16
 ]
 
 

--- a/tasks/computing_math/agentcore_repair/scripts/score_agentcore_repair.py
+++ b/tasks/computing_math/agentcore_repair/scripts/score_agentcore_repair.py
@@ -1,0 +1,69 @@
+"""Deterministic scorer for computing_math/agentcore_repair.
+
+Reconstructs the agent's edited agentcore package + the hidden conformance suite in a temp dir,
+runs the suite in an isolated, timed subprocess, and gate-and-scores the result. Mirrors
+task-intake/agentcore_repair/grade.py + reference/tests_conformance/conformance_runner.py.
+No LLM judge. Anti-gaming: the suite is our own (never the workspace's tests), runs many scenarios
+per behavior, and a timeout defeats an unbounded-retry "fix".
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+TIER_CHECKS = [
+    "step_budget",
+    "arg_coercion",
+    "error_recovery",
+    "retry_budget",
+    "unknown_tool",
+    "final_answer",
+    "loop_detection",
+]
+
+
+def score_submission(modules: dict, conformance_runner_bytes: bytes, *, timeout: int = 120):
+    """modules: {relative_path: bytes} for the agent's edited agentcore package (paths are
+    relative to the package root, e.g. "agent.py" or "sub/helper.py"). Returns (score in [0,1], report)."""
+    ws = Path(tempfile.mkdtemp(prefix="ale_agentcore_"))
+    try:
+        pkg = ws / "agentcore"
+        pkg.mkdir(parents=True)
+        for rel, data in modules.items():
+            dest = pkg / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(data if isinstance(data, (bytes, bytearray)) else str(data).encode("utf-8"))
+        runner = ws / "conformance_runner.py"
+        runner.write_bytes(conformance_runner_bytes)
+
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(runner), "--src", str(ws)],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return 0.0, {"reason": "conformance run timed out (e.g. unbounded-retry fix)"}
+
+        data = None
+        for line in reversed(proc.stdout.strip().splitlines()):
+            if line.strip().startswith("{"):
+                data = json.loads(line)
+                break
+        if not data or not data.get("import_ok"):
+            return 0.0, {"reason": "agentcore failed to import"}
+
+        checks = data.get("checks", {})
+        if not checks.get("happy_path"):
+            return 0.0, {"reason": "happy-path regression (gate failed)", "checks": checks}
+
+        passed = sum(1 for n in TIER_CHECKS if checks.get(n))
+        score = passed / len(TIER_CHECKS)
+        return score, {"score": round(score, 3), "tiers_passed": passed, "tiers_total": len(TIER_CHECKS), "checks": checks}
+    finally:
+        shutil.rmtree(ws, ignore_errors=True)

--- a/tasks/computing_math/agentcore_repair/task_card.json
+++ b/tasks/computing_math/agentcore_repair/task_card.json
@@ -1,25 +1,26 @@
 {
   "taskId": "computing_math/agentcore_repair",
   "title": "Repair and complete a tool-calling agent runtime",
-  "summary": "A partially-working Python tool-calling agent runtime (agentcore) has several seeded defects and one unimplemented feature. The agent must repair the runtime in place so it conforms to the written behavior spec, verified by a hidden conformance suite (SWE-bench-style: the deliverable is the edited package, scored by running hidden tests).",
+  "summary": "A partially-working Python tool-calling agent runtime (agentcore) is broken or unimplemented across sixteen interacting behaviors (B1-B16): step/retry budgets, argument coercion, error recovery, unknown-tool handling, final-answer hygiene, loop and oscillation detection, batched tool calls, observation truncation, non-idempotent retry safety, budget-accounting corners, and history integrity. The agent must repair the runtime in place so it conforms to the written spec, verified by a hidden conformance suite (SWE-bench-style: the deliverable is the edited package, scored by running hidden tests). The behaviors interact, so a fix for one can regress another.",
   "category": "computing_math",
   "software": ["python", "pytest", "uv"],
-  "taskPrompt": "You are given a partially-working Python tool-calling agent runtime in the agentcore/ package (under your task directory), a behavior spec in input/README.md, and a visible subset of tests in input/tests_visible/. The happy path works, but several behaviors in the spec are broken or unimplemented. Repair the bugs and implement the missing loop-detection feature so the runtime conforms to input/README.md. Edit the source in place (e.g. agentcore/agent.py and agentcore/tools.py); do NOT change the public API or the exported names. Check progress with: python -m pytest tests_visible/ -q. Your repaired agentcore/ package is the deliverable.",
+  "taskPrompt": "You are given a partially-working Python tool-calling agent runtime in the agentcore/ package (under your task directory), a behavior spec in input/README.md (B0-B16), and a visible subset of tests in input/tests_visible/. The happy path (B0) works, but behaviors B1-B16 are broken or unimplemented. Repair the bugs and implement the missing behaviors so the runtime conforms to input/README.md. Edit the source in place (e.g. agentcore/agent.py and agentcore/tools.py); do NOT change the public API or the exported names. Check progress with: python -m pytest tests_visible/ -q. Your repaired agentcore/ package is the deliverable.",
   "agentMustDo": [
-    "Read input/README.md (the behavior spec B0-B7) and input/tests_visible/",
-    "Fix the step budget, argument coercion, tool error recovery, retry budget, unknown-tool handling, and final-answer hygiene",
-    "Implement loop detection (stuck_threshold consecutive identical tool calls -> status 'stuck')",
+    "Read input/README.md (the full behavior spec B0-B16) and input/tests_visible/",
+    "Fix step/retry budgets, strict argument coercion, error recovery, unknown-tool handling, and final-answer hygiene",
+    "Implement loop detection, oscillation detection, batched tool calls, observation truncation, non-idempotent retry safety, budget accounting, and history integrity",
+    "Reconcile the interacting behaviors (a Batch is one action for loop detection; retries don't consume the step budget; truncation is per-call) without regressing B0",
     "Keep the public API unchanged and ensure 'import agentcore' succeeds"
   ],
   "inputFiles": [
     { "name": "agentcore", "format": "Python package", "path": "input/agentcore", "description": "the partially-working runtime to repair, edited in place" },
-    { "name": "README.md", "format": "Markdown", "path": "input/README.md", "description": "the behavior spec (B0-B7) the runtime must satisfy" },
+    { "name": "README.md", "format": "Markdown", "path": "input/README.md", "description": "the behavior spec (B0-B16) the runtime must satisfy" },
     { "name": "tests_visible", "format": "pytest", "path": "input/tests_visible", "description": "a visible subset of behavior tests for the agent's dev loop" }
   ],
   "referenceFiles": [
     { "name": "agentcore", "format": "Python package", "path": "input/agentcore", "description": "the deliverable: the agent's repaired agentcore package (a SWE-bench-style in-place edit, not a new output file). Graded by running a hidden conformance suite against it -- see evaluation." }
   ],
-  "evaluation": "Deterministic gate-and-score, no model judgment (scripts/score_agentcore_repair.py). The repaired agentcore package is imported in an isolated subprocess and a hidden conformance suite (8 behavior checks B0-B7, each over multiple scenarios; staged only at eval time, never visible to the agent) is run against it. GATE (score 0.0 if it fails): the package imports AND the happy-path regression check B0 still passes. TIERS (equal weight): the 7 behaviors B1-B7 (step budget, arg coercion, error recovery, retry budget, unknown tool, final-answer hygiene, loop detection). Score equals the fraction of behaviors that conform, in [0,1]. The grader runs its own hidden suite (never tests in the workspace) in a timed subprocess, so hardcoded outputs, a weakened test set, or an unbounded-retry fix all score 0.",
+  "evaluation": "Deterministic gate-and-score, no model judgment (scripts/score_agentcore_repair.py). The repaired agentcore package is imported in an isolated subprocess and a hidden conformance suite (17 behavior checks B0-B16, each over multiple scenarios incl. adversarial cross-behavior cases; staged only at eval time, never visible to the agent) is run against it. GATE (score 0.0 if it fails): the package imports AND the happy-path regression check B0 still passes. TIERS (equal weight): the 16 behaviors B1-B16. Score equals the fraction of behaviors that conform, in [0,1]. The grader runs its own hidden suite (never tests in the workspace) in a timed subprocess, so hardcoded outputs, a weakened test set, or an unbounded-retry fix all score 0.",
   "vm": { "machineType": "c4-standard-4", "snapshot": "cpu-free-ubuntu", "timeout": 3600 },
   "variants": 1,
   "sourceSubmissionId": "<assigned by the agents-last-exam.org/submit portal>",

--- a/tasks/computing_math/agentcore_repair/task_card.json
+++ b/tasks/computing_math/agentcore_repair/task_card.json
@@ -1,0 +1,27 @@
+{
+  "taskId": "computing_math/agentcore_repair",
+  "title": "Repair and complete a tool-calling agent runtime",
+  "summary": "A partially-working Python tool-calling agent runtime (agentcore) has several seeded defects and one unimplemented feature. The agent must repair the runtime in place so it conforms to the written behavior spec, verified by a hidden conformance suite (SWE-bench-style: the deliverable is the edited package, scored by running hidden tests).",
+  "category": "computing_math",
+  "software": ["python", "pytest", "uv"],
+  "taskPrompt": "You are given a partially-working Python tool-calling agent runtime in the agentcore/ package (under your task directory), a behavior spec in input/README.md, and a visible subset of tests in input/tests_visible/. The happy path works, but several behaviors in the spec are broken or unimplemented. Repair the bugs and implement the missing loop-detection feature so the runtime conforms to input/README.md. Edit the source in place (e.g. agentcore/agent.py and agentcore/tools.py); do NOT change the public API or the exported names. Check progress with: python -m pytest tests_visible/ -q. Your repaired agentcore/ package is the deliverable.",
+  "agentMustDo": [
+    "Read input/README.md (the behavior spec B0-B7) and input/tests_visible/",
+    "Fix the step budget, argument coercion, tool error recovery, retry budget, unknown-tool handling, and final-answer hygiene",
+    "Implement loop detection (stuck_threshold consecutive identical tool calls -> status 'stuck')",
+    "Keep the public API unchanged and ensure 'import agentcore' succeeds"
+  ],
+  "inputFiles": [
+    { "name": "agentcore", "format": "Python package", "path": "input/agentcore", "description": "the partially-working runtime to repair, edited in place" },
+    { "name": "README.md", "format": "Markdown", "path": "input/README.md", "description": "the behavior spec (B0-B7) the runtime must satisfy" },
+    { "name": "tests_visible", "format": "pytest", "path": "input/tests_visible", "description": "a visible subset of behavior tests for the agent's dev loop" }
+  ],
+  "referenceFiles": [
+    { "name": "agentcore", "format": "Python package", "path": "input/agentcore", "description": "the deliverable: the agent's repaired agentcore package (a SWE-bench-style in-place edit, not a new output file). Graded by running a hidden conformance suite against it -- see evaluation." }
+  ],
+  "evaluation": "Deterministic gate-and-score, no model judgment (scripts/score_agentcore_repair.py). The repaired agentcore package is imported in an isolated subprocess and a hidden conformance suite (8 behavior checks B0-B7, each over multiple scenarios; staged only at eval time, never visible to the agent) is run against it. GATE (score 0.0 if it fails): the package imports AND the happy-path regression check B0 still passes. TIERS (equal weight): the 7 behaviors B1-B7 (step budget, arg coercion, error recovery, retry budget, unknown tool, final-answer hygiene, loop detection). Score equals the fraction of behaviors that conform, in [0,1]. The grader runs its own hidden suite (never tests in the workspace) in a timed subprocess, so hardcoded outputs, a weakened test set, or an unbounded-retry fix all score 0.",
+  "vm": { "machineType": "c4-standard-4", "snapshot": "cpu-free-ubuntu", "timeout": 3600 },
+  "variants": 1,
+  "sourceSubmissionId": "<assigned by the agents-last-exam.org/submit portal>",
+  "taxonomy": {}
+}

--- a/tasks/computing_math/incident_rca/main.py
+++ b/tasks/computing_math/incident_rca/main.py
@@ -1,0 +1,121 @@
+"""ALE task: computing_math/incident_rca.
+
+Patterned on tasks/demo/hello/main.py. The framework auto-stages input/ + reference/; start()
+ensures the output dir + sanity-checks input; evaluate() reads output/rca.json + the hidden
+reference and scores via scripts/score_incident_rca.py. No LLM judge.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import cua_bench as cb
+
+from tasks.linux_runtime import LinuxTaskConfig
+
+SCRIPTS_DIR = Path(__file__).parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from score_incident_rca import score_submission  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_NAME = "computing_math"
+TASK_NAME = "incident_rca"
+VARIANT_NAME = "base"
+
+
+@dataclass
+class TaskConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = DOMAIN_NAME
+    TASK_NAME: str = TASK_NAME
+    VARIANT_NAME: str = VARIANT_NAME
+
+    @property
+    def deploy_file(self) -> str:
+        return f"{self.input_dir}/deploy/deployment.yaml"
+
+    @property
+    def logs_dir(self) -> str:
+        return f"{self.input_dir}/logs"
+
+    @property
+    def readme_file(self) -> str:
+        return f"{self.input_dir}/README.md"
+
+    @property
+    def rca_output(self) -> str:
+        return f"{self.remote_output_dir}/rca.json"
+
+    @property
+    def ground_truth_reference(self) -> str:
+        return f"{self.reference_dir}/ground_truth.json"
+
+    @property
+    def task_description(self) -> str:
+        return (
+            "You are the on-call SRE for an Ubuntu-based Kubernetes cluster.\n\n"
+            "The `payments-api` service returns 503 'no healthy upstream' and its pods are Running "
+            f"but never Ready. Using `{self.deploy_file}` and the files under `{self.logs_dir}`, "
+            f"diagnose the ONE true root cause and write `{self.rca_output}`:\n"
+            '  {"root_cause": "<token>", "fix": "<token>", "evidence": "the single most decisive line"}\n\n'
+            f"Choose `root_cause` and `fix` from the exact token lists in `{self.readme_file}`. The "
+            "logs contain distractors (benign warnings and a recovered blip); identify the real "
+            f"cause, not a red herring. Write your answer to exactly `{self.rca_output}`."
+        )
+
+    def to_metadata(self) -> dict:
+        m = super().to_metadata()
+        m.update(
+            {
+                "readme_file": self.readme_file,
+                "rca_output": self.rca_output,
+                "ground_truth_reference": self.ground_truth_reference,
+            }
+        )
+        return m
+
+
+@cb.tasks_config(split="train")
+def load():
+    cfg = TaskConfig()
+    return [
+        cb.Task(
+            description=cfg.task_description,
+            metadata=cfg.to_metadata(),
+            computer={"provider": "computer", "setup_config": {"os_type": cfg.OS_TYPE}},
+        )
+    ]
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    meta = task_cfg.metadata
+    await session.run_command(f"mkdir -p {meta['remote_output_dir']!r}", check=False)
+    try:
+        await session.read_file(meta["readme_file"])
+    except Exception as exc:
+        raise RuntimeError(f"staged input missing: {meta['readme_file']} unreadable ({exc})")
+    logger.info("[incident_rca] output dir ready; input staged")
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    meta = task_cfg.metadata
+    try:
+        rca_bytes = await session.read_bytes(meta["rca_output"])
+    except Exception as exc:
+        logger.info("[incident_rca] output unreadable at %s: %s", meta["rca_output"], exc)
+        return [0.0]
+    try:
+        reference_bytes = await session.read_bytes(meta["ground_truth_reference"])
+        score, report = score_submission(rca_bytes, reference_bytes)
+    except Exception as exc:
+        logger.exception("[incident_rca] evaluation failed: %s", exc)
+        return [0.0]
+    logger.info("[incident_rca] eval_report=%s", json.dumps(report, sort_keys=True))
+    return [score]

--- a/tasks/computing_math/incident_rca/scripts/score_incident_rca.py
+++ b/tasks/computing_math/incident_rca/scripts/score_incident_rca.py
@@ -1,0 +1,46 @@
+"""Deterministic scorer for computing_math/incident_rca.
+
+Anti-distractor gate (the confirm_intended idiom): credit only when the agent names the TRUE
+root cause, not a planted red herring. Mirrors task-intake/incident_rca/grade.py, on byte payloads.
+No LLM judge.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+
+def _norm(s) -> str:
+    return re.sub(r"[\s\-]+", "_", str(s).strip().lower())
+
+
+def score_submission(rca_bytes: bytes, reference_bytes: bytes):
+    """Return (score in [0,1], report). GATE: rca.json well-formed AND root_cause == true cause
+    (a distractor scores 0). TIERS (base 0.5): correct fix (+0.25) and decisive evidence (+0.25)."""
+    gt = json.loads(reference_bytes.decode("utf-8"))
+    gt_rc, gt_fix = _norm(gt["root_cause"]), _norm(gt["fix"])
+    ev_sub = str(gt["evidence_substring"])
+
+    try:
+        d = json.loads(rca_bytes.decode("utf-8"))
+        # A missing key must read as empty (not the truthy string "none") so the schema gate
+        # below genuinely requires a non-empty root_cause AND fix.
+        raw_rc, raw_fix = d.get("root_cause"), d.get("fix")
+        rc = _norm(raw_rc) if raw_rc is not None else ""
+        fix = _norm(raw_fix) if raw_fix is not None else ""
+        evidence = str(d.get("evidence", ""))
+    except Exception as exc:
+        return 0.0, {"reason": f"malformed rca.json: {exc}"}
+
+    schema_ok = bool(rc) and bool(fix)
+    if not schema_ok or rc != gt_rc:
+        return 0.0, {"reason": "wrong or missing root_cause (distractor or empty)", "root_cause": rc}
+
+    score = 0.5 + (0.25 if fix == gt_fix else 0.0) + (0.25 if ev_sub in evidence else 0.0)
+    return score, {
+        "score": score,
+        "root_cause": rc,
+        "root_cause_correct": True,
+        "fix_correct": fix == gt_fix,
+        "evidence_ok": ev_sub in evidence,
+    }

--- a/tasks/computing_math/incident_rca/task_card.json
+++ b/tasks/computing_math/incident_rca/task_card.json
@@ -1,0 +1,28 @@
+{
+  "taskId": "computing_math/incident_rca",
+  "title": "Diagnose a Kubernetes 503 outage from logs and config",
+  "summary": "A service returns 503 with pods Running but never Ready. The agent must diagnose the one true root cause from the deployment manifest and logs (which contain planted distractors) and report it as a structured rca.json, graded deterministically.",
+  "category": "computing_math",
+  "software": ["kubernetes", "kubectl", "yaml", "grep"],
+  "taskPrompt": "The payments-api service returns 503 'no healthy upstream' and its pods are Running but never Ready. Using input/deploy/deployment.yaml and the files under input/logs/, diagnose the ONE true root cause and write output/rca.json: {\"root_cause\": \"<token>\", \"fix\": \"<token>\", \"evidence\": \"the single most decisive log line or config snippet\"}. Choose root_cause and fix from the exact token lists in input/README.md. The logs contain distractors (benign warnings and a recovered blip); identify the real cause, not a red herring.",
+  "agentMustDo": [
+    "Read input/deploy/deployment.yaml and the files under input/logs/",
+    "Distinguish the true root cause from the planted distractors",
+    "Write output/rca.json with root_cause and fix chosen from the README token lists",
+    "Quote the single most decisive piece of evidence"
+  ],
+  "inputFiles": [
+    { "name": "deployment.yaml", "format": "YAML", "path": "input/deploy/deployment.yaml", "description": "the Kubernetes Deployment + Service manifest" },
+    { "name": "app.log", "format": "text", "path": "input/logs/app.log", "description": "the application's own log: the decisive evidence line plus benign distractors" },
+    { "name": "kubelet.log", "format": "text", "path": "input/logs/kubelet.log", "description": "node/kubelet events: readiness failures, 0 ready endpoints, 503" },
+    { "name": "README.md", "format": "Markdown", "path": "input/README.md", "description": "scenario + the root_cause/fix token lists + output schema" }
+  ],
+  "referenceFiles": [
+    { "name": "rca.json", "format": "JSON", "path": "output/rca.json", "description": "hidden: the true root_cause / fix / decisive-evidence substring and the planted distractors, used by scripts/score_incident_rca.py" }
+  ],
+  "evaluation": "Deterministic gate-and-score, no model judgment (scripts/score_incident_rca.py). GATE (score 0.0 if it fails): rca.json is well-formed AND root_cause exactly matches the true cause (held in the hidden ground truth). An intended-outcome check rejects the planted distractors, so naming a red herring scores 0 even though it is a plausible-looking token. TIERS (base 0.5): the correct `fix` token, and `evidence` containing the decisive substring. So a correct diagnosis alone = 0.5; plus the right fix and evidence -> 1.0.",
+  "vm": { "machineType": "c4-standard-4", "snapshot": "cpu-free-ubuntu", "timeout": 1800 },
+  "variants": 1,
+  "sourceSubmissionId": "<assigned by the agents-last-exam.org/submit portal>",
+  "taxonomy": {}
+}

--- a/tasks/computing_math/vuln_audit/main.py
+++ b/tasks/computing_math/vuln_audit/main.py
@@ -1,0 +1,120 @@
+"""ALE task: computing_math/vuln_audit.
+
+Patterned on the canonical Linux demo tasks/demo/hello/main.py and the reference task
+tasks/business_finance/american_option_pricing_ls/main.py. The framework auto-stages input/ +
+reference/ (REQUIRES_TASK_DATA); start() just ensures the output dir and sanity-checks input;
+evaluate() reads output/findings.json + the hidden reference and scores via scripts/. No LLM judge.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import cua_bench as cb
+
+from tasks.linux_runtime import LinuxTaskConfig
+
+SCRIPTS_DIR = Path(__file__).parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from score_vuln_audit import score_submission  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_NAME = "computing_math"
+TASK_NAME = "vuln_audit"
+VARIANT_NAME = "base"
+
+
+@dataclass
+class TaskConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = DOMAIN_NAME
+    TASK_NAME: str = TASK_NAME
+    VARIANT_NAME: str = VARIANT_NAME
+
+    @property
+    def repo_dir(self) -> str:
+        return f"{self.input_dir}/repo"
+
+    @property
+    def readme_file(self) -> str:
+        return f"{self.input_dir}/README.md"
+
+    @property
+    def findings_output(self) -> str:
+        return f"{self.remote_output_dir}/findings.json"
+
+    @property
+    def ground_truth_reference(self) -> str:
+        return f"{self.reference_dir}/ground_truth.json"
+
+    @property
+    def task_description(self) -> str:
+        return (
+            "You are a security analyst working on an Ubuntu machine.\n\n"
+            f"The directory `{self.repo_dir}` is a small Python service. Audit it for security "
+            f"vulnerabilities and write your findings to `{self.findings_output}`.\n\n"
+            'Schema (see the README for full details and the CWE scope):\n'
+            '{"findings": [{"file": "<file>.py", "cwe": "CWE-NNN", "line": 7, "explanation": "..."}]}\n\n'
+            "Rules:\n"
+            "- Report each distinct vulnerability class once per file (a file + CWE pair).\n"
+            "- Precision matters: false positives are penalized. Not every file is vulnerable.\n"
+            f"- See `{self.readme_file}` for the schema and scope. Write exactly to `{self.findings_output}`."
+        )
+
+    def to_metadata(self) -> dict:
+        m = super().to_metadata()
+        m.update(
+            {
+                "repo_dir": self.repo_dir,
+                "readme_file": self.readme_file,
+                "findings_output": self.findings_output,
+                "ground_truth_reference": self.ground_truth_reference,
+            }
+        )
+        return m
+
+
+@cb.tasks_config(split="train")
+def load():
+    cfg = TaskConfig()
+    return [
+        cb.Task(
+            description=cfg.task_description,
+            metadata=cfg.to_metadata(),
+            computer={"provider": "computer", "setup_config": {"os_type": cfg.OS_TYPE}},
+        )
+    ]
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    meta = task_cfg.metadata
+    await session.run_command(f"mkdir -p {meta['remote_output_dir']!r}", check=False)
+    try:
+        await session.read_file(meta["readme_file"])  # framework auto-stages input/
+    except Exception as exc:
+        raise RuntimeError(f"staged input missing: {meta['readme_file']} unreadable ({exc})")
+    logger.info("[vuln_audit] output dir ready; input staged")
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    meta = task_cfg.metadata
+    try:
+        findings_bytes = await session.read_bytes(meta["findings_output"])
+    except Exception as exc:
+        logger.info("[vuln_audit] output unreadable at %s: %s", meta["findings_output"], exc)
+        return [0.0]
+    try:
+        reference_bytes = await session.read_bytes(meta["ground_truth_reference"])
+        score, report = score_submission(findings_bytes, reference_bytes)
+    except Exception as exc:
+        logger.exception("[vuln_audit] evaluation failed: %s", exc)
+        return [0.0]
+    logger.info("[vuln_audit] eval_report=%s", json.dumps(report, sort_keys=True))
+    return [score]

--- a/tasks/computing_math/vuln_audit/scripts/score_vuln_audit.py
+++ b/tasks/computing_math/vuln_audit/scripts/score_vuln_audit.py
@@ -1,0 +1,56 @@
+"""Deterministic scorer for computing_math/vuln_audit.
+
+Precision-gated recall over CWE families (no LLM judge). Mirrors the local, fully-tested
+task-intake/vuln_audit/grade.py logic, but operates on byte payloads so main.py's evaluate()
+can call it after reading output/findings.json and the hidden ground_truth.json via the session.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+
+MIN_PRECISION = 0.5
+
+
+def _norm_cwe(value):
+    m = re.search(r"(\d+)", str(value))
+    return f"CWE-{m.group(1)}" if m else None
+
+
+def _norm_file(value):
+    return os.path.basename(str(value).replace("\\", "/")).lower()
+
+
+def score_submission(findings_bytes: bytes, reference_bytes: bytes):
+    """Return (score in [0,1], report dict). One vulnerability per file; a file is credited
+    when reported with a CWE in its accepted family. Precision gate defeats CWE-spam."""
+    gt = json.loads(reference_bytes.decode("utf-8"))
+    accept = {
+        _norm_file(v["file"]): {_norm_cwe(c) for c in v.get("accept_cwes", [v["cwe"]])}
+        for v in gt["vulns"]
+    }
+    try:
+        data = json.loads(findings_bytes.decode("utf-8"))
+        candidate = set()
+        for f in data["findings"]:
+            fn, cwe = _norm_file(f["file"]), _norm_cwe(f.get("cwe"))
+            if fn and cwe:
+                candidate.add((fn, cwe))
+    except Exception as exc:
+        return 0.0, {"reason": f"malformed findings.json: {exc}"}
+
+    tp = {(fn, cwe) for (fn, cwe) in candidate if fn in accept and cwe in accept[fn]}
+    found = {fn for (fn, _) in tp}
+    precision = len(tp) / len(candidate) if candidate else 0.0
+    recall = len(found) / len(accept)
+
+    if not candidate or precision < MIN_PRECISION:
+        return 0.0, {"reason": "precision gate failed", "recall": round(recall, 3), "precision": round(precision, 3)}
+    return recall, {
+        "score": round(recall, 3),
+        "recall": round(recall, 3),
+        "precision": round(precision, 3),
+        "found": sorted(found),
+        "missed": sorted(f for f in accept if f not in found),
+    }

--- a/tasks/computing_math/vuln_audit/task_card.json
+++ b/tasks/computing_math/vuln_audit/task_card.json
@@ -1,0 +1,26 @@
+{
+  "taskId": "computing_math/vuln_audit",
+  "title": "Audit a Python service for security vulnerabilities",
+  "summary": "A small Python service contains seven planted security vulnerabilities across distinct CWE classes plus one benign module. The agent must identify each vulnerability and report it as a (file, CWE) finding, scored deterministically against a hidden ground truth with a precision gate.",
+  "category": "computing_math",
+  "software": ["python", "bandit", "semgrep", "grep"],
+  "taskPrompt": "The repo/ directory under your task directory is a small Python service. Audit it for security vulnerabilities and write your findings to output/findings.json with the schema: {\"findings\": [{\"file\": \"<file>.py\", \"cwe\": \"CWE-NNN\", \"line\": 7, \"explanation\": \"...\"}]}. Report each distinct vulnerability class once per file (a file + CWE pair). Precision matters: false positives are penalized, and not every file is vulnerable. See input/README.md for the schema and scope.",
+  "agentMustDo": [
+    "Inspect every file under input/repo/",
+    "Identify each security vulnerability and its CWE class",
+    "Write output/findings.json with one {file, cwe} entry per distinct vulnerability",
+    "Avoid false positives (do not report benign code)"
+  ],
+  "inputFiles": [
+    { "name": "repo", "format": "Python source tree", "path": "input/repo", "description": "the service to audit: 8 modules (db.py, auth.py, cmd.py, serialize.py, files.py, config.py, calc.py + benign helpers.py)" },
+    { "name": "README.md", "format": "Markdown", "path": "input/README.md", "description": "the findings.json schema and scope" }
+  ],
+  "referenceFiles": [
+    { "name": "findings.json", "format": "JSON", "path": "output/findings.json", "description": "hidden: the (file, CWE-family) ground truth that scripts/score_vuln_audit.py compares the agent's output against" }
+  ],
+  "evaluation": "Deterministic gate-and-score, no model judgment (scripts/score_vuln_audit.py). The candidate's output/findings.json is normalized to (basename, CWE-number) pairs. GATE (score 0.0 if it fails): findings.json is well-formed AND precision >= 0.5 against the hidden ground truth -- this defeats the spam-every-CWE attack (high recall with low precision still scores 0). TIERS (equal weight, one per planted vulnerability): a file is credited when the agent reports it with a CWE in that file's accepted family (e.g. MD5 password hashing accepts CWE-327/328/916; eval accepts CWE-94/95). Score equals recall over the seven planted vulnerabilities, in [0,1].",
+  "vm": { "machineType": "c4-standard-4", "snapshot": "cpu-free-ubuntu", "timeout": 1800 },
+  "variants": 1,
+  "sourceSubmissionId": "<assigned by the agents-last-exam.org/submit portal>",
+  "taxonomy": {}
+}

--- a/tasks/computing_math/vuln_audit/task_card.json
+++ b/tasks/computing_math/vuln_audit/task_card.json
@@ -1,24 +1,24 @@
 {
   "taskId": "computing_math/vuln_audit",
-  "title": "Audit a Python service for security vulnerabilities",
-  "summary": "A small Python service contains seven planted security vulnerabilities across distinct CWE classes plus one benign module. The agent must identify each vulnerability and report it as a (file, CWE) finding, scored deterministically against a hidden ground truth with a precision gate.",
+  "title": "Audit a Python web service for security vulnerabilities",
+  "summary": "A realistic Python web service contains fourteen planted security vulnerabilities spanning distinct CWE classes -- several deliberately subtle (a sanitizer, whitelist, or check that looks sufficient but is bypassable; cross-parameter taint; or an obscure class) -- alongside benign modules that use dangerous-looking APIs safely. The agent must identify each real vulnerability and report it as a (file, CWE) finding, scored deterministically against a hidden ground truth with a precision gate that penalizes false positives. Calibrated to challenge recent frontier agents (Sonnet 4.6 / GPT-5.5 / Gemini 3.1 Pro), none of which fully passes it.",
   "category": "computing_math",
   "software": ["python", "bandit", "semgrep", "grep"],
-  "taskPrompt": "The repo/ directory under your task directory is a small Python service. Audit it for security vulnerabilities and write your findings to output/findings.json with the schema: {\"findings\": [{\"file\": \"<file>.py\", \"cwe\": \"CWE-NNN\", \"line\": 7, \"explanation\": \"...\"}]}. Report each distinct vulnerability class once per file (a file + CWE pair). Precision matters: false positives are penalized, and not every file is vulnerable. See input/README.md for the schema and scope.",
+  "taskPrompt": "The repo/ directory under your task directory is a realistic Python web service. Audit it for security vulnerabilities and write your findings to output/findings.json with the schema: {\"findings\": [{\"file\": \"<file>.py\", \"cwe\": \"CWE-NNN\", \"line\": 7, \"explanation\": \"...\"}]}. Report each distinct vulnerability class once per file (a file + CWE pair). Several vulnerabilities are subtle: code that looks mitigated (a sanitizer/whitelist/check) but is bypassable, or a dangerous-looking API used safely. Precision matters: false positives are penalized, and not every file is vulnerable. See input/README.md for the schema and scope.",
   "agentMustDo": [
-    "Inspect every file under input/repo/",
-    "Identify each security vulnerability and its CWE class",
+    "Inspect every module under input/repo/ and trace request inputs to dangerous sinks",
+    "Identify each real vulnerability and its CWE class -- including subtle/obscure ones and bypassable mitigations",
     "Write output/findings.json with one {file, cwe} entry per distinct vulnerability",
-    "Avoid false positives (do not report benign code)"
+    "Avoid false positives -- do not flag dangerous-looking code that is actually used safely"
   ],
   "inputFiles": [
-    { "name": "repo", "format": "Python source tree", "path": "input/repo", "description": "the service to audit: 8 modules (db.py, auth.py, cmd.py, serialize.py, files.py, config.py, calc.py + benign helpers.py)" },
+    { "name": "repo", "format": "Python source tree", "path": "input/repo", "description": "the service to audit: ~20 small modules forming a realistic web service. Not every file is vulnerable, and several use a dangerous-looking API safely." },
     { "name": "README.md", "format": "Markdown", "path": "input/README.md", "description": "the findings.json schema and scope" }
   ],
   "referenceFiles": [
     { "name": "findings.json", "format": "JSON", "path": "output/findings.json", "description": "hidden: the (file, CWE-family) ground truth that scripts/score_vuln_audit.py compares the agent's output against" }
   ],
-  "evaluation": "Deterministic gate-and-score, no model judgment (scripts/score_vuln_audit.py). The candidate's output/findings.json is normalized to (basename, CWE-number) pairs. GATE (score 0.0 if it fails): findings.json is well-formed AND precision >= 0.5 against the hidden ground truth -- this defeats the spam-every-CWE attack (high recall with low precision still scores 0). TIERS (equal weight, one per planted vulnerability): a file is credited when the agent reports it with a CWE in that file's accepted family (e.g. MD5 password hashing accepts CWE-327/328/916; eval accepts CWE-94/95). Score equals recall over the seven planted vulnerabilities, in [0,1].",
+  "evaluation": "Deterministic gate-and-score, no model judgment (scripts/score_vuln_audit.py). The candidate's output/findings.json is normalized to (basename, CWE-number) pairs. GATE (score 0.0 if it fails): findings.json is well-formed AND precision >= 0.5 against the hidden ground truth -- this defeats the spam-every-CWE attack (high recall with low precision still scores 0). TIERS (equal weight, one per planted vulnerability): a file is credited when the agent reports it with a CWE in that file's accepted family (e.g. weak password KDF accepts CWE-916/327; insecure randomness CWE-330/338; XXE CWE-611; CSV formula injection CWE-1236). Score equals recall over the fourteen planted vulnerabilities, in [0,1].",
   "vm": { "machineType": "c4-standard-4", "snapshot": "cpu-free-ubuntu", "timeout": 1800 },
   "variants": 1,
   "sourceSubmissionId": "<assigned by the agents-last-exam.org/submit portal>",


### PR DESCRIPTION
# PR: add a computing_math cluster — a Last-Exam security task + two near-term tasks

## Summary
Adds three deterministic tasks under `tasks/computing_math/`, expanding coverage into **secure-code
review, agent/LLM engineering, and SRE incident response** — areas the public reference set is thin
on. Each is graded by an executable, outcome-based scorer (no LLM judge). Submitted **code-only**
(`main.py` + `scripts/` + `task_card.json`) per the repo convention — the `input/` + hidden
`reference/` task-data bundles are delivered separately for `gs://ale-data-public`, which also keeps
the answer keys out of public git. Calibrated against **recent frontier agents** (Sonnet 4.6,
GPT-5.5, Gemini 3.1 Pro) per the contributor-track guidance that 100%-on-Sonnet-4.6 isn't yet
challenging.

| taskId | deliverable | grader idiom | tier | frontier full-pass |
|---|---|---|---|---|
| `computing_math/vuln_audit` | `output/findings.json` | precision-gated recall over CWE families | **Last-Exam** | Sonnet **0/5**, GPT-5.5 **1/5**, gemini-3.5-flash **0/3**, gemini-3.1-pro **refuses** |
| `computing_math/agentcore_repair` | repaired `agentcore/` package | hidden conformance suite (B0–B16) | near-term | Sonnet **5/5** (spec-impl is frontier strength) |
| `computing_math/incident_rca` | `output/rca.json` | intended-outcome anti-distractor gate | near-term | — |

## What's included per task (committed)
`task_card.json` (schema matches the reference example) · `main.py` (TaskConfig dataclass + the
`cb` decorators with async start/evaluate, patterned on `tasks/business_finance/american_option_pricing_ls`)
· `scripts/score_*.py` (verified standalone). The `input/` assets and hidden `reference/` (answer
keys) are **not** committed — they go to `gs://ale-data-public` like every other task's data.

## Verification
- Every grader self-calibrates: reference → 1.0, broken/empty → 0.0, partial → smooth credit.
- Anti-gaming tested: CWE-spam → 0.0 (precision gate); distractor diagnosis → 0.0; agentcore hidden
  suite is multi-scenario, isolated, and timed (unbounded-retry fix → 0).
- Difficulty calibrated by running recent frontier agents end-to-end (Sonnet 4.6, GPT-5.5, Gemini
  3.1 Pro / 3.5-flash): `vuln_audit` is **Last-Exam** (no frontier ref fully passes — capability
  misses + an outright Gemini-3.1-pro refusal); `agentcore_repair` (16 behaviors) and `incident_rca`
  are near-term.
- `task_card.json` lints clean; Linux `cpu-free-ubuntu`, no GPU / license / Windows-VM dependency.

## Licensing & provenance
100% original code authored for ALE; obviously-fake placeholder secrets only; no PII/third-party
data. Code Apache-2.0, data CC-BY-4.0.

## Before merge
The `start()` staging + session wiring is already exercised end-to-end: beyond the `--dry-run`, we ran
the **live `start()`/`evaluate()` over a real `cb.DesktopSession`** in the public `ale-kasm` sandbox on
a native-arm64 GCP VM — all three score correctly (empty → 0.0, perfect → 1.0); see
`engineering-track/VALIDATION-VM.md`. Open items for the maintainers: confirm the `input/`-staging +
`agentcore_repair` in-place-edit convention matches your managed harness, and the target
`machineType` (the validated host was arm64; the cards declare x86 `c4-standard-4`). Happy to adjust
the repo-edit hook to your preferred SWE-bench-style pattern.
