### PR TITLE
fix(clustered_cyclic): score on distance-suppression invariant, not absolute reference match

### DIFF
--- a/tasks/computing_math/clustered_cyclic_code_circuit_level_simulation/scripts/score_logical_error_rates.py
+++ b/tasks/computing_math/clustered_cyclic_code_circuit_level_simulation/scripts/score_logical_error_rates.py
@@ -1,4 +1,36 @@
-"""Score clustered-cyclic code logical error-rate CSV outputs."""
+"""Score clustered-cyclic code logical error-rate CSV outputs.
+
+Scoring model (revised 2026-06-13, per task author Andy Liu):
+
+The original grader compared every ``lfr_per_round`` / ``lfr_per_round_per_qubit``
+value against a frozen benchmark reference on a log scale (``LOG_TOLERANCE``).
+That exact-value match is not appropriate for this task: the reference was
+generated on a compute cluster with a large shot budget, whereas agents are
+evaluated on a single CPU VM where the achievable shot count is much lower, so
+the absolute logical-error-rate values carry significant Monte-Carlo noise even
+for a correct implementation. Matching absolute values therefore false-fails
+correct agents.
+
+The author's guiding success criterion is a *physical invariant* that is robust
+to the absolute-scale sampling difference because it compares two codes the
+agent simulated under identical conditions:
+
+    Across physical error rates, the distance-5 code [40,8,5] achieves a lower
+    logical error rate than the distance-3 code [24,8,3].
+
+This is the standard below-threshold distance-suppression signature: a higher
+code distance suppresses logical errors more strongly. A broken decoder (the
+failure mode that motivated this task's audit) inverts or flattens it. We check
+the invariant in the sub-threshold regime, where it is both physically
+meaningful and statistically resolvable, with a noise margin so a correct but
+under-sampled agent is not false-failed.
+
+The schema, simulation-grid, declared-parameter, and internal-consistency
+checks (``p_logical == num_failures / num_shots``, the LFR formulas) are
+retained unchanged — the reference is still used to pin the required
+``(code, p_physical)`` grid and the declared integer parameters, just not the
+outcome values.
+"""
 
 from __future__ import annotations
 
@@ -28,7 +60,35 @@ EXPECTED_COLUMNS = [
 
 KEY_FIELDS = ["code", "p_physical"]
 EXACT_INT_FIELDS = ["n", "k", "d", "num_rounds", "num_shots"]
-LOG_TOLERANCE = 0.1
+
+# ---------------------------------------------------------------------------
+# Distance-suppression criterion parameters (author-specified invariant).
+#
+# The comparison pair: the two k=8 codes, which differ only in distance and are
+# therefore directly comparable block-for-block. [54,18,3] (k=18) is held to the
+# schema/consistency checks but not the suppression comparison, since the
+# author's stated principle names the [40,8,5] vs [24,8,3] pair specifically.
+# ---------------------------------------------------------------------------
+SUPPRESSION_LOW_D_CODE = "[40,8,5]"   # higher distance -> should be LOWER p_logical
+SUPPRESSION_HIGH_D_CODE = "[24,8,3]"  # lower distance  -> should be HIGHER p_logical
+
+# Only assess the invariant where the d=3 code is still well below the
+# random-guess saturation ceiling. Above threshold both codes saturate near 1.0
+# and their ordering is pure Monte-Carlo noise.
+SUBTHRESHOLD_CEILING = 0.4
+
+# Noise margin: the d=5 rate may exceed the d=3 rate by at most this much before
+# it counts as a suppression violation. Absorbs binomial sampling error on a
+# CPU-VM shot budget; physically, sub-threshold suppression is strong (the d=5
+# rate is typically many times below the d=3 rate), so a modest margin does not
+# admit a broken/inverted decoder.
+SUPPRESSION_ABS_MARGIN = 0.02
+SUPPRESSION_REL_MARGIN = 0.25
+
+# Guards so a degenerate output (e.g. all-zeros, or a flat curve) cannot pass
+# the invariant trivially.
+MIN_SUBTHRESHOLD_POINTS = 3   # need enough resolvable sub-threshold comparisons
+MIN_SIGNAL_PLOGICAL = 0.01    # the d=3 curve must reach a real error rate somewhere
 
 
 @dataclass
@@ -134,10 +194,61 @@ def _close_numeric(actual: float, expected: float) -> bool:
     return abs(actual - expected) <= max(1e-12, abs(expected) * 1e-9)
 
 
-def _log_close(actual: float, expected: float) -> bool:
-    if actual <= 0.0 or expected <= 0.0:
-        return False
-    return abs(math.log10(actual) - math.log10(expected)) < LOG_TOLERANCE
+def _check_distance_suppression(
+    agent: dict[tuple[str, Decimal], dict[str, str]],
+    reasons: list[str],
+) -> None:
+    """Assert the author's distance-suppression invariant on the agent's output.
+
+    Across the sub-threshold physical error rates, the distance-5 code must
+    achieve a logical error rate no higher (within a noise margin) than the
+    distance-3 code. Compares the agent's own two k=8 codes, sampled under
+    identical conditions, so the check is robust to the absolute-scale sampling
+    difference between the reference cluster run and the evaluation VM.
+    """
+    def curve(code: str) -> dict[Decimal, float]:
+        out: dict[Decimal, float] = {}
+        for (row_code, p_physical), row in agent.items():
+            if row_code.strip() != code:
+                continue
+            value = _parse_float(row.get("p_logical"), "p_logical", [], f"{code}:{p_physical}")
+            if value is not None:
+                out[p_physical] = value
+        return out
+
+    d5_curve = curve(SUPPRESSION_LOW_D_CODE)
+    d3_curve = curve(SUPPRESSION_HIGH_D_CODE)
+
+    if not d5_curve or not d3_curve:
+        reasons.append(
+            "suppression:missing_code:"
+            f"{SUPPRESSION_LOW_D_CODE if not d5_curve else SUPPRESSION_HIGH_D_CODE}"
+        )
+        return
+
+    # Non-trivial-signal guard: the d=3 curve must reach a real error rate
+    # somewhere, otherwise an all-zero / flat output would pass trivially.
+    if max(d3_curve.values()) < MIN_SIGNAL_PLOGICAL:
+        reasons.append("suppression:no_signal:d3_curve_below_floor")
+        return
+
+    shared = sorted(set(d5_curve) & set(d3_curve))
+    subthreshold = [p for p in shared if d3_curve[p] <= SUBTHRESHOLD_CEILING]
+
+    if len(subthreshold) < MIN_SUBTHRESHOLD_POINTS:
+        reasons.append(
+            f"suppression:insufficient_subthreshold_points:{len(subthreshold)}<{MIN_SUBTHRESHOLD_POINTS}"
+        )
+        return
+
+    for p in subthreshold:
+        d5 = d5_curve[p]
+        d3 = d3_curve[p]
+        margin = max(SUPPRESSION_ABS_MARGIN, SUPPRESSION_REL_MARGIN * d3)
+        if d5 > d3 + margin:
+            reasons.append(
+                f"distance_suppression_violated:p={p}:d5={d5:.6g}>d3={d3:.6g}+margin={margin:.6g}"
+            )
 
 
 def score_logical_error_rates_bytes(
@@ -197,13 +308,6 @@ def score_logical_error_rates_bytes(
         lfr_per_qubit = _parse_float(
             got.get("lfr_per_round_per_qubit"), "lfr_per_round_per_qubit", reasons, row_key
         )
-        ref_lfr = _parse_float(ref.get("lfr_per_round"), "ref_lfr_per_round", reasons, row_key)
-        ref_lfr_per_qubit = _parse_float(
-            ref.get("lfr_per_round_per_qubit"),
-            "ref_lfr_per_round_per_qubit",
-            reasons,
-            row_key,
-        )
 
         if failures is not None and shots is not None:
             if failures < 0 or failures > shots:
@@ -228,14 +332,9 @@ def score_logical_error_rates_bytes(
         ):
             reasons.append(f"lfr_per_qubit_formula_inconsistent:{row_key}")
 
-        if lfr is not None and ref_lfr is not None and not _log_close(lfr, ref_lfr):
-            reasons.append(f"lfr_per_round_log_mismatch:{row_key}")
-        if (
-            lfr_per_qubit is not None
-            and ref_lfr_per_qubit is not None
-            and not _log_close(lfr_per_qubit, ref_lfr_per_qubit)
-        ):
-            reasons.append(f"lfr_per_round_per_qubit_log_mismatch:{row_key}")
+    # Author's physical-invariant criterion (replaces the absolute log-scale
+    # value match against the reference).
+    _check_distance_suppression(agent, reasons)
 
     passed = not reasons
     return LogicalErrorRateScoreResult(

--- a/tasks/computing_math/clustered_cyclic_code_circuit_level_simulation/task_card.json
+++ b/tasks/computing_math/clustered_cyclic_code_circuit_level_simulation/task_card.json
@@ -53,7 +53,7 @@
       "description": "The completed logical failure-rate table."
     }
   ],
-  "evaluation": "The evaluator reads `output/logical_error_rates_3codes.csv`, verifies the exact CSV schema and simulation grid, checks declared code parameters and shot counts, checks failure-count/probability consistency, and compares the logical failure-rate columns against the benchmark reference on log scale. The positive fixture scores `1.0`; the realistic negative fixture scores `0.0`.",
+  "evaluation": "The evaluator reads `output/logical_error_rates_3codes.csv`, verifies the exact CSV schema and simulation grid, checks declared code parameters and shot counts, and checks failure-count/probability consistency (`p_logical == num_failures / num_shots` and the LFR formulas). It then asserts the physical distance-suppression invariant: across the sub-threshold physical error rates, the distance-5 code `[40,8,5]` achieves a logical error rate no higher (within a noise margin) than the distance-3 code `[24,8,3]`. The absolute logical-error-rate values are not matched against the reference, because the reference was produced with a much larger shot budget than the evaluation VM can collect; comparing two codes the agent simulated under identical conditions makes the criterion robust to that sampling difference. The positive fixture scores `1.0`; the realistic negative fixture scores `0.0`.",
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free-ubuntu",


### PR DESCRIPTION
## Summary

Rewrites the `clustered_cyclic_code_circuit_level_simulation` grader to score on a **physical distance-suppression invariant** instead of an absolute log-scale match against a frozen benchmark reference. Author-approved (Andy Liu, Yale, 2026-06-13).

**Why.** The original grader matched every `lfr_per_round` / `lfr_per_round_per_qubit` value against the reference on a log scale (`LOG_TOLERANCE = 0.1`). The reference was generated on a compute cluster with a large shot budget; agents are evaluated on a single CPU VM where far fewer shots are achievable, so the absolute logical-error-rate values carry significant Monte-Carlo noise **even for a correct implementation**. Net effect: **57/57 corpus runs scored 0**, including agents whose decoder physics were correct (the convergent cluster sat ~17× off the reference purely on sampling scale, not correctness).

**What.** The author's success criterion compares two codes the agent simulated under *identical* conditions, so it is robust to the absolute-scale sampling difference:

> Across the sub-threshold physical error rates, the distance-5 code `[40,8,5]` achieves a logical error rate no higher (within a noise margin) than the distance-3 code `[24,8,3]`.

This is the standard below-threshold suppression signature; the broken decoder that motivated this task's audit inverts or flattens it. Implemented noise-robustly:
- checked only in the **sub-threshold regime** (where suppression is physically meaningful and statistically resolvable; above threshold both codes saturate near the random-guess ceiling and the ordering is pure noise);
- a **noise margin** (`max(abs, rel·d3)`) so a correct-but-under-sampled agent is not false-failed;
- a **non-trivial-signal guard** so a degenerate all-zero / flat output cannot pass trivially.

Schema, simulation-grid, declared-parameter, and internal-consistency checks (`p_logical == num_failures/num_shots`, the LFR formulas) are **unchanged**. The reference is still used to pin the required `(code, p_physical)` grid and the declared integer parameters — just not the outcome values.

## Files

- `scripts/score_logical_error_rates.py` — drop `LOG_TOLERANCE` / `_log_close` reference-value match; add `_check_distance_suppression` (the invariant) + parameters.
- `task_card.json` — `evaluation` description updated to match.

## Validation (local, against real corpus outputs)

| Input | Old grader | New grader | Expected |
|---|---|---|---|
| Author's reference curve vs itself | 1.0 | **1.0** | pass |
| `openclaw/claude-opus-4-7` cluster output (previously **0.0** under `LOG_TOLERANCE`) | 0.0 | **1.0** | **pass — the false-zero this fix targets** |
| `grok_cli/grok-4-3` (broken decoder, near random-guess everywhere) | 0.0 | **0.0** | fail |
| Synthetic inverted curve (`d5 > d3` in the sub-threshold band) | — | **0.0** | fail (`distance_suppression_violated`) |

## ⚠️ This PR is necessary but not sufficient — out-of-repo prerequisites

The scorer is a repo module (`main.py` imports it and runs it at eval time), so this PR makes the grader change live. **But two pieces of the fix are GCS-staged input data, not in this repo**, and must land before a re-grade/rerun is meaningful:

- [ ] **Stage Convention-A spec + author's seed matrices to GCS** — `gs://ale-data-all/computing_math/clustered_cyclic_code_circuit_level_simulation/base/input/cc_codes_quits_extraction.tex` (+ the `/mnt/data/agenthle/...` VM mirror). The author confirmed the published task should use **Convention A** (QUITS-standard `H_X = (I⊗H₁ | H₂*⊗I)`) and the seed matrices from his `run_memory.py` presets, **not** the paper's (same `[[n,k,d]]`, different Tanner graphs). This `.tex` is read by the agent from the VM, not from this repo, so it does not appear in this diff.
- [ ] *(optional)* bump `simulation_grid.csv` `num_shots` for crisper sub-threshold sampling on the CPU VM.
- [ ] Mirror this scorer change into the private dev repo (`cua-verse/agenthle`) so the two stay in sync.

## TODO — empirical validation runs (pending, not yet run)

The grader change is validated on *stored* outputs above, but the **corrected task has not been re-run end-to-end**. Two probe runs are planned once the GCS spec/seeds are staged (a re-grade of old outputs is not sufficient — the spec materially changed and the historical outputs are sample-starved):

- [ ] **`openclaw/claude-opus-4-7`** on `computing_math/clustered_cyclic_code_circuit_level_simulation` — primary probe (the cluster representative; ~$10, ~90 min on `c4-standard-4`).
- [ ] **`openclaw/gemini-3-1-pro-preview`** — secondary probe (near-reference contrast), **with an early timeout** (well under the 5 h default — historical good run finished in ~47 min; the expensive runs ran away to 600–900 turns, so cap it).

Both must run against the **corrected** spec (Convention A + author seeds), i.e. after the GCS prerequisite above. Reviewer: please treat the two probe-run boxes as the acceptance gate before this is relied on for a leaderboard number.

## Re-grade caveat

This changes scoring, so any historical re-grade must re-run **all** agents on this task, not a one-sided subset — and because the spec also changes (out-of-repo, above) and the historical outputs were sample-limited, a full rerun (not a regrade) is the defensible path to a reported number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
