### PR TITLE
feat(codex): merged-upstream fork + version-pinned install + OpenRouter MCP fixes

### DIFF
--- a/ale_run/agents/codex/AGENTS.md
+++ b/ale_run/agents/codex/AGENTS.md
@@ -103,6 +103,62 @@ NDJSON (one JSON object per line) on stdout:
 
 ---
 
+## 4b. Tool Compatibility Matrix (demo/tool_smoke)
+
+Probed by `demo/tool_smoke` (Linux) and `demo/tool_smoke_win` (Windows) on the
+re-baked dev VMs, 2026-06-15, fork `codex-cli 0.0.0-agenthle-20260614`, a
+direct-provider model. The task exercises every tool the agent is offered
+and records pass/fail per tool. Result: **Linux 32/32 tested passed (2 untested),
+Windows 26/28 passed (2 failed, 2 untested)** — all 14 GUI `mcp__cua.*` tools
+pass on both OSes.
+
+Legend: ✅ works · ❌ fails · ➖ untested (couldn't exercise) · — not offered on that OS
+
+| Tool | Linux | Win | Note |
+|---|---|---|---|
+| `functions.exec_command` | ✅ | — | one-shot shell; **Win uses `shell_command`** (`unified_exec` off on Windows) |
+| `functions.write_stdin` | ✅ | — | stdin to a persistent `unified_exec` session — Linux only |
+| `functions.shell_command` | — | ✅ | Windows shell exec (replaces exec_command/write_stdin) |
+| `functions.apply_patch` | ✅ | ✅ | **Win relies on the fork `apply_patch.exe` hardlink fix** |
+| `functions.update_plan` | ✅ | ✅ | |
+| `functions.view_image` | ✅ | ✅ | |
+| `functions.list_mcp_resources` | ✅ | ✅ | |
+| `functions.list_mcp_resource_templates` | ✅ | ✅ | |
+| `functions.read_mcp_resource` | ➖ | ➖ | untested: MCP resource list empty, no URI to read |
+| `functions.request_user_input` | ➖ | ➖ | untested: Plan-mode only + needs a human (headless) |
+| `functions.spawn_agent` | ✅ | ✅ | multi_agent_v2 sub-agent (the target model accepts it; V1 must stay disabled) |
+| `functions.wait_agent` | ✅ | ✅ | |
+| `functions.interrupt_agent` | ✅ | ✅ | |
+| `functions.list_agents` | ✅ | ✅ | |
+| `functions.send_message` | ✅ | ❌ | **❌Win**: strict "no observable return content" (child DID receive `SEND_MESSAGE_OK`) — V2-messaging/test-rule artifact, not a transport bug |
+| `functions.followup_task` | ✅ | ❌ | **❌Win**: same strict-return artifact (child returned `FOLLOWUP_TASK_OK`) |
+| `functions.create_goal` | ✅ | — | goals tools not surfaced/exercised on Windows in this run |
+| `functions.get_goal` | ✅ | — | |
+| `functions.update_goal` | ✅ | — | |
+| `mcp__cua.screenshot` | ✅ | ✅ | GUI via CUA MCP bridge |
+| `mcp__cua.click` | ✅ | ✅ | |
+| `mcp__cua.type` | ✅ | ✅ | (needs a clean desktop to verify visible effect) |
+| `mcp__cua.scroll` | ✅ | ✅ | (needs a clean desktop to verify visible effect) |
+| `mcp__cua.drag` | ✅ | ✅ | |
+| `mcp__cua.key` / `key_down` / `key_up` / `hold_key` | ✅ | ✅ | |
+| `mcp__cua.mouse_move` / `mouse_down` / `mouse_up` | ✅ | ✅ | |
+| `mcp__cua.cursor_position` | ✅ | ✅ | |
+| `mcp__cua.wait` | ✅ | ✅ | |
+| `web.run` | ✅ | ✅ | |
+| `multi_tool_use.parallel` | ✅ | ✅ | parallel tool-call wrapper |
+
+Notes:
+- Total tool count differs by OS (Linux 34, Windows 30) because `unified_exec`
+  (and its `exec_command`/`write_stdin`) is off on Windows and the goals tools
+  weren't offered there; Windows substitutes `shell_command`.
+- The only true failures are the two Windows V2-messaging tools, and they're a
+  strict scorer rule ("the call itself returned no observable payload") rather
+  than a real breakage — the sub-agent did receive/complete the work.
+- GUI (`mcp__cua.*`) tools all pass on both OSes; `type`/`scroll` only verify
+  their visible effect on a clean desktop (leftover windows can hide it).
+
+---
+
 ## 5. Config Fields
 
 | Field | Type | Default | Meaning |

--- a/ale_run/agents/codex/config.py
+++ b/ale_run/agents/codex/config.py
@@ -1,30 +1,50 @@
 """CodexConfig: per-episode knobs for the OpenAI Codex CLI deployer.
 
-Codex CLI is installed from NPM (``@openai/codex@<version>``). An
-optional patched native binary (from a GitHub Release URL) replaces the
-vendor binary to fix the Windows ``apply_patch.bat`` corruption bug.
+The deployer ensures the running codex is exactly the pinned **fork** build
+(``fork_version``, e.g. ``codex-cli 0.0.0-agenthle-20260614``): it compares
+``codex --version`` and, when the binary is missing/stale/stock, installs stock
+``@openai/codex`` from NPM (if needed) and overlays the fork native binary from
+the GitHub Release; a matching version skips the download. The fork = openai/codex
+``main`` merged in, plus two carries: the Windows ``apply_patch.exe`` hardlink
+fix and the OpenRouter MCP adaptation (namespaced-tool flatten + dispatch
+remap). Built from cua-verse/codex ``agenthle``; published as the release below.
 
 Auth: OpenRouter routing uses ``OPENROUTER_API_KEY`` injected via env.
 Direct OpenAI routing uses ``OPENAI_API_KEY``.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import ClassVar
 
-# Default NPM package version for the Codex CLI.
+logger = logging.getLogger(__name__)
+
+# Reasoning-effort variants the fork binary can deserialize. The merged build
+# accepts the full set incl. ``max`` (a newer reasoning level — upstream
+# represents it as ReasoningEffort::Custom, so any string parses). Kept as a
+# guard so a much older baked fork still loads the catalog; entries with an
+# unknown effort are stripped at load time (logged, not silent).
+_FORK_KNOWN_REASONING_EFFORTS = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+)
+
+# NPM fallback version: only used when NO codex is on PATH (rare — images bake
+# the fork). The stock package is installed then the fork binary is overlaid, so
+# this is just the stock base the overlay replaces. Pin a real published stock
+# version so the fallback install succeeds.
 _DEFAULT_CODEX_VERSION = "0.114.0"
 
-# GitHub Release URLs for the patched native binary, per OS. When set and
-# reachable, the deployer downloads the matching binary and overwrites the
-# npm-installed vendor binary. When empty the binary-replacement step is
-# silently skipped. Linux ships ``codex`` (musl x86-64); Windows ships
-# ``codex-x86_64-pc-windows-msvc.exe`` — separate release assets because a
-# single binary can't cover both targets. Both are built from
-# cua-verse/codex @ ee3e51688 (agenthle): the OpenRouter MCP adaptation,
-# plus — on Windows only — the apply_patch.exe-hardlink fix.
+# GitHub Release of the fork native binary, per OS. Downloaded and overlaid over
+# the vendor binary whenever the running version != ``fork_version``.
+# Both are glibc/MSVC x86-64 release builds from cua-verse/codex
+# ``agenthle`` (openai/main merged + Windows apply_patch fix + OpenRouter MCP
+# adaptation). Empty string = skip overlay. Linux asset ``codex``; Windows asset
+# ``codex-x86_64-pc-windows-msvc.exe`` (distinct targets, separate assets).
 _RELEASE_BASE = (
-    "https://github.com/cua-verse/codex/releases/download/v0.114.0-agenthle"
+    "https://github.com/cua-verse/codex/releases/download/v0.0.0-agenthle-20260614"
 )
 _DEFAULT_PATCHED_BINARY_URL = f"{_RELEASE_BASE}/codex"
 _DEFAULT_PATCHED_BINARY_URL_WINDOWS = (
@@ -79,3 +99,99 @@ class CodexConfig:
     # ``patched_binary_url`` when running on Windows. Empty string = skip
     # replacement on Windows (use npm's bundled codex.exe).
     patched_binary_url_windows: str = _DEFAULT_PATCHED_BINARY_URL_WINDOWS
+
+    # Pinned fork version the running ``codex`` must report (``codex --version``).
+    # The deployer ensures the engine is exactly this build: if no codex is on
+    # PATH it installs stock + overlays the fork; if a codex is present but its
+    # version doesn't match this string, it downloads + overlays the fork; if it
+    # already matches, it skips the download. This replaces the old
+    # baked-fork-by-sentinel skip, which couldn't tell an old fork from a new one
+    # (both reported plain ``0.0.0``). Must match the version baked into the
+    # release at ``patched_binary_url`` (see codex-rs workspace Cargo.toml).
+    fork_version: str = "0.0.0-agenthle-20260614"
+
+    # ---- model catalog (models not in codex's bundled catalog) ----
+    # Host path to a Codex model-catalog JSON (an external catalog
+    # file). Needed to run models the bundled catalog
+    # does not know about. Resolved relative to the
+    # process cwd (same convention as ``secret_file``). Empty = no catalog
+    # (use codex's bundled catalog). When set, the file is read + sanitised
+    # host-side in __post_init__ and the content is shipped to the sandbox via
+    # ``model_catalog_content`` below; the deployer writes it to
+    # ``~/.codex/model_catalog.json`` and points config.toml's
+    # ``model_catalog_json`` at it.
+    model_catalog_path: str = ""
+
+    # Auto-populated from ``model_catalog_path`` (do not set by hand). Carries
+    # the (sanitised) catalog JSON text into the sandbox through the serialized
+    # config kwargs — the deployer runs in-sandbox where ``model_catalog_path``
+    # is not reachable, so the content must travel with the config.
+    model_catalog_content: str = ""
+
+    # ---- codex feature flags (== tool surface) ----
+    # Override codex's default ``[features]`` map. A ``{feature_key: bool}`` dict
+    # written verbatim into ``~/.codex/config.toml`` ``[features]``. ``true``
+    # force-enables, ``false`` force-disables — both directions in one map
+    # (codex's own features table is a single bool map). Empty = inherit codex's
+    # current defaults unchanged. Only headless-meaningful keys are worth setting;
+    # the consolidated codex.yaml preset documents them all (commented). Example:
+    # ``{"multi_agent_v2": True, "multi_agent": False}``.
+    feature_overrides: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Load the catalog host-side (build_config) and embed its content so it
+        # reaches the in-sandbox deployer. On the in-sandbox reconstruction the
+        # content kwarg is already populated → we skip the (host-only) file read.
+        if self.model_catalog_path and not self.model_catalog_content:
+            try:
+                raw = Path(self.model_catalog_path).read_text(encoding="utf-8")
+            except OSError as exc:
+                raise RuntimeError(
+                    f"codex: model_catalog_path {self.model_catalog_path!r} "
+                    f"could not be read: {exc}"
+                ) from exc
+            self.model_catalog_content = _sanitise_catalog_for_fork(raw)
+
+
+def _sanitise_catalog_for_fork(raw: str) -> str:
+    """Drop reasoning-effort variants the pinned fork binary cannot parse.
+
+    The fork's ``ReasoningEffort`` enum predates ``max``; an entry listing it
+    (or any other unknown variant) makes the whole catalog fail to load. We
+    remove those entries — and rewrite a model's ``default_reasoning_level`` to
+    ``high`` if it pointed at a dropped variant — and log exactly what changed.
+    Returns the JSON text unchanged when nothing needed stripping.
+    """
+    try:
+        catalog = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"codex: model catalog is not valid JSON: {exc}") from exc
+
+    dropped: list[str] = []
+    for model in catalog.get("models", []):
+        if not isinstance(model, dict):
+            continue
+        slug = model.get("slug", "?")
+        levels = model.get("supported_reasoning_levels")
+        if isinstance(levels, list):
+            kept = []
+            for entry in levels:
+                effort = entry.get("effort") if isinstance(entry, dict) else entry
+                if effort in _FORK_KNOWN_REASONING_EFFORTS:
+                    kept.append(entry)
+                else:
+                    dropped.append(f"{slug}.supported_reasoning_levels[{effort}]")
+            model["supported_reasoning_levels"] = kept
+        default = model.get("default_reasoning_level")
+        if default is not None and default not in _FORK_KNOWN_REASONING_EFFORTS:
+            dropped.append(f"{slug}.default_reasoning_level={default}->high")
+            model["default_reasoning_level"] = "high"
+
+    if not dropped:
+        return raw
+    logger.warning(
+        "codex: stripped %d catalog field(s) the pinned fork cannot parse "
+        "(rebuild the fork to use them): %s",
+        len(dropped), ", ".join(dropped),
+    )
+    return json.dumps(catalog)

--- a/ale_run/agents/codex/deployer.py
+++ b/ale_run/agents/codex/deployer.py
@@ -1,12 +1,16 @@
-"""CodexDeployer — drives the OpenAI ``codex`` CLI (v0.114.0).
+"""CodexDeployer — drives the OpenAI ``codex`` CLI (fork build, reports 0.0.0).
 
-Installed via ``npm install -g @openai/codex@<version>``.  An optional
-patched native binary (downloaded from a GitHub Release URL) replaces
-the npm-installed vendor binary to fix the Windows ``apply_patch``
-corruption bug.
+The deployer ensures the running ``codex`` is exactly the pinned fork build
+(``CodexConfig.fork_version``): it compares ``codex --version`` and overlays the
+fork native binary from a GitHub Release when missing/stale/stock (installing
+stock from NPM first if nothing is on PATH), else skips the download. The fork =
+openai/codex ``main`` + Windows ``apply_patch.exe`` fix + OpenRouter MCP
+adaptation (see CodexConfig).
 
 OpenRouter routing: ``OPENROUTER_API_KEY`` + ``config.toml`` with
-``model_provider = "openrouter"`` and a custom model_providers block.
+``model_provider = "openrouter"`` and a custom model_providers block. Direct
+routing: ``OPENAI_API_KEY`` → ``CODEX_API_KEY`` (non-default models via a supplied
+model catalog).
 
 MCP config at ``~/.codex/config.toml``.  Headless via
 ``--dangerously-bypass-approvals-and-sandbox`` (yolo) or
@@ -97,23 +101,26 @@ class CodexDeployer(BaseAgentDeployer):
         from ale_run.agents._bootstrap import ensure_npm
         self._npm_path = await ensure_npm()
 
-        # Skip-install policy (Option B): if a ``codex`` is already present
-        # (baked into the image) USE IT, regardless of its version string. Both
-        # the ale-ubuntu22 and ale-win10 images bake the *fork* build, which
-        # reports ``codex-cli 0.0.0`` — requiring the npm-pinned semver would
-        # force a needless reinstall + GitHub re-download on every single run.
-        # We only treat a baked binary as good enough to skip the patched-binary
-        # overlay when it IS the fork; a stock build (or anything not the fork)
-        # still gets the fork overlaid below, so the running engine is always
-        # the fork — we never silently fall back to stock.
+        # Ensure the running codex is exactly the pinned fork build
+        # (cfg.fork_version), comparing `codex --version`:
+        #   * not on PATH        -> npm install stock, then overlay the fork
+        #   * present, wrong ver -> overlay the fork (download)  [e.g. a stale
+        #                           baked fork, or stock]
+        #   * present, matches   -> already current, skip the GitHub download
+        #                           (matters at concurrency × 135 tasks)
+        # We compare the FULL version string (not a 0.0.0 sentinel) so an old
+        # fork build is correctly seen as stale and replaced — there is no
+        # silent fall back to stock/old.
+        patched_url = (
+            cfg.patched_binary_url_windows if self._is_windows
+            else cfg.patched_binary_url
+        )
         codex_path = shutil.which("codex")
-        baked_is_fork = bool(codex_path) and await self._is_fork_build(codex_path)
-        if codex_path:
-            logger.info(
-                "codex: using pre-installed binary %s (fork=%s), skipping npm install",
-                codex_path, baked_is_fork,
-            )
-        else:
+        already_current = bool(codex_path) and await self._version_matches(
+            codex_path, cfg.fork_version
+        )
+        need_overlay = True
+        if not codex_path:
             logger.info(
                 "codex: not found on PATH, installing @openai/codex@%s via npm ...",
                 cfg.codex_version,
@@ -125,25 +132,30 @@ class CodexDeployer(BaseAgentDeployer):
                     "CodexDeployer: 'codex' still not found after "
                     f"npm install -g @openai/codex@{cfg.codex_version}"
                 )
+        elif already_current:
+            logger.info(
+                "codex: %s already at pinned %s, skipping overlay",
+                codex_path, cfg.fork_version,
+            )
+            need_overlay = False
+        else:
+            logger.info(
+                "codex: %s present but not at pinned %s — overlaying fork",
+                codex_path, cfg.fork_version,
+            )
         self._codex_path = codex_path
 
-        # 2. Overlay the patched fork native binary UNLESS we already have the
-        # fork. A baked fork build needs no overlay (this skips a per-run GitHub
-        # download — important at concurrency × 135 tasks); a freshly
-        # npm-installed stock build (or a non-fork baked one) gets the fork
-        # overlaid so the engine is always the fork. The Linux and Windows
-        # builds are distinct release assets, so pick the URL matching the OS.
-        if baked_is_fork:
-            logger.info("codex: baked fork build detected, skipping patched-binary overlay")
-        else:
-            patched_url = (
-                cfg.patched_binary_url_windows if self._is_windows
-                else cfg.patched_binary_url
-            )
-            if patched_url:
-                await self._replace_native_binary(patched_url)
+        # 2. Overlay the fork native binary when needed (missing/stale/stock).
+        if need_overlay:
+            if not patched_url:
+                raise RuntimeError(
+                    "codex: need the fork binary but patched_binary_url is empty "
+                    f"(running codex is not pinned {cfg.fork_version})"
+                )
+            await self._replace_native_binary(patched_url)
 
-        # 3. Verify codex --version
+        # 3. Verify codex --version is now the pinned fork (ensure latest or fail
+        # loudly — never silently run a stale build).
         try:
             probe = await asyncio.to_thread(
                 subprocess.run,
@@ -152,7 +164,13 @@ class CodexDeployer(BaseAgentDeployer):
             )
         except subprocess.TimeoutExpired as e:
             raise RuntimeError(f"codex --version timed out: {e}")
-        logger.info("codex: CLI ok -- %s", (probe.stdout or "").strip())
+        version_out = (probe.stdout or "").strip()
+        logger.info("codex: CLI ok -- %s", version_out)
+        if need_overlay and cfg.fork_version not in version_out:
+            raise RuntimeError(
+                f"codex: overlay did not yield pinned {cfg.fork_version!r} "
+                f"(got {version_out!r}); refusing to run a stale build"
+            )
 
         # 4. Prepare work directory
         wd = Path(self.executor.work_dir)
@@ -165,19 +183,6 @@ class CodexDeployer(BaseAgentDeployer):
 
         # 5. Write MCP config (config.toml) for CUA bridge
         await self._write_codex_config(cfg)
-
-    # The cua-verse fork carries no real semver and reports ``codex-cli
-    # 0.0.0``; any stock npm release reports a normal version (e.g.
-    # ``0.114.0``). We use that sentinel to recognise a baked fork build.
-    _FORK_VERSION_MARKER: ClassVar[str] = "0.0.0"
-
-    async def _is_fork_build(self, codex_path: str) -> bool:
-        """True if the codex at ``codex_path`` is our cua-verse fork build.
-
-        Used to decide whether the patched-binary overlay can be skipped (the
-        baked binary already IS the fork) — see :meth:`install` step 2.
-        """
-        return await self._version_matches(codex_path, self._FORK_VERSION_MARKER)
 
     async def _version_matches(self, codex_path: str, version: str) -> bool:
         """True if ``codex --version`` reports the pinned version string."""
@@ -341,6 +346,24 @@ class CodexDeployer(BaseAgentDeployer):
         if is_openrouter:
             preamble += 'model_provider = "openrouter"\n'
 
+        # Model catalog (models not in codex's bundled catalog). Write the shipped catalog
+        # content to ~/.codex/model_catalog.json and point config.toml at it via
+        # ``model_catalog_json`` (must be an absolute path — codex parses it as
+        # AbsolutePathBuf). The content travelled here in the serialized config
+        # (cfg.model_catalog_content), already sanitised host-side.
+        home = os.path.expanduser("~")
+        codex_config_dir = os.path.join(home, ".codex")
+        os.makedirs(codex_config_dir, exist_ok=True)
+        if cfg.model_catalog_content:
+            catalog_path = os.path.join(codex_config_dir, "model_catalog.json")
+            Path(catalog_path).write_text(cfg.model_catalog_content, encoding="utf-8")
+            toml_catalog_path = (
+                catalog_path.replace("\\", "/") if not sandbox.is_linux
+                else catalog_path
+            )
+            preamble += f'model_catalog_json = "{toml_catalog_path}"\n'
+            logger.info("codex: model catalog written to %s", catalog_path)
+
         config_toml = preamble + "\n"
 
         # MCP server config for CUA bridge. CUA_SERVER_URL points the bridge at
@@ -365,10 +388,24 @@ class CodexDeployer(BaseAgentDeployer):
                 'env_key = "OPENROUTER_API_KEY"\n'
             )
 
-        # Write config file
-        home = os.path.expanduser("~")
-        codex_config_dir = os.path.join(home, ".codex")
-        os.makedirs(codex_config_dir, exist_ok=True)
+        # Feature overrides → codex [features] map (== tool surface). Each entry
+        # force-enables (true) or force-disables (false) a codex feature; an
+        # empty map leaves codex's defaults untouched. codex's features table is
+        # a single bool map so both directions live here (e.g. enable
+        # multi_agent_v2 + disable multi_agent). Keys are validated by codex at
+        # load (unknown keys warn); see CodexConfig.feature_overrides and the
+        # codex.yaml preset for the documented headless-meaningful keys.
+        if cfg.feature_overrides:
+            config_toml += "\n[features]\n"
+            for key, val in cfg.feature_overrides.items():
+                config_toml += f"{key} = {'true' if val else 'false'}\n"
+            logger.info(
+                "codex: feature overrides -> %s",
+                ", ".join(f"{k}={'on' if v else 'off'}"
+                          for k, v in cfg.feature_overrides.items()),
+            )
+
+        # Write config file (codex_config_dir created above).
         config_path = os.path.join(codex_config_dir, "config.toml")
         Path(config_path).write_text(config_toml, encoding="utf-8")
         logger.info("codex: config written to %s", config_path)


### PR DESCRIPTION
## Summary
Upgrades the **codex** agent deployer and its forked codex CLI.

### Forked codex CLI (submodule `ale_run/agents/codex/upstream` → cua-verse/codex `agenthle`)
- Merged **openai/codex `main`** (~1.6k commits) into the fork.
- Carries: **Windows `apply_patch.exe` hardlink fix** + **OpenRouter MCP adaptation** (flatten namespaced MCP tools to canonical `mcp__server__tool` names + a dispatch remap so flattened names resolve; empty-param schema fill).
- **Stamped version `0.0.0-agenthle-20260614`** so old vs new fork builds are distinguishable; published as a GitHub release. Submodule gitlink bumped to it.

### Deployer (`ale_run/agents/codex/`)
- **Version-pinned ensure-latest install**: compares `codex --version` to `fork_version`, overlays the fork binary from the release when missing/stale/stock, hard-fails if it can't reach the pinned build (no silent stale fallback).
- **`model_catalog_path`/`model_catalog_content`**: run models not in codex's bundled catalog by shipping a model-catalog JSON into the sandbox and wiring `model_catalog_json`; works over direct OpenAI (`provider=direct`).
- **`feature_overrides`**: a `{feature: bool}` map written to config.toml `[features]` (bidirectional, mirrors claude_code's `disabled_tools`). The `codex.yaml` preset documents the headless-meaningful features (commented = default).
- **Docs**: `AGENTS.md` records the Linux/Windows tool-compatibility matrix.

### Validation (dev VMs)
- `tool_smoke`/`tool_smoke_win`: **14/14 cua-mcp tools pass** on both OSes; `apply_patch` passes on Windows.
- `seecheck`/`seecheck_win`: **1.0** on both OSes (MCP-over-OpenRouter image path works).

### Not committed (intentional)
- Experiment/run config files and task lists are temporary — they live in the worktree but are not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
