### PR TITLE
feat(antigravity_cli): add Google Antigravity CLI (agy) in-sandbox agent

### DIFF
--- a/ale_run/agents/antigravity_cli/AGENTS.md
+++ b/ale_run/agents/antigravity_cli/AGENTS.md
@@ -1,0 +1,179 @@
+# Antigravity CLI Integration Notes
+
+## Source
+
+- Binary: `agy` — Google's Antigravity CLI (successor to Gemini CLI), a closed
+  native Go binary. **No fork** (it cannot be patched like the JS gemini-cli).
+- Install: official installer `https://antigravity.google/cli/install.sh` drops
+  `~/.local/bin/agy`. Pinnable tarball via the updater manifest
+  (`.../manifests/linux_amd64.json` → `storage.googleapis.com/antigravity-public/...`).
+  The current ALE pin is `1.1.25`; its official URL and checksum are retained in
+  the deployer so a newer latest-only manifest does not break reproducible installs.
+- Auth: this integration uses Google OAuth via the host-login → token-file →
+  in-sandbox-injection flow. `agy` also supports Gemini API keys; OpenRouter's
+  OpenAI-compatible endpoint is not wire-compatible with agy's native Gemini
+  requests without a translation proxy.
+
+## Install
+
+`AntigravityCliDeployer.install()` probes `agy --version` and installs the exact
+configured release from Google's updater manifest when missing or mismatched.
+It verifies the manifest SHA-512, then writes the OAuth credential, CUA MCP
+config, and CLI policy settings. Linux targets `~/.local/bin/agy`; Windows
+targets `%LOCALAPPDATA%\agy\bin\agy.exe`.
+
+## Runtime
+
+The deployer launches:
+
+```bash
+agy --print="<prompt>" --model "<display name>" --output-format stream-json \
+  --dangerously-skip-permissions --add-dir <task_data_root>
+```
+
+- `--model` takes the `agy models` display names verbatim (e.g.
+  `Gemini 3.7 Flash (High)`, `Claude Sonnet 4.6 (Thinking)`, `GPT-OSS 120B (Medium)`).
+- Streaming JSON supplies per-generation usage, per-tool duration, and the final
+  response in `transcript.jsonl`. ALE normalizes it into ATIF and one
+  `metrics_summary.json` artifact whose `api_calls` shape matches the Codex and
+  Claude telemetry summaries as far as agy's native fields permit.
+- The deployer pins agy's native `--log-file` to `agy_cli.log` inside each task's
+  work directory. This avoids the global `cli.log` symlink race under concurrent
+  runs and ensures the native log is pulled with the task.
+- Native `agy` omits cache-write tokens, request cost, and per-transport-retry
+  tokens/latency. Availability flags retain those gaps.
+- Auth at launch is **silent**: `agy` reads the injected
+  `~/.gemini/antigravity-cli/antigravity-oauth-token` and refreshes it itself.
+
+## Tool Surface
+
+`agy` exposes a rich native toolset **plus** the CUA MCP tools. Unlike
+gemini-cli, the CUA bridge must be declared in `agy`'s **native**
+`~/.gemini/config/mcp_config.json` (NOT `settings.json`), or no GUI tools load.
+
+The matrix below is the agent's own self-report from `demo/tool_smoke` on
+`ale-ubuntu22` (Gemini 3.1 Pro): **36 tools identified, 33 passed, 0 failed,
+3 untested**.
+
+### Native `agy` tools (19 — all exercised, all passed)
+
+| Tool | Classification | Notes |
+|---|---|---|
+| `run_command` | supported | VM shell execution. |
+| `view_file`, `write_to_file` | supported | VM filesystem read/write. |
+| `replace_file_content`, `multi_replace_file_content` | supported | In-place edits. |
+| `list_dir`, `grep_search` | supported | File discovery / content search. |
+| `search_web`, `read_url_content` | supported | Web access (internet is allowed). |
+| `generate_image` | supported | Image generation. |
+| `call_mcp_tool`, `list_resources`, `list_permissions` | supported | MCP meta / introspection. |
+| `define_subagent`, `invoke_subagent`, `manage_subagents` | supported | Sub-agent orchestration. |
+| `manage_task`, `schedule` | supported | Task list / scheduled work. |
+| `send_message` | supported | Agent message channel. |
+
+### CUA MCP GUI tools (14 — all exercised, all passed)
+
+| Tool | Notes |
+|---|---|
+| `screenshot` | Desktop capture — the GUI→model image path (proven by `demo/seecheck`). |
+| `click`, `mouse_move`, `mouse_down`, `mouse_up`, `drag` | Pointer actions. |
+| `key`, `key_down`, `key_up`, `hold_key`, `type` | Keyboard actions. |
+| `scroll`, `wait`, `cursor_position` | Scroll / pause / pointer query. |
+
+> The CUA action tools require real arguments (e.g. `mouse_move` needs a
+> `coordinate`). During the smoke test `agy`'s first degenerate probe calls
+> returned `MCP -32602 Invalid arguments`; it then retried with proper args and
+> all passed — so the errors are agent-side, not a bridge incompatibility.
+
+### Untested (3)
+
+| Tool | Reason |
+|---|---|
+| `ask_permission`, `ask_question` | Interactive — block headless; `agy` self-skips them. |
+| `read_resource` | No MCP resources are exposed on the `cua` server. |
+
+### Headless permissions
+
+The deployer writes `toolPermission: always-proceed` and
+`artifactReviewPolicy: always-proceed` to agy's CLI settings and launches with
+`--dangerously-skip-permissions`. This avoids human-review prompts during a
+task. The previous `tools.exclude` setting was removed because it belonged to a
+different Gemini settings schema and was not enforced by `agy`.
+
+## Validation (OS × provider)
+
+| Task | Linux / QEMU | Linux / docker | Linux / gcloud | Windows / gcloud |
+|---|---|---|---|---|
+| `demo/seecheck` (GUI vision) | **1.0** (agy 1.1.25, Claude Sonnet 4.6 Thinking) | **1.0** | **1.0** | — |
+| `demo/seecheck_win` (GUI vision) | n/a | n/a | n/a | **1.0** (3/3, with the cua mitigation) |
+| `demo/tool_smoke` | — | **0.92** (33/36) | **0.92** (33/36) | n/a |
+| `demo/tool_smoke_win` | n/a | n/a | n/a | **0.92** (34/37) — all 14 cua + native pass, incl. `grep_search` |
+
+`demo/tool_smoke_win` (Claude Sonnet 4.6): all 14 cua GUI tools pass + the native
+tools, including **`grep_search` (verified passing end-to-end)** — `install()`
+puts Git-for-Windows' GNU grep (`…\Git\usr\bin\grep.exe`, baked into ale-win10)
+on PATH (`grep (GNU grep) 3.0`). The remaining non-passes are expected and vary
+by run: `read_resource` (cua exposes no MCP resources), `ask_question`
+(interactive), `generate_image` (separate image-model quota), or a stray
+`command_status`/`cua_scroll` model test-artifact. Note: Sonnet invokes the
+cua tools via the `call_mcp_tool` wrapper, so they appear as
+`call_mcp_tool__cua__screenshot` etc. (Gemini promotes them to bare names) — both
+work. The thinking model is slow over 38 tools, so the run hit the 30-min wall
+(`status=timeout`, score still real).
+
+gcloud uses the operator's **active gcloud account** (compute access) when
+`GCP_SA_KEY` is unset/missing — `gcloud_sa_key_path()` returns None and the
+provider falls back to it. `output_path: local` needs no GCS key.
+
+## Windows
+
+The deployer supports Windows: it installs `agy.exe` via `install.ps1` into
+`%LOCALAPPDATA%\agy\bin`, writes the OAuth token + MCP config under
+`%USERPROFILE%\.gemini` (the Linux-generated token authenticates fine on
+Windows), and launches `agy.exe --print="<prompt>"`. **agy's native tools work**
+(`run_command`, file tools, web, etc.). `grep_search` shells out to `grep`, so
+the deployer adds Git-for-Windows' GNU grep to `PATH` (or installs a BusyBox
+fallback when Git is absent).
+
+### cua GUI on Windows — an intermittent startup race (mitigated)
+
+The CUA MCP tools loaded only **intermittently** on Windows (≈1 run in 4) — some
+runs registered and used all 14, others registered none. Everything the deployer
+controls is correct (verified on a live VM: `mcp_config.json` with the right
+`node.exe`/`index.js` paths, the bridge, and its `node_modules` are all present;
+the `GeminiDir "...not absolute, falling back to default"` log line is a red
+herring — it appears even when cua works). The variance is a **race on the FIRST
+agy run on a fresh VM**: agy's config-migration + auto-updater + a cold `node`
+start (slow on Windows — Defender scan + ESM module load of the MCP SDK) race
+with agy's MCP tool-discovery window, so cua sometimes isn't registered in time.
+
+The deployer mitigates this in `install()` (all steps cost **no model quota**):
+
+1. **Pre-warm the node bridge** — spawn it once so its modules are cached /
+   Defender-scanned, making agy's spawn at launch fast.
+2. **Prime agy** with `agy models` (a metadata call, *not* a `-p` generation
+   turn) so first-run config-migration + the auto-updater are already done.
+3. **Pass `--gemini_dir=<absolute>`** so config discovery is deterministic.
+
+The deployer passes `--log-file=work_dir/agy_cli.log` and incrementally pulls it
+as a hot artifact to keep this diagnosable. **Validated:** with the mitigation,
+`demo/seecheck_win` (GUI vision) passes **3/3 = 1.0** on fresh ale-win10 gcloud
+VMs — so cua now loads reliably on Windows.
+
+### Account / quota note (important)
+
+agy's quota is **per Google account AND per model**. If runs 429 with
+*"Individual quota reached — please upgrade your subscription"*, the **active
+account is a free tier**, not the intended plan. Check the active account in
+`~/.gemini/google_accounts.json` (there is no agy CLI quota command; the web
+Settings → Models tab shows usage). A different model can have separate quota —
+e.g. when Gemini was exhausted, `Claude Sonnet 4.6 (Thinking)` still worked; the
+Windows validation above used it. To switch accounts, delete
+`~/.gemini/antigravity-cli/antigravity-oauth-token` and re-run the host login.
+
+## Quota
+
+Auth/routing is the operator's Google plan, not OpenRouter. The **free tier has
+a limited rolling quota**: a normal task or a single ~36-tool smoke run
+completes, but back-to-back heavy runs can exhaust it
+(`RESOURCE_EXHAUSTED (429): Individual quota reached`, multi-day reset). Light
+calls keep working while the heavy budget is depleted.

--- a/ale_run/agents/antigravity_cli/README.md
+++ b/ale_run/agents/antigravity_cli/README.md
@@ -1,0 +1,189 @@
+# Antigravity CLI Agent (`agy`)
+
+Google's Antigravity CLI — the successor to Gemini CLI — run as a one-shot
+process inside the sandbox:
+
+```text
+agy --print=<prompt> --model <name> --output-format stream-json --dangerously-skip-permissions
+  → CUA MCP Server (stdio, from ~/.gemini/config/mcp_config.json)
+  → sandbox desktop (screenshot / click / type) + filesystem
+```
+
+It is a generalist CLI **and** GUI agent: it gets the shell/files natively from
+the sandbox OS, and the desktop (screenshot, click, type…) through the CUA MCP
+bridge — so it can do real computer-use tasks, not just terminal ones.
+
+> **This preset validates Google account auth.** `agy` supports both Google
+> OAuth and, in recent releases, a Gemini API-key mode. ALE currently stages an
+> OAuth token file so the same authenticated account can run headlessly in each
+> sandbox. OpenRouter cannot be selected by changing the base URL alone: `agy`
+> speaks Gemini's native `streamGenerateContent` protocol while OpenRouter's
+> public endpoint is OpenAI-compatible; a translation proxy would be required.
+
+---
+
+## Quick start
+
+Everything below is a **one-time setup on your own machine**. After it, runs are
+fully headless.
+
+### 1. Install the pinned `agy` on your host
+
+```bash
+curl -fsSL https://antigravity.google/cli/install.sh | bash
+# installs to ~/.local/bin/agy
+~/.local/bin/agy --version   # expected: 1.1.25
+```
+
+### 2. Log in with your Google account
+
+Run `agy` in an interactive terminal on the host and follow the prompt:
+
+```bash
+~/.local/bin/agy
+```
+
+- It prints a **Google sign-in URL**.
+- Open it in a browser (on **any** machine — this also works on a headless
+  server: just copy the URL to your laptop's browser).
+- Approve with a **Google account that has Antigravity access**.
+- The `antigravity.google/oauth-callback` page shows an **authorization code** —
+  paste it back into the terminal.
+
+That writes your credential to:
+
+```text
+~/.gemini/antigravity-cli/antigravity-oauth-token
+```
+
+> Tip: use the plain `agy` command to log in (it waits for you). Avoid the
+> `agy -p "…"` one-shot form for login — it only gives a ~30-second window to
+> paste the code, too short for a browser round-trip.
+
+### 3. Verify the login works headlessly
+
+```bash
+~/.local/bin/agy -p "Reply with exactly: PONG"
+# → PONG     (no browser, reusing the saved token)
+```
+
+If you see `PONG`, the credential is good. It carries a refresh token, so it
+keeps working across runs without logging in again.
+
+### 4. Point ALE at the credential
+
+Add the path to `secret/.env` (or export it in your shell):
+
+```bash
+export ANTIGRAVITY_OAUTH_TOKEN_PATH=$HOME/.gemini/antigravity-cli/antigravity-oauth-token
+```
+
+ALE forwards that file into the sandbox each run and `agy` silent-auths there —
+you never log in inside the sandbox.
+
+### 5. Run it
+
+Pick a task list and reference the agent preset from an experiment:
+
+```bash
+echo "demo/seecheck" > selected_tasks/my_tasks.txt   # one task id per line
+```
+
+```yaml
+# my_exp.yaml
+secret_file: secret/.env
+agents:      [configs/agents/antigravity_cli.yaml]
+environment: configs/environments/docker.yaml      # or your GCE env
+tasks:       selected_tasks/my_tasks.txt
+```
+
+```bash
+uv run python -m ale_run run my_exp.yaml
+```
+
+---
+
+## Choosing a model
+
+`--model` takes the display names from `agy models` verbatim. Set it in the
+preset's `model:` field:
+
+```
+Gemini 3.1 Pro (High)        Gemini 3.7 Flash (High)
+Claude Sonnet 4.6 (Thinking) Claude Opus 4.6 (Thinking)
+GPT-OSS 120B (Medium)
+```
+
+Which models you can use — and how much — depends on your Google plan. **Quota
+is per account AND per model**, so if one model is throttled another may still
+work (e.g. Gemini exhausted but Claude Sonnet 4.6 fine).
+
+## Config
+
+```yaml
+# configs/agents/antigravity_cli.yaml
+harness: antigravity_cli
+model: Claude Sonnet 4.6 (Thinking)
+config:
+  dangerously_skip_permissions: true   # required headless
+  cli_version: "1.1.25"                # pinned official release
+  print_timeout: "120m"                 # ALE wall time remains authoritative
+  download_url: ""                      # optional custom archive/binary
+  download_sha512: ""                   # required with a custom URL
+```
+
+## How auth gets into the sandbox
+
+1. **Host (once):** you log in → `~/.gemini/antigravity-cli/antigravity-oauth-token`.
+2. **Per run:** ALE reads that file (via `ANTIGRAVITY_OAUTH_TOKEN_PATH`) and
+   forwards its content into the sandbox; the deployer writes it back into place
+   and `chmod 600`s it.
+3. **In sandbox:** `agy` finds the token and silent-auths — no browser, no
+   re-login. The token self-renews via its refresh token.
+
+Treat the token file as a secret — it's a long-lived credential for your Google
+account.
+
+## Troubleshooting
+
+- **Which account am I logged in as?** `cat ~/.gemini/google_accounts.json`
+  (the `active` field). There is no agy CLI quota command — the web
+  **Settings → Models** tab (signed in as that account) shows your plan + usage.
+- **Runs 429 with `Individual quota reached … please upgrade your
+  subscription`** → you're on a **free-tier** account (the "upgrade" wording is
+  the tell), or that model's quota is spent. Either switch `model:` to one with
+  quota left (e.g. `Claude Sonnet 4.6 (Thinking)`), or re-login with the right
+  account: delete `~/.gemini/antigravity-cli/antigravity-oauth-token` and redo
+  step 2.
+- **Windows GUI tasks**: the CUA tools load reliably (the deployer warms up the
+  node bridge + primes agy's first-run migration so they win agy's MCP
+  tool-discovery race). No action needed.
+
+## Notes
+
+- The CUA GUI tools are declared in `agy`'s **native** `~/.gemini/config/mcp_config.json`
+  (not gemini-cli's `settings.json`).
+- `agy --output-format stream-json` writes logical model-generation usage and
+  tool durations to `transcript.jsonl`. ALE converts it to ATIF and writes one
+  `metrics_summary.json` with an `api_calls` list of per-generation
+  tokens/latency, tool calls and latency, multimodal output groups, and physical
+  transport request count.
+- Each task passes `--log-file=<work_dir>/agy_cli.log`, so agy's complete native
+  log is pulled with that task even under high concurrency. Native `agy` does
+  not expose cache-write tokens, request cost, or per-transport-retry
+  tokens/latency; the summary marks these as unavailable instead of zero.
+- CLI policy lives in
+  `~/.gemini/antigravity-cli/settings.json`; the CUA MCP declaration lives in
+  the separate `~/.gemini/config/mcp_config.json`.
+
+## Smoke test
+
+Run the experiment from step 5 against **`demo/seecheck`** (a vision smoke test:
+read a code off the desktop) — the quickest end-to-end check that auth + the GUI
+bridge both work:
+
+```bash
+uv run python -m ale_run run my_exp.yaml
+```
+
+On Windows use `demo/seecheck_win` instead.

--- a/ale_run/agents/antigravity_cli/__init__.py
+++ b/ale_run/agents/antigravity_cli/__init__.py
@@ -1,0 +1,6 @@
+"""Antigravity CLI (``agy``) in-sandbox deployer."""
+
+from .config import AntigravityCliConfig
+from .deployer import AntigravityCliDeployer
+
+__all__ = ["AntigravityCliConfig", "AntigravityCliDeployer"]

--- a/ale_run/agents/antigravity_cli/config.py
+++ b/ale_run/agents/antigravity_cli/config.py
@@ -1,0 +1,50 @@
+"""Per-episode knobs for Google's Antigravity CLI (``agy``).
+
+The default ALE path reuses an OAuth credential the operator obtains once by
+logging in interactively on the host:
+
+    ~/.gemini/antigravity-cli/antigravity-oauth-token   (carries a refresh_token)
+
+That file's content is forwarded into the sandbox by the lifecycle env
+passthrough (``ANTIGRAVITY_OAUTH_TOKEN`` inline, or ``ANTIGRAVITY_OAUTH_TOKEN_PATH``
+pointing at the host file) and written back into place by the deployer, after
+which ``agy`` silent-auths headlessly. See the module docstring on the deployer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass
+class AntigravityCliConfig:
+    """Tunables for :class:`AntigravityCliDeployer`. Standalone (no shared base)."""
+
+    name: ClassVar[str] = "antigravity-cli"
+
+    # Model display name as printed by ``agy models`` (accepted verbatim).
+    # Empty => let agy use its configured default.
+    model: str = "Gemini 3.7 Flash (High)"
+
+    # Bypass all tool-permission prompts (required headless). Maps to
+    # ``--dangerously-skip-permissions``.
+    dangerously_skip_permissions: bool = True
+
+    # Pinned CLI version. The deployer enforces this exact version.
+    cli_version: str = "1.1.25"
+
+    # Override the install source. Empty => resolve the exact version from the
+    # official updater manifest. A direct binary/tarball URL may be supplied for
+    # reproducibility or pre-release validation.
+    download_url: str = ""
+    # Required SHA-512 hex digest when download_url is set. The official
+    # manifest supplies its own checksum when download_url is empty.
+    download_sha512: str = ""
+
+    # agy print-mode wait, passed as ``--print-timeout``. agy's OWN default is
+    # only 5m, which silently cuts off any longer task (e.g. a slow thinking
+    # model, or a multi-step task) before it finishes — the run then has no
+    # output. Set it well above any task's wall budget so the orchestration's
+    # ``wall_time_s`` is the real cap, not agy's internal timer.
+    print_timeout: str = "120m"

--- a/ale_run/agents/antigravity_cli/deployer.py
+++ b/ale_run/agents/antigravity_cli/deployer.py
@@ -1,0 +1,1006 @@
+"""AntigravityCliDeployer — drives the Google Antigravity CLI (``agy``).
+
+Shape: in-sandbox CLI (``executor=sandbox``), same as gemini_cli/claude_code.
+
+The default ALE integration forwards an OAuth credential file the operator
+produced by logging in once on the host:
+
+  1. host (one-time):   ``agy``  → browser login → writes
+     ``~/.gemini/antigravity-cli/antigravity-oauth-token`` (contains a refresh_token).
+  2. env passthrough:   the lifecycle materialises that file's content into
+     ``ANTIGRAVITY_OAUTH_TOKEN`` (or passes ``ANTIGRAVITY_OAUTH_TOKEN_PATH``).
+  3. install() here:    writes it back to the same path inside the sandbox and
+     ``chmod 600`` it, after which ``agy`` silent-auths headlessly.
+
+GUI comes from the cua MCP bridge declared in ``agy``'s native
+``~/.gemini/config/mcp_config.json`` (NOT the gemini-cli ``settings.json``).
+Modern ``agy`` releases expose an NDJSON event stream, which is captured as
+``transcript.jsonl``. ALE normalizes its per-generation usage and per-tool
+duration into a task-level metrics summary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+from typing import ClassVar
+
+from ale_run.base_interface import (
+    AgentRunResult,
+    BaseAgentDeployer,
+    ContentPart,
+    Observation,
+    StepMetrics,
+    ToolCall,
+    ToolResult,
+    TrajectoryBuilder,
+)
+
+from .config import AntigravityCliConfig
+from .metrics import build_metrics_summary
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_S = 2.0
+_TERM_GRACE_S = 2.0
+_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+_UPDATER_BASE_URL = "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app"
+_PINNED_RELEASES: dict[tuple[str, str], tuple[str, str]] = {
+    ("1.1.25", "linux_amd64"): (
+        (
+            "https://storage.googleapis.com/antigravity-public/antigravity-cli/"
+            "1.1.25-6680093607723008/linux-x64/cli_linux_x64.tar.gz"
+        ),
+        (
+            "c5af6d1cfc2faf3d183b3497c56cb4951067bb56e8a1d1e5a4f081875aac2b07"
+            "3bd97d0eb9458b772f2ddb934222372935f48ae2c7893d7013d975afd7516e6c"
+        ),
+    ),
+    ("1.1.25", "windows_amd64"): (
+        (
+            "https://storage.googleapis.com/antigravity-public/antigravity-cli/"
+            "1.1.25-6680093607723008/windows-x64/cli_windows_x64.exe"
+        ),
+        (
+            "55bfcfe11ac6196ac7c1ff440a9be96efd1bf8e2567b696d0dd92b64f53a37ae9"
+            "83fcca571ff93d7b81c347cd124ba64d0769d212295504a4acd43a65f8924f2"
+        ),
+    ),
+}
+
+# agy stores its OAuth credential here (shared ~/.gemini home, agy-specific dir).
+_TOKEN_RELPATH = (".gemini", "antigravity-cli", "antigravity-oauth-token")
+_ACCOUNTS_RELPATH = (".gemini", "google_accounts.json")
+_CREDENTIAL_TRANSPORT_VARS = (
+    "ANTIGRAVITY_OAUTH_TOKEN",
+    "ANTIGRAVITY_OAUTH_TOKEN_PATH",
+    "ANTIGRAVITY_GOOGLE_ACCOUNTS",
+)
+
+
+def _installed_version(agy_path: str) -> str | None:
+    try:
+        # stdin=DEVNULL: a bare `agy --version` can otherwise wait on a TTY /
+        # trip Defender on Windows.
+        probe = subprocess.run(
+            [agy_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    m = _VERSION_RE.search((probe.stdout or "") + (probe.stderr or ""))
+    return m.group(1) if m else None
+
+
+def _win_appdata_bin(home: str) -> str:
+    """``%LOCALAPPDATA%\\agy\\bin`` — where install.ps1 drops ``agy.exe``."""
+    local_appdata = os.environ.get("LOCALAPPDATA") or os.path.join(home, "AppData", "Local")
+    return os.path.join(local_appdata, "agy", "bin")
+
+
+def _find_agy(home: str, *, is_windows: bool) -> str | None:
+    """Resolve the agy binary, preferring the installer's drop location.
+
+    The sandbox entry runs without a login shell, so the install dir may not be
+    on PATH and ``shutil.which`` misses the installer-dropped binary. Linux:
+    ``~/.local/bin/agy``; Windows: ``%LOCALAPPDATA%\\agy\\bin\\agy.exe``."""
+    cand = _install_target(home, is_windows=is_windows)
+    if cand.is_file():
+        return str(cand)
+    return shutil.which("agy.exe" if is_windows else "agy") or shutil.which("agy")
+
+
+def _install_target(home: str, *, is_windows: bool) -> Path:
+    if is_windows:
+        return Path(_win_appdata_bin(home)) / "agy.exe"
+    return Path(home) / ".local" / "bin" / "agy"
+
+
+def _official_release(version: str, *, is_windows: bool) -> tuple[str, str]:
+    """Resolve an exact official release URL and checksum.
+
+    The updater endpoint only exposes the latest release. Keep metadata for the
+    pinned default locally so a later upstream release does not make an older,
+    reproducible ALE config impossible to install.
+    """
+    platform_name = "windows_amd64" if is_windows else "linux_amd64"
+    pinned = _PINNED_RELEASES.get((version, platform_name))
+    if pinned is not None:
+        return pinned
+    manifest_url = f"{_UPDATER_BASE_URL}/manifests/{platform_name}.json"
+    with urllib.request.urlopen(manifest_url, timeout=60) as response:
+        manifest = json.load(response)
+    actual = str(manifest.get("version", ""))
+    if actual != version:
+        raise RuntimeError(
+            "antigravity_cli: configured version "
+            f"{version} is not the current official manifest version {actual}; "
+            "set download_url to an archived release or update cli_version"
+        )
+    url = str(manifest.get("url", ""))
+    sha512 = str(manifest.get("sha512", ""))
+    if not url or not re.fullmatch(r"[0-9a-fA-F]{128}", sha512):
+        raise RuntimeError("antigravity_cli: updater manifest is missing url/sha512")
+    return url, sha512.lower()
+
+
+def _sha512(path: Path) -> str:
+    digest = hashlib.sha512()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _install_release(cfg: AntigravityCliConfig, home: str, *, is_windows: bool) -> None:
+    """Download and install the configured release, verifying official hashes."""
+    target = _install_target(home, is_windows=is_windows)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if cfg.download_url:
+        url = cfg.download_url
+        expected_sha512 = cfg.download_sha512.lower()
+        if not re.fullmatch(r"[0-9a-f]{128}", expected_sha512):
+            raise RuntimeError(
+                "antigravity_cli: download_sha512 must be a SHA-512 hex digest "
+                "when download_url is set"
+            )
+    else:
+        url, expected_sha512 = _official_release(cfg.cli_version, is_windows=is_windows)
+
+    with tempfile.TemporaryDirectory(prefix="ale-agy-install-") as tmp:
+        payload = Path(tmp) / ("agy.exe" if is_windows else "agy.tar.gz")
+        urllib.request.urlretrieve(url, payload)
+        if expected_sha512:
+            actual_sha512 = _sha512(payload)
+            if actual_sha512 != expected_sha512:
+                raise RuntimeError(
+                    "antigravity_cli: release checksum mismatch "
+                    f"({actual_sha512} != {expected_sha512})"
+                )
+
+        source = payload
+        if not is_windows:
+            with tarfile.open(payload, "r:gz") as archive:
+                member = next(
+                    (
+                        item
+                        for item in archive.getmembers()
+                        if item.isfile() and Path(item.name).name in {"antigravity", "agy"}
+                    ),
+                    None,
+                )
+                if member is None:
+                    raise RuntimeError("antigravity_cli: release archive has no CLI binary")
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    raise RuntimeError("antigravity_cli: could not extract CLI binary")
+                source = Path(tmp) / "agy"
+                source.write_bytes(extracted.read())
+
+        staged = target.with_suffix(target.suffix + ".new")
+        shutil.copyfile(source, staged)
+        staged.chmod(0o755)
+        os.replace(staged, target)
+
+
+def _spawn_agy(
+    argv: list[str],
+    *,
+    transcript_file: Path,
+    stderr_log: Path,
+    env: dict[str, str],
+    cwd: Path,
+) -> subprocess.Popen:
+    """Open launch files and spawn agy outside the asyncio event loop."""
+    with transcript_file.open("wb") as tout, stderr_log.open("wb") as terr:
+        return subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=tout,
+            stderr=terr,
+            env=env,
+            cwd=str(cwd),
+            start_new_session=bool(hasattr(os, "setsid")),
+        )
+
+
+class AntigravityCliDeployer(BaseAgentDeployer):
+    """Stdlib-only deployer for the Google ``agy`` CLI."""
+
+    default_executor: ClassVar[str] = "sandbox"
+    supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
+    hot_artifacts: ClassVar[tuple[str, ...]] = (
+        "transcript.jsonl",
+        "stderr.log",
+        "agy_cli.log",
+    )
+
+    @property
+    def version(self) -> str | None:
+        cfg: AntigravityCliConfig = self.config  # type: ignore[assignment]
+        return cfg.cli_version
+
+    # =========================================================================
+    # install
+    # =========================================================================
+
+    async def install(self) -> None:
+        cfg: AntigravityCliConfig = self.config  # type: ignore[assignment]
+        sandbox = self.executor.sandbox
+        self._is_windows = not sandbox.is_linux
+
+        home = os.path.expanduser("~")
+
+        # 1. Locate/install agy and enforce the exact configured version. The
+        # official bootstrapper installs "latest" and refuses to replace an
+        # existing binary, so use the signed updater manifest directly.
+        agy = _find_agy(home, is_windows=self._is_windows)
+        installed = await asyncio.to_thread(_installed_version, agy) if agy else None
+        stale = bool(agy and cfg.cli_version and installed and installed != cfg.cli_version)
+        if not agy or stale:
+            if stale:
+                logger.info(
+                    "antigravity_cli: %s != pinned %s — reinstalling", installed, cfg.cli_version
+                )
+            await self._install_agy(cfg, home)
+            agy = _find_agy(home, is_windows=self._is_windows)
+            if not agy:
+                raise RuntimeError("antigravity_cli: 'agy' not found after install")
+            installed = await asyncio.to_thread(_installed_version, agy)
+        if cfg.cli_version and installed != cfg.cli_version:
+            raise RuntimeError(
+                f"antigravity_cli: installed version {installed!r} does not match "
+                f"configured {cfg.cli_version!r}"
+            )
+        self._agy_path = agy
+        # Put the install dir on PATH so launch() and any self-update find it.
+        bin_dir = (
+            _win_appdata_bin(home) if self._is_windows else os.path.join(home, ".local", "bin")
+        )
+        if bin_dir not in os.environ.get("PATH", ""):
+            os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
+        logger.info("antigravity_cli: CLI ok — agy %s at %s", installed or "?", agy)
+
+        # 2. clean work dir
+        wd = Path(self.executor.work_dir)
+        wd.mkdir(parents=True, exist_ok=True)
+
+        # 3. inject the OAuth credential the operator produced on the host.
+        self._write_oauth_token()
+
+        # 4. cua GUI bridge + agy config. Idempotent bridge install.
+        from ale_run.agents._bootstrap import cua_bridge_env, ensure_cua_mcp_server
+
+        await ensure_cua_mcp_server(sandbox)
+
+        gemini_home = Path(home) / ".gemini"
+        gemini_home.mkdir(parents=True, exist_ok=True)
+        self._gemini_dir = str(gemini_home)
+        cua_server = {
+            "cua": {
+                "command": sandbox.node,
+                "args": [
+                    self._join(sandbox.mcp_server_dir, "src", "index.js", is_linux=sandbox.is_linux)
+                ],
+                "env": cua_bridge_env(self.executor),
+            },
+        }
+        # agy reads its MCP servers from ~/.gemini/config/mcp_config.json (its
+        # NATIVE config), NOT the gemini-cli settings.json — that is where the
+        # cua GUI tools (screenshot/click/type/…) must be declared to load.
+        config_dir = gemini_home / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "mcp_config.json").write_text(
+            json.dumps({"mcpServers": cua_server}, indent=2),
+            encoding="utf-8",
+        )
+        # agy >= 1.1 reads CLI policy from its own app-data directory. Keep the
+        # permission mode explicit even though launch also passes the one-run
+        # override; this prevents artifact/tool review prompts in headless mode.
+        settings = {
+            "toolPermission": (
+                "always-proceed" if cfg.dangerously_skip_permissions else "request-review"
+            ),
+            "artifactReviewPolicy": (
+                "always-proceed" if cfg.dangerously_skip_permissions else "asks-for-review"
+            ),
+        }
+        cli_app_dir = gemini_home / "antigravity-cli"
+        cli_app_dir.mkdir(parents=True, exist_ok=True)
+        (cli_app_dir / "settings.json").write_text(
+            json.dumps(settings, indent=2),
+            encoding="utf-8",
+        )
+        logger.info(
+            "antigravity_cli: config staged at %s (cua -> config/mcp_config.json)", gemini_home
+        )
+
+        # 5. Windows: pre-warm node + the cua bridge modules. A COLD node start
+        #    on Windows (Defender scan + ESM module load of the MCP SDK) is slow
+        #    enough to intermittently miss agy's MCP tool-discovery window at
+        #    launch, so the cua GUI tools register only ~1 run in 4. One warm-up
+        #    run loads the modules into the OS file cache and lets Defender scan
+        #    them once, so agy's spawn of the bridge at launch is fast and wins
+        #    the race. (Linux node start is fast; no warm-up needed there.)
+        if self._is_windows:
+            self._ensure_grep_windows()
+            await self._prewarm_bridge(sandbox)
+            await self._prewarm_agy()
+
+    def _ensure_grep_windows(self) -> None:
+        """Put ``grep`` on PATH for agy's ``grep_search`` tool.
+
+        agy shells out to ``grep``, which isn't on the Windows sandbox PATH by
+        default — so ``grep_search`` fails with ``exec: 'grep': ... not found``.
+        Git for Windows (baked into ale-win10) already ships a real GNU grep at
+        ``…\\Git\\usr\\bin\\grep.exe`` (with its DLLs co-located); it's just not
+        on PATH. Prepend that dir. As a fallback for an image WITHOUT Git, fetch
+        a single-file busybox-w32 and run it as ``grep.exe``. Best-effort: a
+        failure only loses ``grep_search``, not the run.
+        """
+        if shutil.which("grep"):
+            return
+        home = os.path.expanduser("~")
+        for d in (
+            r"C:\Program Files\Git\usr\bin",
+            r"C:\Program Files (x86)\Git\usr\bin",
+            os.path.join(home, "AppData", "Local", "Programs", "Git", "usr", "bin"),
+        ):
+            if os.path.isfile(os.path.join(d, "grep.exe")):
+                self._prepend_path(d)
+                logger.info("antigravity_cli: grep via Git for Windows (%s on PATH)", d)
+                return
+        # No Git grep — fetch busybox-w32 (single exe; run as grep.exe → grep applet).
+        bin_dir = _win_appdata_bin(home)
+        try:
+            import urllib.request
+
+            os.makedirs(bin_dir, exist_ok=True)
+            grep_exe = os.path.join(bin_dir, "grep.exe")
+            urllib.request.urlretrieve("https://frippery.org/files/busybox/busybox.exe", grep_exe)
+            self._prepend_path(bin_dir)
+            logger.info("antigravity_cli: installed busybox grep at %s", grep_exe)
+        except Exception as e:  # noqa: BLE001 — best-effort, non-fatal
+            logger.warning(
+                "antigravity_cli: could not provision grep (grep_search "
+                "will be unavailable on Windows): %s",
+                e,
+            )
+
+    @staticmethod
+    def _prepend_path(directory: str) -> None:
+        if directory not in os.environ.get("PATH", ""):
+            os.environ["PATH"] = directory + os.pathsep + os.environ.get("PATH", "")
+
+    async def _prewarm_agy(self) -> None:
+        """Run ``agy models`` once so the FIRST-run side effects (config
+        migration, the background auto-updater) are done before the real launch.
+        On a fresh Windows VM those first-run steps otherwise race with MCP tool
+        discovery, so the cua tools register only intermittently; priming makes
+        the real launch a reliable 'subsequent' run.
+
+        Uses ``models`` (a metadata call), NOT a ``-p`` generation turn, so it
+        consumes **no model quota** — a per-task generation warm-up would double
+        quota usage across a benchmark and exhaust the account.
+        """
+        # gemini_dir is a global flag. agy 1.1.25 rejects it when it appears
+        # after the subcommand (``agy models --gemini_dir=...``).
+        argv = [self._agy_path, f"--gemini_dir={self._gemini_dir}", "models"]
+        env = self._without_credential_transport(os.environ.copy())
+        try:
+            await asyncio.to_thread(
+                subprocess.run,
+                argv,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=60,
+                env=env,
+            )
+            logger.info(
+                "antigravity_cli: warmed up agy (first-run migration primed, no quota used)"
+            )
+        except subprocess.TimeoutExpired:
+            logger.info("antigravity_cli: agy warm-up timed out (continuing)")
+        except (OSError, subprocess.SubprocessError) as e:
+            logger.info("antigravity_cli: agy warm-up skipped: %s", e)
+
+    async def _prewarm_bridge(self, sandbox) -> None:
+        """Spawn the cua bridge once so node + its modules are warm/cached."""
+        from ale_run.agents._bootstrap import cua_bridge_env
+
+        index_js = self._join(sandbox.mcp_server_dir, "src", "index.js", is_linux=sandbox.is_linux)
+        env = self._without_credential_transport({**os.environ, **cua_bridge_env(self.executor)})
+        try:
+            # stdin=DEVNULL → the stdio MCP server gets EOF and idles/exits once
+            # its modules are loaded; the timeout caps the (slow, one-time) cold
+            # start. We only care that the modules end up cached, not the output.
+            await asyncio.to_thread(
+                subprocess.run,
+                [sandbox.node, index_js],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=45,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            pass
+        except (OSError, subprocess.SubprocessError) as e:
+            logger.info("antigravity_cli: bridge pre-warm skipped: %s", e)
+            return
+        logger.info("antigravity_cli: pre-warmed cua bridge (node modules cached)")
+
+    async def _install_agy(self, cfg: AntigravityCliConfig, home: str) -> None:
+        """Install the exact configured agy release on Linux or Windows."""
+        await asyncio.to_thread(_install_release, cfg, home, is_windows=self._is_windows)
+        logger.info("antigravity_cli: installed agy %s", cfg.cli_version)
+
+    def _write_oauth_token(self) -> None:
+        """Write agy's OAuth credential into place from env passthrough.
+
+        Resolution order (mirrors cursor_cli's auth.json handling):
+        1. ``ANTIGRAVITY_OAUTH_TOKEN``       — raw token-file JSON content.
+        2. ``ANTIGRAVITY_OAUTH_TOKEN_PATH``  — path to the token file.
+        Optional ``ANTIGRAVITY_GOOGLE_ACCOUNTS`` writes google_accounts.json.
+        Security: never log the content, only byte counts.
+        """
+        home = Path(os.path.expanduser("~"))
+        token_file = home.joinpath(*_TOKEN_RELPATH)
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+
+        content = os.environ.get("ANTIGRAVITY_OAUTH_TOKEN", "").strip()
+        if not content:
+            path = os.environ.get("ANTIGRAVITY_OAUTH_TOKEN_PATH", "").strip()
+            if path and Path(path).expanduser().is_file():
+                content = Path(path).expanduser().read_text(encoding="utf-8")
+        if not content:
+            raise RuntimeError(
+                "antigravity_cli: no OAuth credential. Log in once on the host "
+                "(`agy`) then set ANTIGRAVITY_OAUTH_TOKEN_PATH to "
+                "~/.gemini/antigravity-cli/antigravity-oauth-token (or "
+                "ANTIGRAVITY_OAUTH_TOKEN to its content)."
+            )
+        token_file.write_text(content, encoding="utf-8")
+        token_file.chmod(0o600)
+        logger.info("antigravity_cli: wrote OAuth token (%d B)", len(content))
+
+        accounts = os.environ.get("ANTIGRAVITY_GOOGLE_ACCOUNTS", "").strip()
+        if accounts:
+            af = home.joinpath(*_ACCOUNTS_RELPATH)
+            af.write_text(accounts, encoding="utf-8")
+            logger.info("antigravity_cli: wrote google_accounts.json (%d B)", len(accounts))
+
+    # =========================================================================
+    # launch
+    # =========================================================================
+
+    async def launch(self, prompt: str) -> AgentRunResult:
+        cfg: AntigravityCliConfig = self.config  # type: ignore[assignment]
+        wd = Path(self.executor.work_dir)
+        wd.mkdir(parents=True, exist_ok=True)
+
+        prompt_file = wd / "prompt.txt"
+        transcript_file = wd / "transcript.jsonl"
+        stderr_log = wd / "stderr.log"
+        agy_log = wd / "agy_cli.log"
+        pid_file = wd / "agy.pid"
+        for f in (transcript_file, stderr_log, agy_log, pid_file):
+            if f.exists():
+                try:
+                    f.unlink()
+                except OSError:
+                    pass
+        prompt_file.write_text(prompt, encoding="utf-8")
+
+        # agy's print flag consumes its argument; unlike Gemini CLI, a lone
+        # hyphen means the literal prompt "-" rather than "read stdin".
+        argv = [self._agy_path, f"--print={prompt}"]
+        # Pin the gemini dir to an ABSOLUTE path: agy resolves a relative
+        # ".gemini" against CWD on Windows and falls back to a default, which
+        # makes config discovery (incl. the cua MCP server) non-deterministic.
+        gemini_dir = getattr(self, "_gemini_dir", "")
+        if gemini_dir:
+            argv.append(f"--gemini_dir={gemini_dir}")
+        # Give every task its own native agy log. Copying agy's global cli.log
+        # symlink after exit races under concurrency and can capture a different
+        # task's log. Direct logging also lets the lifecycle incrementally pull
+        # this file while the task is still running.
+        argv.append(f"--log-file={agy_log}")
+        if cfg.model:
+            argv += ["--model", cfg.model]
+        argv += ["--output-format", "stream-json"]
+        # Raise agy's print-mode timeout well above the wall budget — its 5m
+        # default silently truncates longer tasks (no output written).
+        if getattr(cfg, "print_timeout", ""):
+            argv.append(f"--print-timeout={cfg.print_timeout}")
+        if cfg.dangerously_skip_permissions:
+            argv.append("--dangerously-skip-permissions")
+        # agy file tools reject paths outside the workspace; add the task data
+        # root (outside cwd) as an extra workspace dir.
+        task_data_root = getattr(self.executor.sandbox, "task_data_root", "")
+        if task_data_root:
+            argv += ["--add-dir", task_data_root]
+
+        env = os.environ.copy()
+        for k, v in (self.executor.env or {}).items():
+            env[k] = v
+        env["NO_COLOR"] = "1"
+        env["TERM"] = "dumb"
+        # The OAuth credential reaches agy via the file written in install(), NOT
+        # the env. Strip the transport vars so the long-lived refresh token never
+        # enters agy's process env (and thus any shell command the agent runs).
+        self._without_credential_transport(env)
+        logger.info(
+            "antigravity_cli: launching agy (model=%r, prompt_chars=%d, stream_json=true)",
+            cfg.model,
+            len(prompt),
+        )
+
+        t0 = time.monotonic()
+        proc = await asyncio.to_thread(
+            _spawn_agy,
+            argv,
+            transcript_file=transcript_file,
+            stderr_log=stderr_log,
+            env=env,
+            cwd=wd,
+        )
+        pid_file.write_text(str(proc.pid), encoding="ascii")
+        logger.info("antigravity_cli: spawned pid=%s", proc.pid)
+
+        try:
+            while proc.poll() is None:
+                await asyncio.sleep(_POLL_INTERVAL_S)
+        except asyncio.CancelledError:
+            self._terminate_proc_group(proc, force=False)
+            try:
+                await asyncio.wait_for(asyncio.to_thread(proc.wait), timeout=_TERM_GRACE_S)
+            except (TimeoutError, asyncio.CancelledError):
+                self._terminate_proc_group(proc, force=True)
+            raise
+
+        duration_s = time.monotonic() - t0
+        exit_code = proc.returncode
+        native_result = _read_result_envelope(transcript_file)
+        native_status = str((native_result or {}).get("status") or "").upper()
+        status = "completed" if exit_code == 0 and native_status == "SUCCESS" else "failed"
+        error: str | None = None
+        if status == "failed":
+            native_error = (native_result or {}).get("error")
+            if native_status and native_status != "SUCCESS" and native_error:
+                error = f"agy result status={native_status}: {_json_text(native_error)}"
+            elif exit_code == 0 and native_status != "SUCCESS":
+                error = "agy exited without a terminal SUCCESS result"
+            else:
+                error = self._diagnose_failure(stderr_log, transcript_file, exit_code)
+        return AgentRunResult(
+            status=status,
+            pid=proc.pid,
+            exit_code=exit_code,
+            transcript_path=str(transcript_file),
+            stderr_path=str(stderr_log),
+            duration_s=duration_s,
+            error=error,
+        )
+
+    @staticmethod
+    def _terminate_proc_group(proc: subprocess.Popen, *, force: bool) -> None:
+        """Terminate agy and its MCP/subagent child processes together."""
+        try:
+            if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+                os.killpg(
+                    os.getpgid(proc.pid),
+                    signal.SIGKILL if force else signal.SIGTERM,
+                )
+            elif force:
+                proc.kill()
+            else:
+                proc.terminate()
+        except (ProcessLookupError, OSError):
+            pass
+
+    @staticmethod
+    def _without_credential_transport(env: dict[str, str]) -> dict[str, str]:
+        """Remove host-to-sandbox credential carriers from a child env."""
+        for name in _CREDENTIAL_TRANSPORT_VARS:
+            env.pop(name, None)
+        return env
+
+    # =========================================================================
+    # internals
+    # =========================================================================
+
+    @staticmethod
+    def _join(*parts: str, is_linux: bool) -> str:
+        sep = "/" if is_linux else "\\"
+        head = parts[0].rstrip("/\\")
+        tail = sep.join(p.strip("/\\") for p in parts[1:])
+        return f"{head}{sep}{tail}" if tail else head
+
+    def _diagnose_failure(self, stderr_log: Path, transcript: Path, exit_code: int | None) -> str:
+        parts = [f"agent failed (rc={exit_code})"]
+        st = _read_text_tolerant(stderr_log)
+        tx = _read_text_tolerant(transcript)
+        if st.strip():
+            parts.append(f"stderr tail: ...{st[-800:]}")
+        if tx.strip():
+            parts.append(f"transcript tail: ...{tx[-800:]}")
+        return " | ".join(parts)
+
+    # =========================================================================
+    # parse_artifacts
+    # =========================================================================
+
+    @classmethod
+    def parse_artifacts(
+        cls,
+        *,
+        work_dir: Path,
+        config: AntigravityCliConfig,
+        run_result: AgentRunResult,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        """Convert agy's native event stream into an ATIF trajectory."""
+        transcript_file = work_dir / "transcript.jsonl"
+        if not transcript_file.exists():
+            builder.add_step(
+                source="system",
+                message=f"antigravity-cli: no transcript at {transcript_file}",
+                extra={"reason": "no_transcript"},
+            )
+            try:
+                metrics = build_metrics_summary(work_dir, model=config.model or None)
+            except (OSError, TypeError, ValueError) as exc:
+                logger.warning("antigravity_cli: could not build metrics summary: %s", exc)
+            else:
+                builder.trajectory.extra.setdefault("antigravity_cli", {}).update(
+                    {
+                        "exit_code": run_result.exit_code,
+                        "transcript_path": str(transcript_file),
+                        "agy_log_path": str(work_dir / "agy_cli.log"),
+                        "metrics_summary_path": str(work_dir / "metrics_summary.json"),
+                        "metrics_availability": metrics.get("availability"),
+                    }
+                )
+            return
+        raw = _strip_ansi(transcript_file.read_text(encoding="utf-8", errors="replace"))
+        native_events: list[dict] = []
+        for line in raw.splitlines():
+            try:
+                decoded = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(decoded, dict):
+                native_events.append(decoded)
+
+        envelope: dict | None = None
+        for event in native_events:
+            if event.get("event") == "result" and isinstance(event.get("result"), dict):
+                envelope = event["result"]
+        if (
+            envelope is None
+            and len(native_events) == 1
+            and (
+                "response" in native_events[0]
+                or "status" in native_events[0]
+                or "usage" in native_events[0]
+            )
+        ):
+            envelope = native_events[0]
+
+        metadata: dict = {
+            "exit_code": run_result.exit_code,
+            "transcript_path": str(transcript_file),
+        }
+        before_stream_steps = len(builder.trajectory.steps)
+        added_generation = cls._consume_stream_steps(native_events, builder)
+        stream_steps_added = len(builder.trajectory.steps) > before_stream_steps
+        if envelope is not None and (
+            "response" in envelope or "status" in envelope or "usage" in envelope
+        ):
+            usage = envelope.get("usage")
+            if not isinstance(usage, dict):
+                usage = {}
+            response = envelope.get("response")
+            if not added_generation and isinstance(response, str) and response.strip():
+                builder.add_step(
+                    source="agent",
+                    message=response,
+                    metrics=StepMetrics(
+                        input_tokens=_optional_int(usage.get("input_tokens")),
+                        output_tokens=_optional_int(usage.get("output_tokens")),
+                        cache_read_tokens=_optional_int(usage.get("cache_read_tokens")),
+                        duration_ms=_duration_ms(envelope.get("duration_seconds")),
+                    ),
+                    extra={"thinking_tokens": _optional_int(usage.get("thinking_tokens"))},
+                )
+            error = envelope.get("error")
+            if isinstance(error, str) and error.strip():
+                builder.add_step(
+                    source="system",
+                    message=error,
+                    extra={"reason": "agy_error", "status": envelope.get("status")},
+                )
+            builder.override_final_metrics(
+                total_input_tokens=_optional_int(usage.get("input_tokens")),
+                total_output_tokens=_optional_int(usage.get("output_tokens")),
+                total_cache_read_tokens=_optional_int(usage.get("cache_read_tokens")),
+            )
+            metadata.update(
+                {
+                    "conversation_id": envelope.get("conversation_id"),
+                    "status": envelope.get("status"),
+                    "num_turns": envelope.get("num_turns"),
+                    "usage": usage,
+                }
+            )
+        elif not native_events:
+            lines = [line.rstrip() for line in raw.splitlines() if line.strip()]
+            if lines:
+                builder.add_step(source="agent", message="\n".join(lines))
+        elif not stream_steps_added:
+            builder.add_step(
+                source="system",
+                message="antigravity-cli: native stream ended without result or usable steps",
+                extra={"reason": "incomplete_native_stream"},
+            )
+
+        try:
+            metrics = build_metrics_summary(work_dir, model=config.model or None)
+        except (OSError, TypeError, ValueError) as exc:
+            logger.warning("antigravity_cli: could not build metrics summary: %s", exc)
+        else:
+            metadata.update(
+                {
+                    "agy_log_path": str(work_dir / "agy_cli.log"),
+                    "metrics_summary_path": str(work_dir / "metrics_summary.json"),
+                    "metrics_availability": metrics.get("availability"),
+                }
+            )
+        builder.trajectory.extra.setdefault("antigravity_cli", {}).update(metadata)
+
+    @classmethod
+    def _consume_stream_steps(
+        cls,
+        native_events: list[dict],
+        builder: TrajectoryBuilder,
+    ) -> bool:
+        """Map agy's step stream to ordered ATIF generation/tool steps.
+
+        ``agy`` emits multiple ACTIVE ``text_delta`` records followed by a DONE
+        record for one agent response. Tool records similarly have ACTIVE and
+        terminal copies. Grouping by ``step_index`` preserves the complete text
+        while emitting every tool exactly once.
+        """
+        updates: dict[int, list[dict]] = {}
+        order: list[int] = []
+        for event in native_events:
+            if event.get("event") != "step_update":
+                continue
+            update = event.get("step_update")
+            if not isinstance(update, dict):
+                continue
+            step_index = _optional_int(update.get("step_index"))
+            if step_index is None:
+                continue
+            if step_index not in updates:
+                updates[step_index] = []
+                order.append(step_index)
+            updates[step_index].append(update)
+
+        added_generation = False
+        for step_index in order:
+            records = updates[step_index]
+            terminal = next(
+                (
+                    record
+                    for record in reversed(records)
+                    if record.get("state") in {"DONE", "ERROR"}
+                ),
+                None,
+            )
+            if terminal is None:
+                latest = records[-1]
+                if latest.get("step_type") == "tool":
+                    cls._consume_tool_step(latest, step_index, builder, include_result=False)
+                elif latest.get("step_type") == "agent_response":
+                    chunks = [
+                        record["text_delta"]
+                        for record in records
+                        if isinstance(record.get("text_delta"), str) and record["text_delta"]
+                    ]
+                    if chunks:
+                        builder.add_step(
+                            source="agent",
+                            message="".join(chunks),
+                            extra={
+                                "agy_step_index": step_index,
+                                "agy_step_type": "agent_response",
+                                "incomplete": True,
+                            },
+                        )
+                        added_generation = True
+                continue
+            step_type = str(terminal.get("step_type") or "")
+            if step_type == "agent_response":
+                chunks = [
+                    record["text_delta"]
+                    for record in records
+                    if isinstance(record.get("text_delta"), str) and record["text_delta"]
+                ]
+                step_usage = terminal.get("usage")
+                if not isinstance(step_usage, dict):
+                    step_usage = {}
+                builder.add_step(
+                    source="agent",
+                    message="".join(chunks) or None,
+                    metrics=StepMetrics(
+                        input_tokens=_optional_int(step_usage.get("input_tokens")),
+                        output_tokens=_optional_int(step_usage.get("output_tokens")),
+                        cache_read_tokens=_optional_int(step_usage.get("cache_read_tokens")),
+                        duration_ms=_duration_ms(terminal.get("duration_seconds")),
+                    ),
+                    extra={
+                        "thinking_tokens": _optional_int(step_usage.get("thinking_tokens")),
+                        "agy_step_index": step_index,
+                        "agy_step_type": step_type,
+                    },
+                )
+                added_generation = True
+            elif step_type == "tool":
+                cls._consume_tool_step(terminal, step_index, builder)
+            elif step_type not in {"", "user_input"}:
+                builder.add_step(
+                    source="system",
+                    message=None,
+                    extra={
+                        "agy_step_index": step_index,
+                        "agy_step_type": step_type,
+                        "state": terminal.get("state"),
+                    },
+                )
+        return added_generation
+
+    @staticmethod
+    def _consume_tool_step(
+        update: dict,
+        step_index: int,
+        builder: TrajectoryBuilder,
+        *,
+        include_result: bool = True,
+    ) -> None:
+        tool_info = update.get("tool_info")
+        if not isinstance(tool_info, dict):
+            tool_info = {}
+        tool_name = str(update.get("tool_name") or tool_info.get("name") or "unknown")
+        arguments = tool_info.get("parameters")
+        if not isinstance(arguments, dict):
+            arguments = {"value": arguments} if arguments is not None else {}
+        call_id = f"agy_step_{step_index}"
+        builder.add_step(
+            source="agent",
+            tool_calls=[ToolCall(id=call_id, name=tool_name, arguments=arguments)],
+            extra={
+                "agy_step_index": step_index,
+                "state": update.get("state"),
+                "duration_ms": _duration_ms(update.get("duration_seconds")),
+                "incomplete": not include_result,
+            },
+        )
+
+        if not include_result:
+            return
+
+        output = tool_info.get("output")
+        error = tool_info.get("error")
+        content: list[ContentPart] = []
+        if output is not None:
+            content.append(ContentPart(type="text", text=_json_text(output)))
+        if error is not None:
+            content.append(ContentPart(type="text", text=_json_text(error)))
+        builder.add_step(
+            source="environment",
+            observation=Observation(
+                results=[
+                    ToolResult(
+                        tool_call_id=call_id,
+                        content=content,
+                        is_error=update.get("state") == "ERROR" or error is not None,
+                    )
+                ],
+            ),
+            extra={
+                "agy_step_index": step_index,
+                "state": update.get("state"),
+                "duration_ms": _duration_ms(update.get("duration_seconds")),
+            },
+        )
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+
+def _strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    return None
+
+
+def _duration_ms(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return round(value * 1000)
+    return None
+
+
+def _read_text_tolerant(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (FileNotFoundError, OSError):
+        return ""
+
+
+def _json_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _read_result_envelope(path: Path) -> dict | None:
+    """Return the last native result record, tolerating partial JSONL tails."""
+    for line in reversed(_read_text_tolerant(path).splitlines()):
+        try:
+            record = json.loads(_strip_ansi(line))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        result = record.get("result")
+        if record.get("event") == "result" and isinstance(result, dict):
+            return result
+        if any(key in record for key in ("response", "status", "usage")):
+            return record
+    return None

--- a/ale_run/agents/antigravity_cli/metrics.py
+++ b/ale_run/agents/antigravity_cli/metrics.py
@@ -1,0 +1,397 @@
+"""Extract task-level metrics from Antigravity CLI's native event stream."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_TRANSPORT_RE = re.compile(
+    r"[IWEF](?P<month>\d{2})(?P<day>\d{2})\s+"
+    r"(?P<clock>\d{2}:\d{2}:\d{2}\.\d+)\s+.*?"
+    r"URL:\s+(?P<url>\S*streamGenerateContent\S*)\s+"
+    r"Trace:\s+(?P<trace>\S+)(?:\s+ResponseID:\s+(?P<response_id>\S+))?"
+)
+_MULTIMODAL_TOOL_NAMES = frozenset({"capture_browser_screenshot", "generate_image", "screenshot"})
+_IMAGE_PATH_RE = re.compile(
+    r"(?:file://)?(?P<path>/[^\s\]\)\"']+\.(?:gif|jpe?g|png|webp))",
+    re.IGNORECASE,
+)
+
+
+def build_metrics_summary(
+    work_dir: Path,
+    *,
+    model: str | None,
+) -> dict[str, Any]:
+    """Write one metrics summary derived from agy's native run artifacts."""
+    transcript_path = work_dir / "transcript.jsonl"
+    native_log_path = work_dir / "agy_cli.log"
+    native_events = list(_iter_jsonl(transcript_path))
+    summary = _summarize_native_events(native_events, model=model)
+    transport_attempts = _parse_transport_attempts(native_log_path)
+    summary["native_stream_present"] = transcript_path.exists()
+    summary["native_log_present"] = native_log_path.exists()
+    summary["native_log_bytes"] = native_log_path.stat().st_size if native_log_path.exists() else 0
+    summary["physical_request_count"] = len(transport_attempts)
+    summary["transport_attempts"] = transport_attempts
+    summary["availability"]["per_transport_attempt"]["observed"] = bool(transport_attempts)
+    summary["artifacts"] = {
+        "native_stream": transcript_path.name,
+        "native_log": native_log_path.name,
+    }
+    (work_dir / "metrics_summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def _summarize_native_events(
+    native_events: list[dict[str, Any]],
+    *,
+    model: str | None,
+) -> dict[str, Any]:
+    model_generations: list[dict[str, Any]] = []
+    tool_executions: list[dict[str, Any]] = []
+    multimodal_groups: list[dict[str, Any]] = []
+    multimodal_resources: set[str] = set()
+    result: dict[str, Any] = {}
+    observed_model: str | None = None
+    terminal_tool_steps: set[int] = set()
+
+    for native in native_events:
+        if native.get("event") == "init" and isinstance(native.get("init"), dict):
+            init_model = native["init"].get("model")
+            if isinstance(init_model, str) and init_model:
+                observed_model = init_model
+        if native.get("event") != "step_update" or not isinstance(native.get("step_update"), dict):
+            continue
+        update = native["step_update"]
+        step_index = _int_or_none(update.get("step_index"))
+        if (
+            update.get("step_type") == "tool"
+            and update.get("state") in {"DONE", "ERROR"}
+            and step_index is not None
+        ):
+            terminal_tool_steps.add(step_index)
+
+    effective_model = observed_model or model
+
+    for native in native_events:
+        event_name = native.get("event")
+        payload = native.get(event_name)
+        if not isinstance(payload, dict):
+            if not event_name and any(key in native for key in ("response", "status", "usage")):
+                result = native
+            continue
+        if event_name == "result":
+            result = payload
+            continue
+        if event_name != "step_update" or payload.get("state") not in {"DONE", "ERROR"}:
+            continue
+
+        step_index = _int_or_none(payload.get("step_index"))
+        usage = payload.get("usage")
+        if isinstance(usage, dict) and payload.get("state") == "DONE":
+            input_tokens = _int_or_none(usage.get("input_tokens"))
+            cache_read_tokens = _int_or_none(usage.get("cache_read_tokens"))
+            model_generations.append(
+                {
+                    "sequence": len(model_generations) + 1,
+                    "step_index": step_index,
+                    "step_type": payload.get("step_type"),
+                    "model": effective_model,
+                    "duration_ms": _duration_ms(payload.get("duration_seconds")),
+                    "input_tokens": input_tokens,
+                    "uncached_input_tokens": input_tokens,
+                    "cached_input_tokens": cache_read_tokens,
+                    "cache_read_tokens": cache_read_tokens,
+                    "cache_write_tokens": None,
+                    "output_tokens": _int_or_none(usage.get("output_tokens")),
+                    "thinking_tokens": _int_or_none(usage.get("thinking_tokens")),
+                    "total_tokens": _int_or_none(usage.get("total_tokens")),
+                    "request_id": None,
+                    "cost_usd": None,
+                }
+            )
+
+        if payload.get("step_type") != "tool":
+            continue
+        _append_tool_execution(
+            payload,
+            tool_executions=tool_executions,
+            multimodal_groups=multimodal_groups,
+            multimodal_resources=multimodal_resources,
+        )
+
+    incomplete_tools: dict[int, dict[str, Any]] = {}
+    for native in native_events:
+        if native.get("event") != "step_update" or not isinstance(native.get("step_update"), dict):
+            continue
+        payload = native["step_update"]
+        step_index = _int_or_none(payload.get("step_index"))
+        if (
+            payload.get("step_type") == "tool"
+            and payload.get("state") == "ACTIVE"
+            and step_index is not None
+            and step_index not in terminal_tool_steps
+        ):
+            incomplete_tools[step_index] = payload
+    for payload in incomplete_tools.values():
+        _append_tool_execution(
+            payload,
+            tool_executions=tool_executions,
+            multimodal_groups=multimodal_groups,
+            multimodal_resources=multimodal_resources,
+        )
+
+    result_usage = result.get("usage")
+    if not isinstance(result_usage, dict):
+        result_usage = {}
+    generation_totals = {
+        key: sum(generation[key] or 0 for generation in model_generations)
+        for key in (
+            "input_tokens",
+            "uncached_input_tokens",
+            "cache_read_tokens",
+            "output_tokens",
+            "thinking_tokens",
+            "total_tokens",
+        )
+    }
+    generation_totals["cached_input_tokens"] = generation_totals["cache_read_tokens"]
+    generation_totals["overall_input_tokens"] = (
+        generation_totals["uncached_input_tokens"] + generation_totals["cached_input_tokens"]
+    )
+    result_totals = _usage_totals(result_usage)
+    usage_reconciles = all(
+        expected is None or generation_totals[key] == expected
+        for key, expected in result_totals.items()
+    )
+
+    generations_observed = bool(model_generations)
+    step_stream_observed = any(native.get("event") == "step_update" for native in native_events)
+    availability = {
+        "model_generations_observed": generations_observed,
+        "request_granularity": "logical_model_generation",
+        "input_token_semantics": (
+            "input_tokens and uncached_input_tokens exclude cache reads; "
+            "overall_input_tokens = input_tokens + cache_read_tokens"
+        ),
+        "per_model_generation": {
+            "duration": generations_observed
+            and all(item["duration_ms"] is not None for item in model_generations),
+            "output_tokens": generations_observed
+            and all(item["output_tokens"] is not None for item in model_generations),
+            "cached_input_tokens": generations_observed
+            and all(item["cache_read_tokens"] is not None for item in model_generations),
+            "uncached_input_tokens": generations_observed
+            and all(item["uncached_input_tokens"] is not None for item in model_generations),
+            "cache_write_tokens": False,
+            "cost_usd": False,
+        },
+        "per_transport_attempt": {
+            "observed": False,
+            "duration": False,
+            "tokens": False,
+        },
+        "tool_calls": step_stream_observed,
+        "tool_latency": step_stream_observed
+        and all(tool["duration_ms"] is not None for tool in tool_executions),
+        "multimodal_output_groups": step_stream_observed,
+        "generation_usage_reconciles_with_result": usage_reconciles,
+        "limitations": [
+            "agy does not expose cache-write tokens or request cost",
+            "transport retries are visible in agy_cli.log, but their latency and tokens are not",
+            "logical model generations and physical transport requests are not one-to-one",
+        ],
+    }
+    return {
+        "schema_version": "ALE-agent-metrics-v1",
+        "source": "agy-stream-json",
+        # Match the Codex/Claude telemetry-summary surface. For agy these are
+        # logical model generations exposed by stream-json, not necessarily
+        # one-to-one with the physical HTTP attempts below.
+        "api_calls": model_generations,
+        "api_call_count": len(model_generations),
+        "logical_model_generation_count": len(model_generations),
+        "tool_executions": tool_executions,
+        "tool_call_count": len(tool_executions),
+        "tool_latency_ms": sum(tool["duration_ms"] or 0 for tool in tool_executions),
+        "multimodal_output_groups": multimodal_groups,
+        "multimodal_output_group_count": len(multimodal_groups),
+        "logical_usage_totals": generation_totals,
+        "result_usage": result_totals,
+        "run": {
+            "conversation_id": result.get("conversation_id"),
+            "status": result.get("status"),
+            "duration_ms": _duration_ms(result.get("duration_seconds")),
+            "num_turns": _int_or_none(result.get("num_turns")),
+            "model": effective_model,
+            "configured_model": model,
+        },
+        "availability": availability,
+    }
+
+
+def _append_tool_execution(
+    payload: dict[str, Any],
+    *,
+    tool_executions: list[dict[str, Any]],
+    multimodal_groups: list[dict[str, Any]],
+    multimodal_resources: set[str],
+) -> None:
+    tool_info = payload.get("tool_info")
+    if not isinstance(tool_info, dict):
+        tool_info = {}
+    tool_name = str(payload.get("tool_name") or tool_info.get("name") or "")
+    output = tool_info.get("output")
+    error = tool_info.get("error")
+    state = payload.get("state")
+    tool = {
+        "sequence": len(tool_executions) + 1,
+        "step_index": _int_or_none(payload.get("step_index")),
+        "tool_name": tool_name,
+        "duration_ms": _duration_ms(payload.get("duration_seconds")),
+        "state": state,
+        "success": state == "DONE" and error in (None, "") if state != "ACTIVE" else None,
+        "parameters": tool_info.get("parameters"),
+        "output": output,
+        "error": error,
+    }
+    tool_executions.append(tool)
+
+    detection = _multimodal_detection(tool_name, tool["parameters"], output)
+    if detection is not None and detection["resource"] not in multimodal_resources:
+        multimodal_resources.add(detection["resource"])
+        multimodal_groups.append(
+            {
+                "sequence": len(multimodal_groups) + 1,
+                "step_index": tool["step_index"],
+                "tool_sequence": tool["sequence"],
+                "tool_name": tool_name,
+                "detection": detection["detection"],
+                "resource": detection["resource"],
+            }
+        )
+
+
+def _usage_totals(usage: dict[str, Any]) -> dict[str, int | None]:
+    totals = {
+        "input_tokens": _int_or_none(usage.get("input_tokens")),
+        "cache_read_tokens": _int_or_none(usage.get("cache_read_tokens")),
+        "output_tokens": _int_or_none(usage.get("output_tokens")),
+        "thinking_tokens": _int_or_none(usage.get("thinking_tokens")),
+        "total_tokens": _int_or_none(usage.get("total_tokens")),
+    }
+    input_tokens = totals["input_tokens"]
+    cache_read_tokens = totals["cache_read_tokens"]
+    totals["uncached_input_tokens"] = input_tokens
+    totals["cached_input_tokens"] = cache_read_tokens
+    totals["overall_input_tokens"] = (
+        input_tokens + cache_read_tokens
+        if input_tokens is not None and cache_read_tokens is not None
+        else None
+    )
+    return totals
+
+
+def _parse_transport_attempts(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    year = datetime.fromtimestamp(path.stat().st_mtime, UTC).year
+    attempts: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = _TRANSPORT_RE.search(line)
+        if match is None:
+            continue
+        attempts.append(
+            {
+                "sequence": len(attempts) + 1,
+                "observed_at": (
+                    f"{year:04d}-{match.group('month')}-{match.group('day')}T{match.group('clock')}"
+                ),
+                "observed_at_timezone": None,
+                "endpoint": match.group("url"),
+                "trace_id": match.group("trace"),
+                "response_id": match.group("response_id"),
+                "duration_ms": None,
+                "tokens": None,
+            }
+        )
+    return attempts
+
+
+def _multimodal_detection(
+    tool_name: str,
+    parameters: Any,
+    output: Any,
+) -> dict[str, str] | None:
+    canonical_name = tool_name.rsplit("__", 1)[-1]
+    parameter_text = _json_or_value(parameters)
+    output_text = _json_or_value(output)
+    combined = "\n".join(value for value in (parameter_text, output_text) if isinstance(value, str))
+    image_path = _IMAGE_PATH_RE.search(combined)
+    if image_path is not None:
+        return {
+            "detection": "image_resource",
+            "resource": image_path.group("path"),
+        }
+    if canonical_name == "call_mcp_tool" and isinstance(parameters, dict):
+        nested_name = str(parameters.get("ToolName") or parameters.get("tool_name") or "")
+        if nested_name.rsplit("__", 1)[-1] in _MULTIMODAL_TOOL_NAMES:
+            return {
+                "detection": "nested_tool_name",
+                "resource": f"tool-step:{nested_name}",
+            }
+    if canonical_name in _MULTIMODAL_TOOL_NAMES:
+        return {
+            "detection": "tool_name",
+            "resource": f"tool-step:{canonical_name}",
+        }
+    lowered = combined.lower()
+    if "data:image/" in lowered or '"media_type":"image/' in lowered:
+        return {
+            "detection": "output_payload",
+            "resource": f"inline-image:{hashlib.sha256(combined.encode()).hexdigest()}",
+        }
+    return None
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    if not path.exists():
+        return
+    with path.open(encoding="utf-8", errors="replace") as file:
+        for line in file:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                yield record
+
+
+def _json_or_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _duration_ms(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return round(value * 1000)
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/ale_run/agents/antigravity_cli/pyproject.toml
+++ b/ale_run/agents/antigravity_cli/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "ale-antigravity-cli"
+version = "0.1.0"
+description = "Google Antigravity CLI (agy) in-sandbox deployer for ALE."
+requires-python = ">=3.12,<3.14"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = []
+sources = {}
+bypass-selection = true

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -33,6 +33,7 @@ _AGENT_FQNS: dict[str, str] = {
     "kimi_code": "ale_run.agents.kimi_code.deployer.KimiCodeDeployer",
     "ale_claw": "ale_run.agents.ale_claw.deployer.AleClawDeployer",
     "gemini_cli": "ale_run.agents.gemini_cli.deployer.GeminiCliDeployer",
+    "antigravity_cli": "ale_run.agents.antigravity_cli.deployer.AntigravityCliDeployer",
     "grok_build": "ale_run.agents.grok_build.deployer.GrokBuildDeployer",
     "grok_cli": "ale_run.agents.grok_cli.deployer.GrokCliDeployer",
     "cursor_cli": "ale_run.agents.cursor_cli.deployer.CursorCliDeployer",

--- a/ale_run/orchestration/lifecycle.py
+++ b/ale_run/orchestration/lifecycle.py
@@ -241,7 +241,7 @@ async def run_one_unit(
 
             builder = TrajectoryBuilder(
                 agent_name=getattr(config, "name", unit.agent_spec.class_),
-                agent_version=None,
+                agent_version=getattr(config, "cli_version", None),
                 model=config.model,
                 task_path=unit.task_path,
                 variant_index=unit.variant_index,
@@ -480,13 +480,7 @@ async def run_one_unit(
                         extra={"reason": "parse_error"},
                     )
 
-                traj_status = (
-                    "completed"
-                    if run_result.status == "completed"
-                    else "timeout"
-                    if run_result.status == "timeout"
-                    else "failed"
-                )
+                traj_status = _trajectory_status(run_result.status, eval_status)
                 trajectory = builder.finalize(reward=score, status=traj_status)
                 # Move inline base64 screenshots to <run_dir>/screenshots/NNNN.png
                 # and rewrite refs to relative-path form BEFORE serialising —
@@ -649,6 +643,21 @@ def _extract_score(eval_output: Any) -> float | None:
     return None
 
 
+def _trajectory_status(agent_status: str, eval_status: str) -> str:
+    """Return the whole-episode status recorded in trajectory final metrics."""
+    # Match the lifecycle promotion order below exactly so trajectory.json and
+    # run.json cannot disagree when both phases fail differently.
+    if agent_status == "timeout":
+        return "timeout"
+    if agent_status == "failed":
+        return "failed"
+    if eval_status == "timeout":
+        return "timeout"
+    if eval_status == "failed":
+        return "failed"
+    return "completed"
+
+
 def _build_env_spec(task_meta: dict[str, Any], *, unit: RunUnit | None = None) -> SandboxSpec:
     snapshot = task_meta.get("image_category") or task_meta.get("snapshot_name")
     if not snapshot:
@@ -755,6 +764,9 @@ def _collect_env_passthrough() -> dict[str, str]:
         "FACTORY_API_KEY",
         "CURSOR_AUTH_JSON_PATH",
         "CURSOR_AUTH_JSON",
+        "ANTIGRAVITY_OAUTH_TOKEN_PATH",
+        "ANTIGRAVITY_OAUTH_TOKEN",
+        "ANTIGRAVITY_GOOGLE_ACCOUNTS",
     )
     result = {k: os.environ[k] for k in keys if k in os.environ}
 
@@ -779,6 +791,42 @@ def _collect_env_passthrough() -> dict[str, str]:
                         "env_passthrough: failed to read CURSOR_AUTH_JSON_PATH=%s: %s",
                         auth_path_str, e,
                     )
+
+    # Antigravity CLI's ALE preset uses OAuth: forward its host credential
+    # file content (a refresh-token JSON) and the active-account marker so the
+    # in-sandbox deployer can write them back and silent-auth headlessly.
+    if "ANTIGRAVITY_OAUTH_TOKEN" not in result:
+        tok_path_str = os.environ.get("ANTIGRAVITY_OAUTH_TOKEN_PATH", "").strip()
+        if tok_path_str:
+            tok_path = _Path(tok_path_str).expanduser()
+            if tok_path.is_file():
+                try:
+                    content = tok_path.read_text(encoding="utf-8")
+                    if content.strip():
+                        result["ANTIGRAVITY_OAUTH_TOKEN"] = content
+                        logger.info(
+                            "env_passthrough: materialised ANTIGRAVITY_OAUTH_TOKEN "
+                            "from ANTIGRAVITY_OAUTH_TOKEN_PATH (%d B)", len(content),
+                        )
+                except OSError as e:
+                    logger.warning(
+                        "env_passthrough: failed to read ANTIGRAVITY_OAUTH_TOKEN_PATH=%s: %s",
+                        tok_path_str, e,
+                    )
+            # The active-account marker sits next to the token file (own
+            # try/except so its failure isn't mis-attributed to the token read).
+            if "ANTIGRAVITY_GOOGLE_ACCOUNTS" not in result and tok_path.is_file():
+                acc = tok_path.parent.parent / "google_accounts.json"
+                if acc.is_file():
+                    try:
+                        ac = acc.read_text(encoding="utf-8")
+                        if ac.strip():
+                            result["ANTIGRAVITY_GOOGLE_ACCOUNTS"] = ac
+                    except OSError as e:
+                        logger.warning(
+                            "env_passthrough: failed to read google_accounts.json "
+                            "next to %s: %s", tok_path_str, e,
+                        )
 
     return result
 
@@ -1017,7 +1065,7 @@ def _build_run_meta(
             "id": unit.agent_id,
             "class": unit.agent_spec.class_,
             "name": getattr(config, "name", unit.agent_spec.class_),
-            "version": None,
+            "version": getattr(config, "cli_version", None),
             "model": config.model,
             "executor": executor_type,
             "config_repr": cfg_repr,

--- a/configs/agents/antigravity_cli.yaml
+++ b/configs/agents/antigravity_cli.yaml
@@ -1,0 +1,36 @@
+# antigravity_cli — Google's Antigravity CLI (`agy`), run headless on the sandbox.
+#
+# Default auth is a reusable Google OAuth credential. Log in ONCE on the host:
+#
+#     ~/.local/bin/agy            # browser/paste-code login with a Google account
+#
+# That writes ~/.gemini/antigravity-cli/antigravity-oauth-token (a refresh-token
+# credential). Point the run at it via the host env (in secret/.env or shell):
+#
+#     export ANTIGRAVITY_OAUTH_TOKEN_PATH=$HOME/.gemini/antigravity-cli/antigravity-oauth-token
+#     # optional: export ANTIGRAVITY_GOOGLE_ACCOUNTS="$(cat $HOME/.gemini/google_accounts.json)"
+#
+# The lifecycle forwards that into the sandbox and the deployer writes it back
+# into place, after which agy silent-auths headlessly. agy >= 1.1.13 also has a
+# direct Gemini-API-key mode, but this preset intentionally validates the
+# account/OAuth route first. OpenRouter is not Gemini-wire-compatible and needs
+# a translation proxy rather than merely a different base URL.
+#
+# Reference from an experiment as:  agents: [ configs/agents/antigravity_cli.yaml ]
+
+harness: antigravity_cli
+# executor: sandbox          # only supported value (deployer default).
+
+# One of the display names printed by `agy models` (accepted verbatim by --model).
+model: Gemini 3.7 Flash (High)
+
+config:
+  # Bypass tool-permission prompts (required headless) -> --dangerously-skip-permissions.
+  dangerously_skip_permissions: true
+
+  # Exact CLI version. Empty download_url resolves this version through Google's
+  # updater manifest and verifies SHA-512; stale binaries are replaced.
+  cli_version: "1.1.25"
+  print_timeout: "120m"        # agy --print-timeout; its 5m default truncates long tasks
+  download_url: ""
+  download_sha512: ""          # required SHA-512 when overriding download_url

--- a/tests/ale_run/test_antigravity_cli.py
+++ b/tests/ale_run/test_antigravity_cli.py
@@ -1,0 +1,653 @@
+"""Focused regression tests for the Antigravity CLI integration."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ale_run.agents.antigravity_cli.config import AntigravityCliConfig
+from ale_run.agents.antigravity_cli.deployer import (
+    AntigravityCliDeployer,
+    _find_agy,
+    _install_release,
+    _official_release,
+)
+from ale_run.base_interface import AgentRunResult, TrajectoryBuilder
+from ale_run.orchestration.experiment_spec import AgentSpec, RunUnit
+from ale_run.orchestration.lifecycle import _build_run_meta, _trajectory_status
+
+
+def _result() -> AgentRunResult:
+    return AgentRunResult(
+        status="completed",
+        exit_code=0,
+        transcript_path="transcript.jsonl",
+        duration_s=1.25,
+    )
+
+
+def test_parse_json_envelope_records_response_and_usage(tmp_path: Path) -> None:
+    envelope = {
+        "conversation_id": "conv-123",
+        "status": "SUCCESS",
+        "response": "finished",
+        "error": "",
+        "duration_seconds": 1.25,
+        "num_turns": 3,
+        "usage": {
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "thinking_tokens": 7,
+            "cache_read_tokens": 80,
+            "total_tokens": 157,
+        },
+    }
+    (tmp_path / "transcript.jsonl").write_text(json.dumps(envelope), encoding="utf-8")
+    builder = TrajectoryBuilder(
+        agent_name="antigravity-cli", task_path="demo/seecheck", variant_index=0
+    )
+
+    AntigravityCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=AntigravityCliConfig(),
+        run_result=_result(),
+        builder=builder,
+    )
+
+    step = builder.trajectory.steps[0]
+    assert step.source == "agent"
+    assert step.message == "finished"
+    assert step.metrics is not None
+    assert step.metrics.input_tokens == 120
+    assert step.metrics.output_tokens == 30
+    assert step.metrics.cache_read_tokens == 80
+    assert step.metrics.duration_ms == 1250
+    assert step.extra["thinking_tokens"] == 7
+    extra = builder.trajectory.extra["antigravity_cli"]
+    assert extra["conversation_id"] == "conv-123"
+    assert extra["num_turns"] == 3
+
+    metrics = builder.finalize(reward=1.0, status="completed").final_metrics
+    assert metrics.total_input_tokens == 120
+    assert metrics.total_output_tokens == 30
+    assert metrics.total_cache_read_tokens == 80
+
+
+def test_parse_json_error_envelope_adds_system_step(tmp_path: Path) -> None:
+    envelope = {
+        "status": "ERROR",
+        "response": "",
+        "error": "authentication failed",
+        "usage": {},
+    }
+    (tmp_path / "transcript.jsonl").write_text(json.dumps(envelope), encoding="utf-8")
+    builder = TrajectoryBuilder(
+        agent_name="antigravity-cli", task_path="demo/seecheck", variant_index=0
+    )
+
+    AntigravityCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=AntigravityCliConfig(),
+        run_result=AgentRunResult(status="failed", exit_code=1),
+        builder=builder,
+    )
+
+    assert builder.trajectory.steps[0].source == "system"
+    assert builder.trajectory.steps[0].message == "authentication failed"
+
+
+def test_missing_transcript_still_builds_metrics_summary(tmp_path: Path) -> None:
+    builder = TrajectoryBuilder(
+        agent_name="antigravity-cli", task_path="demo/seecheck", variant_index=0
+    )
+
+    AntigravityCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=AntigravityCliConfig(),
+        run_result=AgentRunResult(status="failed", exit_code=1),
+        builder=builder,
+    )
+
+    summary = json.loads((tmp_path / "metrics_summary.json").read_text())
+    assert summary["native_stream_present"] is False
+    assert summary["native_log_present"] is False
+    assert summary["native_log_bytes"] == 0
+    assert summary["availability"]["model_generations_observed"] is False
+    assert summary["availability"]["per_transport_attempt"]["observed"] is False
+    assert summary["availability"]["tool_calls"] is False
+    assert summary["availability"]["tool_latency"] is False
+    assert summary["availability"]["multimodal_output_groups"] is False
+    assert not (tmp_path / "telemetry.jsonl").exists()
+    assert not (tmp_path / "otel_requests.jsonl").exists()
+
+
+def test_parse_plain_text_fallback(tmp_path: Path) -> None:
+    (tmp_path / "transcript.jsonl").write_text("first\n\nsecond\n", encoding="utf-8")
+    builder = TrajectoryBuilder(
+        agent_name="antigravity-cli", task_path="demo/seecheck", variant_index=0
+    )
+
+    AntigravityCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=AntigravityCliConfig(),
+        run_result=_result(),
+        builder=builder,
+    )
+
+    assert builder.trajectory.steps[0].message == "first\nsecond"
+
+
+def test_parse_stream_json_builds_metrics_summary(tmp_path: Path) -> None:
+    events = [
+        {
+            "event": "init",
+            "init": {"model": "Gemini 3.7 Flash (High)"},
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "conv-stream",
+                "step_index": 1,
+                "state": "DONE",
+                "step_type": "agent_response",
+                "duration_seconds": 2.5,
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "thinking_tokens": 8,
+                    "cache_read_tokens": 60,
+                    "total_tokens": 120,
+                },
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "conv-stream",
+                "step_index": 2,
+                "state": "DONE",
+                "step_type": "tool",
+                "tool_name": "call_mcp_tool__cua__screenshot",
+                "duration_seconds": 0.25,
+                "tool_info": {
+                    "name": "call_mcp_tool__cua__screenshot",
+                    "parameters": {},
+                    "output": "captured",
+                },
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "conv-stream",
+                "step_index": 3,
+                "state": "ACTIVE",
+                "step_type": "agent_response",
+                "text_delta": "all ",
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "conv-stream",
+                "step_index": 3,
+                "state": "DONE",
+                "step_type": "agent_response",
+                "text_delta": "finished",
+                "duration_seconds": 1.0,
+                "usage": {
+                    "input_tokens": 70,
+                    "output_tokens": 10,
+                    "thinking_tokens": 4,
+                    "cache_read_tokens": 50,
+                    "total_tokens": 80,
+                },
+            },
+        },
+        {
+            "event": "result",
+            "result": {
+                "conversation_id": "conv-stream",
+                "status": "SUCCESS",
+                "response": "finished",
+                "duration_seconds": 3.75,
+                "num_turns": 1,
+                "usage": {
+                    "input_tokens": 170,
+                    "output_tokens": 30,
+                    "thinking_tokens": 12,
+                    "cache_read_tokens": 110,
+                    "total_tokens": 200,
+                },
+            },
+        },
+    ]
+    (tmp_path / "transcript.jsonl").write_text(
+        "".join(json.dumps(event) + "\n" for event in events), encoding="utf-8"
+    )
+    (tmp_path / "agy_cli.log").write_text(
+        "ERROR: logging before google.Init: I0828 08:33:41.418031 462 "
+        "http_helpers.go:246] URL: https://example/v1internal:streamGenerateContent?alt=sse "
+        "Trace: 0x123 ResponseID: response-1\n",
+        encoding="utf-8",
+    )
+    builder = TrajectoryBuilder(
+        agent_name="antigravity-cli", task_path="demo/seecheck", variant_index=0
+    )
+
+    AntigravityCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=AntigravityCliConfig(),
+        run_result=_result(),
+        builder=builder,
+    )
+
+    summary = json.loads((tmp_path / "metrics_summary.json").read_text())
+    assert summary["native_log_present"] is True
+    assert summary["native_log_bytes"] > 0
+    assert summary["api_call_count"] == 2
+    assert summary["logical_model_generation_count"] == 2
+    assert summary["api_calls"][0]["uncached_input_tokens"] == 100
+    assert summary["api_calls"][0]["cached_input_tokens"] == 60
+    assert summary["api_calls"][1]["output_tokens"] == 10
+    assert summary["tool_call_count"] == 1
+    assert summary["tool_latency_ms"] == 250
+    assert summary["multimodal_output_group_count"] == 1
+    assert summary["transport_attempts"][0]["response_id"] == "response-1"
+    assert summary["availability"]["generation_usage_reconciles_with_result"] is True
+    assert summary["availability"]["per_model_generation"]["cache_write_tokens"] is False
+    assert summary["run"]["model"] == "Gemini 3.7 Flash (High)"
+    assert summary["run"]["configured_model"] == "Gemini 3.7 Flash (High)"
+    assert not (tmp_path / "telemetry.jsonl").exists()
+    assert not (tmp_path / "otel_requests.jsonl").exists()
+
+    metrics = builder.finalize(reward=1.0, status="completed").final_metrics
+    assert metrics.total_input_tokens == 170
+    assert metrics.total_output_tokens == 30
+    assert metrics.total_cache_read_tokens == 110
+
+    trajectory = builder.trajectory
+    assert [step.source for step in trajectory.steps] == [
+        "agent",
+        "agent",
+        "environment",
+        "agent",
+    ]
+    tool_step = trajectory.steps[1]
+    assert tool_step.tool_calls[0].id == "agy_step_2"
+    assert tool_step.tool_calls[0].name == "call_mcp_tool__cua__screenshot"
+    result_step = trajectory.steps[2]
+    assert result_step.observation is not None
+    assert result_step.observation.results[0].tool_call_id == "agy_step_2"
+    assert result_step.observation.results[0].content[0].text == "captured"
+    assert trajectory.steps[3].message == "all finished"
+
+
+def test_incomplete_tool_is_retained_without_fabricated_result(tmp_path: Path) -> None:
+    events = [
+        {
+            "event": "init",
+            "init": {"model": "Observed Model"},
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "step_index": 1,
+                "state": "DONE",
+                "step_type": "agent_response",
+                "usage": {"input_tokens": 4, "output_tokens": 2, "cache_read_tokens": 1},
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "step_index": 2,
+                "state": "ACTIVE",
+                "step_type": "tool",
+                "tool_name": "run_command",
+                "tool_info": {"parameters": {"CommandLine": "long-running-task"}},
+            },
+        },
+        {
+            "event": "result",
+            "result": {
+                "status": "ERROR",
+                "error": "stream interrupted",
+                "usage": {"input_tokens": 4, "output_tokens": 2, "cache_read_tokens": 1},
+            },
+        },
+    ]
+    (tmp_path / "transcript.jsonl").write_text(
+        "".join(json.dumps(event) + "\n" for event in events), encoding="utf-8"
+    )
+    builder = TrajectoryBuilder(
+        agent_name="antigravity-cli", task_path="demo/interrupted", variant_index=0
+    )
+
+    AntigravityCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=AntigravityCliConfig(model="Configured Model"),
+        run_result=AgentRunResult(status="failed", exit_code=1),
+        builder=builder,
+    )
+
+    calls = [call for step in builder.trajectory.steps for call in step.tool_calls]
+    results = [
+        result
+        for step in builder.trajectory.steps
+        if step.observation is not None
+        for result in step.observation.results
+    ]
+    assert len(calls) == 1
+    assert calls[0].name == "run_command"
+    assert results == []
+    tool_step = next(step for step in builder.trajectory.steps if step.tool_calls)
+    assert tool_step.extra["incomplete"] is True
+
+    summary = json.loads((tmp_path / "metrics_summary.json").read_text())
+    assert summary["run"]["model"] == "Observed Model"
+    assert summary["run"]["configured_model"] == "Configured Model"
+    assert summary["tool_call_count"] == 1
+    assert summary["tool_executions"][0]["state"] == "ACTIVE"
+    assert summary["tool_executions"][0]["success"] is None
+    assert summary["availability"]["tool_latency"] is False
+
+
+def test_find_agy_prefers_managed_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    managed = tmp_path / ".local" / "bin" / "agy"
+    managed.parent.mkdir(parents=True)
+    managed.write_text("managed", encoding="utf-8")
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/agy")
+
+    assert _find_agy(str(tmp_path), is_windows=False) == str(managed)
+
+
+def test_custom_download_requires_checksum(tmp_path: Path) -> None:
+    config = AntigravityCliConfig(download_url="https://example.invalid/agy.tar.gz")
+
+    with pytest.raises(RuntimeError, match="download_sha512"):
+        _install_release(config, str(tmp_path), is_windows=False)
+
+
+def test_pinned_release_does_not_depend_on_latest_manifest() -> None:
+    linux_url, linux_checksum = _official_release("1.1.25", is_windows=False)
+    windows_url, windows_checksum = _official_release("1.1.25", is_windows=True)
+
+    assert "/1.1.25-" in linux_url
+    assert linux_url.endswith("/cli_linux_x64.tar.gz")
+    assert len(linux_checksum) == 128
+    assert "/1.1.25-" in windows_url
+    assert windows_url.endswith("/cli_windows_x64.exe")
+    assert len(windows_checksum) == 128
+
+
+@pytest.mark.parametrize(
+    ("agent_status", "eval_status", "expected"),
+    [
+        ("completed", "success", "completed"),
+        ("completed", "failed", "failed"),
+        ("failed", "success", "failed"),
+        ("completed", "timeout", "timeout"),
+        ("timeout", "success", "timeout"),
+        ("timeout", "failed", "timeout"),
+        ("failed", "timeout", "failed"),
+    ],
+)
+def test_trajectory_status_covers_agent_and_evaluator(
+    agent_status: str,
+    eval_status: str,
+    expected: str,
+) -> None:
+    assert _trajectory_status(agent_status, eval_status) == expected
+
+
+def test_run_metadata_records_cli_version() -> None:
+    agent = AgentSpec(
+        id="antigravity-cli",
+        class_="antigravity_cli",
+        config={"model": "Gemini 3.7 Flash (High)", "cli_version": "1.1.25"},
+    )
+    unit = RunUnit(
+        agent_id=agent.id,
+        agent_spec=agent,
+        task_path="demo/seecheck",
+        variant_index=0,
+    )
+
+    metadata = _build_run_meta(
+        run_id="run-1",
+        unit=unit,
+        config=AntigravityCliConfig(),
+        executor_type="sandbox",
+        status="completed",
+        score=1.0,
+        phase=None,
+        error_obj=None,
+        error_str=None,
+        total_s=1.0,
+        trajectory=None,
+        category=None,
+    )
+
+    assert metadata["agent"]["version"] == "1.1.25"
+
+
+@pytest.mark.asyncio
+async def test_windows_prewarm_places_global_flag_before_subcommand(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = AntigravityCliConfig()
+    executor = SimpleNamespace(config=config)
+    deployer = AntigravityCliDeployer(executor)
+    deployer._agy_path = r"C:\agy\agy.exe"
+    deployer._gemini_dir = r"C:\Users\ale\.gemini"
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("ANTIGRAVITY_OAUTH_TOKEN", "secret-token-json")
+    monkeypatch.setenv("ANTIGRAVITY_OAUTH_TOKEN_PATH", "/host/secret/token")
+    monkeypatch.setenv("ANTIGRAVITY_GOOGLE_ACCOUNTS", "secret-account-json")
+
+    def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = argv
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    await deployer._prewarm_agy()
+
+    assert captured["argv"] == [
+        r"C:\agy\agy.exe",
+        r"--gemini_dir=C:\Users\ale\.gemini",
+        "models",
+    ]
+    child_env = captured["env"]
+    assert isinstance(child_env, dict)
+    assert "ANTIGRAVITY_OAUTH_TOKEN" not in child_env
+    assert "ANTIGRAVITY_OAUTH_TOKEN_PATH" not in child_env
+    assert "ANTIGRAVITY_GOOGLE_ACCOUNTS" not in child_env
+
+
+@pytest.mark.asyncio
+async def test_launch_passes_prompt_as_print_value(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = AntigravityCliConfig(model="")
+    sandbox = SimpleNamespace(task_data_root="", is_linux=True)
+    executor = SimpleNamespace(
+        work_dir=str(tmp_path),
+        env={
+            "ANTIGRAVITY_OAUTH_TOKEN": "secret-token-json",
+            "ANTIGRAVITY_OAUTH_TOKEN_PATH": "/host/secret/token",
+            "ANTIGRAVITY_GOOGLE_ACCOUNTS": "secret-account-json",
+        },
+        sandbox=sandbox,
+        config=config,
+    )
+    deployer = AntigravityCliDeployer(executor)
+    deployer._agy_path = "/fake/agy"
+    deployer._gemini_dir = "/fake/.gemini"
+    captured: dict[str, object] = {}
+
+    class FakeProcess:
+        pid = 123
+        returncode = 0
+
+        def poll(self) -> int:
+            return 0
+
+    def fake_spawn(argv: list[str], **kwargs: object) -> FakeProcess:
+        captured["argv"] = argv
+        captured.update(kwargs)
+        transcript = kwargs["transcript_file"]
+        assert isinstance(transcript, Path)
+        transcript.write_text(
+            json.dumps({"event": "result", "result": {"status": "SUCCESS"}}) + "\n",
+            encoding="utf-8",
+        )
+        return FakeProcess()
+
+    monkeypatch.setattr("ale_run.agents.antigravity_cli.deployer._spawn_agy", fake_spawn)
+    result = await deployer.launch("full task instruction")
+
+    argv = captured["argv"]
+    assert isinstance(argv, list)
+    assert argv[1] == "--print=full task instruction"
+    assert "-p" not in argv
+    assert f"--log-file={tmp_path / 'agy_cli.log'}" in argv
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+    child_env = captured["env"]
+    assert isinstance(child_env, dict)
+    assert "ANTIGRAVITY_OAUTH_TOKEN" not in child_env
+    assert "ANTIGRAVITY_OAUTH_TOKEN_PATH" not in child_env
+    assert "ANTIGRAVITY_GOOGLE_ACCOUNTS" not in child_env
+    assert result.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_launch_treats_native_error_as_failed_even_with_zero_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = AntigravityCliConfig(model="")
+    sandbox = SimpleNamespace(task_data_root="", is_linux=True)
+    executor = SimpleNamespace(work_dir=str(tmp_path), env={}, sandbox=sandbox, config=config)
+    deployer = AntigravityCliDeployer(executor)
+    deployer._agy_path = "/fake/agy"
+    deployer._gemini_dir = "/fake/.gemini"
+
+    class FakeProcess:
+        pid = 456
+        returncode = 0
+
+        def poll(self) -> int:
+            return 0
+
+    def fake_spawn(argv: list[str], **kwargs: object) -> FakeProcess:
+        transcript = kwargs["transcript_file"]
+        assert isinstance(transcript, Path)
+        transcript.write_text(
+            json.dumps(
+                {
+                    "event": "result",
+                    "result": {
+                        "status": "ERROR",
+                        "error": "Individual quota reached",
+                        "usage": {},
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return FakeProcess()
+
+    monkeypatch.setattr("ale_run.agents.antigravity_cli.deployer._spawn_agy", fake_spawn)
+    result = await deployer.launch("task")
+
+    assert result.status == "failed"
+    assert result.exit_code == 0
+    assert result.error == "agy result status=ERROR: Individual quota reached"
+
+
+@pytest.mark.asyncio
+async def test_launch_rejects_zero_exit_without_terminal_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = AntigravityCliConfig(model="")
+    sandbox = SimpleNamespace(task_data_root="", is_linux=True)
+    executor = SimpleNamespace(work_dir=str(tmp_path), env={}, sandbox=sandbox, config=config)
+    deployer = AntigravityCliDeployer(executor)
+    deployer._agy_path = "/fake/agy"
+    deployer._gemini_dir = "/fake/.gemini"
+
+    class FakeProcess:
+        pid = 789
+        returncode = 0
+
+        def poll(self) -> int:
+            return 0
+
+    def fake_spawn(argv: list[str], **kwargs: object) -> FakeProcess:
+        transcript = kwargs["transcript_file"]
+        assert isinstance(transcript, Path)
+        transcript.write_text(
+            json.dumps({"event": "init", "init": {"model": "Model"}}) + "\n",
+            encoding="utf-8",
+        )
+        return FakeProcess()
+
+    monkeypatch.setattr("ale_run.agents.antigravity_cli.deployer._spawn_agy", fake_spawn)
+    result = await deployer.launch("task")
+
+    assert result.status == "failed"
+    assert result.exit_code == 0
+    assert result.error == "agy exited without a terminal SUCCESS result"
+
+
+def test_partial_stream_without_result_retains_response_and_tool(tmp_path: Path) -> None:
+    events = [
+        {"event": "init", "init": {"model": "Observed Model"}},
+        {
+            "event": "step_update",
+            "step_update": {
+                "step_index": 1,
+                "state": "ACTIVE",
+                "step_type": "agent_response",
+                "text_delta": "partial response",
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "step_index": 2,
+                "state": "ACTIVE",
+                "step_type": "tool",
+                "tool_name": "run_command",
+                "tool_info": {"parameters": {"CommandLine": "long-running-task"}},
+            },
+        },
+    ]
+    (tmp_path / "transcript.jsonl").write_text(
+        "".join(json.dumps(event) + "\n" for event in events), encoding="utf-8"
+    )
+    builder = TrajectoryBuilder(
+        agent_name="antigravity-cli", task_path="demo/interrupted", variant_index=0
+    )
+
+    AntigravityCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=AntigravityCliConfig(),
+        run_result=AgentRunResult(status="timeout", exit_code=None),
+        builder=builder,
+    )
+
+    assert builder.trajectory.steps[0].message == "partial response"
+    assert builder.trajectory.steps[0].extra["incomplete"] is True
+    assert builder.trajectory.steps[1].tool_calls[0].name == "run_command"
+    assert builder.trajectory.steps[1].extra["incomplete"] is True
+    assert all(step.observation is None for step in builder.trajectory.steps)


### PR DESCRIPTION
## Summary

Adds Google Antigravity CLI (`agy`) as an ALE sandbox agent harness for terminal and GUI tasks. The integration uses reusable Google OAuth credentials, the CUA MCP bridge, structured native streaming output, and task-local native logs. `Gemini 3.7 Flash (High)` is the default model; any display name returned by `agy models` can be configured.

## Runtime design

- Runs through ALE's `sandbox` executor on QEMU or cloud VM providers.
- Pins the official `agy` 1.1.25 Linux and Windows releases and verifies their SHA-512 digests before installation. Archived release metadata is retained locally so the pin remains reproducible after Google's latest-only updater manifest advances.
- Enforces the configured CLI version and replaces missing or stale binaries.
- Writes the CUA MCP declaration to agy's native `~/.gemini/config/mcp_config.json` and enables non-interactive tool execution for headless evals.
- Launches one `agy --print` process per task with `--output-format stream-json`, an explicit model, an extended print timeout, the task-data root, and a task-specific `--log-file`.
- Terminates the complete agy/MCP process group when an ALE wall timeout or cancellation occurs.
- Includes Windows first-run/CUA warm-up and `grep_search` provisioning without consuming model quota.

## Authentication

The operator signs in once with the interactive CLI:

```bash
~/.local/bin/agy
```

Then exposes the generated credential file to ALE:

```bash
export ANTIGRAVITY_OAUTH_TOKEN_PATH=$HOME/.gemini/antigravity-cli/antigravity-oauth-token
```

For every task, ALE materializes the credential inside the sandbox at agy's expected path with mode `0600`. Credential transport variables are removed from agy, CUA bridge, and warm-up child-process environments after staging. The task itself therefore runs headlessly and cannot read the OAuth token through inherited environment variables.

## Trajectory and artifacts

Each task preserves:

- `transcript.jsonl`: agy's native `stream-json` events
- `agy_cli.log`: complete task-local native agy log
- `stderr.log`
- `prompt.txt`
- `metrics_summary.json`

The native stream is normalized into ALE's ATIF trajectory with complete agent text, model-step usage, tool calls, tool results, errors, and stable call/result IDs. Partial agent text and active tool calls are retained if a run is interrupted; an unfinished tool never receives a fabricated result.

`transcript.jsonl`, `stderr.log`, and `agy_cli.log` are hot artifacts and are incrementally pulled while the task runs. The explicit per-task log path avoids the global `cli.log` symlink race under concurrency.

## Metrics

`metrics_summary.json` follows the existing Codex/Claude telemetry-summary shape where agy's native fields permit it:

- `api_calls`: one entry per logical model generation, including model, latency, output tokens, uncached input tokens, cache-read/cached input tokens, thinking tokens, and total tokens
- `tool_executions`: tool name, parameters, output/error, state, success, and latency
- tool-call count and aggregate tool latency
- multimodal output groups
- result-level usage totals and reconciliation against per-generation totals
- physical `streamGenerateContent` request attempts parsed from `agy_cli.log`, including trace/response IDs when present
- explicit availability flags and input-token semantics

Logical generations are not assumed to be one-to-one with physical transport attempts. Native agy does not expose cache-write tokens, request cost, or per-transport-attempt tokens/latency; those fields are explicitly marked unavailable rather than inferred.

No synthetic OpenTelemetry exporter or telemetry log is added because agy's native stream and log already provide the available measurements.

## Outcome semantics

A task is considered successfully completed only when both conditions hold:

1. the agy process exits with code 0; and
2. the native result envelope reports `SUCCESS`.

Native `ERROR` envelopes and missing terminal results are failures even if the process exit code is 0. Evaluator failure/timeout is also reflected consistently in `run.json` and trajectory final metrics. Evaluator scores remain the single source of truth for `run.json`, `eval_result.json`, and trajectory reward.

## Validation

- Final QEMU `demo/seecheck` smoke with OAuth and agy 1.1.25: `completed`, evaluator `success`, score `1.0`.
- `run.json`, `eval_result.json`, and trajectory reward all agreed at `1.0`; run and trajectory both recorded CLI version `1.1.25`.
- 11 ATIF steps with 3 tool calls and 3 matching tool results.
- 4 logical API calls, 1 multimodal output group, and complete token reconciliation.
- Native stream and native log were pulled locally; stderr was empty.
- Exact OAuth token and API-key value scans found no credential leakage in run artifacts.
- Historical Antigravity runs were audited for score consistency across run, evaluator, and trajectory outputs.
- Focused regression suite: 36 passed.
- Antigravity Ruff, formatting, and diff checks pass.

## Documentation

- `ale_run/agents/antigravity_cli/README.md`: operator setup, OAuth login, model selection, configuration, troubleshooting, and smoke testing
- `ale_run/agents/antigravity_cli/AGENTS.md`: implementation, runtime/tool surface, platform behavior, metrics, and validation notes
