### PR TITLE
fix: Windows transcript/screenshot pull from cua-server (+ local-docker image fixes)

### DIFF
--- a/ale_run/base_interface/sandbox.py
+++ b/ale_run/base_interface/sandbox.py
@@ -258,27 +258,60 @@ def _strip_bom(raw: bytes) -> bytes:
     return raw[3:] if raw.startswith(b"\xef\xbb\xbf") else raw
 
 
+# SSE body read chunk. Large on purpose: ``requests.iter_lines`` defaults to a
+# 512-byte chunk and rebuilds a growing ``pending`` buffer on every chunk, which
+# is O(n^2) on the single multi-MB ``data:`` line cua-server returns for
+# read_bytes / download_range (a 5.6 MB reply measured ~19s via iter_lines vs
+# ~1s reading the body in MB chunks). We read big chunks into a bytearray
+# (amortized O(1) append) and scan for the first complete line ourselves.
+_SSE_READ_CHUNK = 1 << 20  # 1 MiB
+
+
 def _read_first_sse_event(
     resp: requests.Response, read_timeout: float = 30,
 ) -> dict[str, Any] | None:
-    """Stream until the first ``data:`` line, parse + return JSON.
+    """Read until the first SSE ``data:`` line, parse + return its JSON.
 
-    cua-server replies as SSE — first data event is the result; any
-    later events are progress/keepalives we don't consume here."""
-    # NOTE: requests doesn't support asyncio time loops — this function is
-    # meant to be called from inside a worker thread where the host's
-    # blocking read is fine. Inline timeout is enforced via the original
-    # requests.post(stream=True, timeout=...).
-    for line in resp.iter_lines(decode_unicode=False):
-        if not line:
+    cua-server replies as SSE — the first data event is the result; any later
+    events are progress/keepalives we don't consume here, so we stop and return
+    as soon as the first ``data:`` line is complete.
+
+    Reads via :meth:`requests.Response.iter_content` with a large chunk into a
+    ``bytearray`` (O(n)) rather than :meth:`iter_lines` (512-byte default chunk
+    → O(n^2) on a multi-MB single line; see ``_SSE_READ_CHUNK``). The socket
+    read timeout is enforced by the originating ``requests.post(timeout=...)``;
+    ``read_timeout`` is accepted for call-site symmetry."""
+    buf = bytearray()
+    line_start = 0   # index of the current (in-progress) line's first byte
+    scan_pos = 0     # index to resume the newline search from
+    for chunk in resp.iter_content(chunk_size=_SSE_READ_CHUNK):
+        if not chunk:
             continue
-        if line.startswith(b"data:"):
-            payload = _strip_bom(line[len(b"data:"):].strip())
-            try:
-                return json.loads(payload)
-            except json.JSONDecodeError as e:
-                logger.debug("SSE parse failed: %s -- raw=%s", e, payload[:200])
-                return None
+        buf.extend(chunk)
+        while True:
+            nl = buf.find(b"\n", scan_pos)
+            if nl == -1:
+                scan_pos = len(buf)
+                break
+            line = bytes(buf[line_start:nl]).rstrip(b"\r")
+            line_start = scan_pos = nl + 1
+            if line.startswith(b"data:"):
+                payload = _strip_bom(line[len(b"data:"):].strip())
+                try:
+                    return json.loads(payload)
+                except json.JSONDecodeError as e:
+                    logger.debug("SSE parse failed: %s -- raw=%s", e, payload[:200])
+                    return None
+    # Stream ended without a newline-terminated data line — accept a trailing
+    # unterminated ``data:`` line if present (server closed right after it).
+    tail = bytes(buf[line_start:]).rstrip(b"\r\n")
+    if tail.startswith(b"data:"):
+        payload = _strip_bom(tail[len(b"data:"):].strip())
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as e:
+            logger.debug("SSE parse failed (trailing): %s -- raw=%s", e, payload[:200])
+            return None
     return None
 
 
@@ -495,7 +528,13 @@ def _upload_local_file_sync(sandbox: SandboxHandle, local_path: str, remote_path
     _write_binary_sync(sandbox, remote_path, content)
 
 
-_DOWNLOAD_CHUNK_BYTES = 4 * 1024 * 1024
+# Per-RPC read_bytes chunk for whole-file downloads. Larger is faster here: with
+# the O(n) SSE reader (see _read_first_sse_event) throughput RISES with chunk
+# size (measured on a GCE win10 VM: 4MiB≈4.3, 8MiB≈6.9, 16MiB≈12 MB/s) because
+# the per-RPC overhead is amortized. 8 MiB halves the round-trips vs 4 MiB and
+# gives headroom for very large transcripts under the gather deadline, while
+# keeping the in-flight base64 payload (~11 MiB) modest.
+_DOWNLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 
 
 def _download_to_local_sync(
@@ -588,7 +627,15 @@ def _build_range_cmd_windows(remote_path: str, start: int, max_chunk_bytes: int)
         "\"SIZE=$len\";\"B64=$b64\""
         "}catch{\"SIZE=-2\";\"B64=\";\"ERR=$($_.Exception.Message)\"}"
     )
-    return f'powershell -NoProfile -Command "{ps}"'
+    # Pass via -EncodedCommand (base64 of UTF-16LE) rather than -Command "<ps>":
+    # the cua-server runs commands through cmd.exe, which mangles this script's
+    # many nested double-quotes — the quotes broke, PowerShell then tried to
+    # execute the bare "SIZE=-2" output token ("not recognized as a cmdlet"),
+    # so download_range ALWAYS failed on Windows (the incremental tail was dead;
+    # transcripts only ever arrived via the slower post-run gather). base64 is
+    # cmd-safe (only [A-Za-z0-9+/=]), so the script reaches PowerShell intact.
+    encoded = base64.b64encode(ps.encode("utf-16-le")).decode("ascii")
+    return f"powershell -NoProfile -EncodedCommand {encoded}"
 
 
 def _parse_range_stdout(stdout: str, *, expected_start: int) -> RangeResult:
@@ -609,6 +656,13 @@ def _parse_range_stdout(stdout: str, *, expected_start: int) -> RangeResult:
             err_text = line[4:].strip()
     if size is None:
         return RangeResult(success=False, error="missing SIZE line")
+    if size == -1:
+        # Remote file does not exist (yet). This is a valid, non-error outcome:
+        # the tail's _tick_one keys off ``new_size == -1`` to reset its offset
+        # and await creation. Collapsing it into success=False would make the
+        # reconcile (post-fix) report a spurious failure for a never-written
+        # transcript. Only the -2 (exception) sentinel is a real error.
+        return RangeResult(success=True, new_size=-1)
     if size < 0:
         return RangeResult(
             success=False, new_size=0,

--- a/ale_run/environments/images/ale_ubuntu22_docker/cleanup.sh
+++ b/ale_run/environments/images/ale_ubuntu22_docker/cleanup.sh
@@ -26,30 +26,51 @@ if ! command -v startxfce4 >/dev/null 2>&1; then
   || echo "WARN: XFCE install failed (desktop will fall back to bare Xvfb)"
 fi
 
-# --- Chrome in a container: GUI tasks (e.g. demo/hello) launch google-chrome,
-#     but the rootfs-export image breaks it two ways:
-#       1. Chrome's zygote sandbox needs user-namespace/CAP the container doesn't
-#          grant, so a bare `google-chrome` dies (zygote FATAL → defunct zombie,
-#          app never opens). It needs --no-sandbox (the container is the boundary).
-#       2. the export caught the dev VM's *running* Chrome, baking a stale
-#          ~/.config/google-chrome/SingletonLock -> <vm-host>-<pid>, which makes a
-#          fresh Chrome reject the default profile as "in use".
-#     Fix both at the image layer (so every Chrome task works, no task-data edits):
-#     drop the stale singleton locks, and shim google-chrome with the flags a
-#     container needs (--no-sandbox + skip the first-run wizard). /usr/local/bin
-#     precedes /usr/bin on PATH, so the shim wins. ---
-rm -f /home/user/.config/google-chrome/Singleton* 2>/dev/null || true
-if [ -e /usr/bin/google-chrome ]; then
-  cat > /usr/local/bin/google-chrome <<'CHROME_SHIM'
+# --- Chrome in a container: GUI tasks launch google-chrome, but the
+#     rootfs-export image breaks it. Chrome's zygote sandbox needs
+#     user-namespace/CAP the container doesn't grant, so a bare launch dies
+#     (zygote FATAL → defunct zombie, app never opens); it needs --no-sandbox
+#     (the container is the boundary). We also skip the first-run wizard and hide
+#     the "unsupported flag" infobar (--test-type).
+#     Wrap the REAL launcher (/opt/google/chrome/google-chrome) — not a PATH
+#     shim — so EVERY caller gets the flags: `google-chrome` by name, the
+#     absolute /usr/bin/google-chrome[-stable] symlinks, and the XFCE menu/dock
+#     .desktop (exo-open), which all resolve here. ---
+rm -f /usr/local/bin/google-chrome /usr/local/bin/google-chrome-stable 2>/dev/null || true  # old PATH shim
+if [ -e /opt/google/chrome/google-chrome ] && [ ! -e /opt/google/chrome/google-chrome.real ]; then
+  mv /opt/google/chrome/google-chrome /opt/google/chrome/google-chrome.real
+  cat > /opt/google/chrome/google-chrome <<'CHROME'
 #!/bin/bash
-# Container shim: a container can't run Chrome's sandbox, and we skip the
-# first-run wizard. --test-type hides the resulting "unsupported flag" infobar
-# (a docker-only artifact) so GUI tasks see the clean window the VM shows.
-exec /usr/bin/google-chrome --no-sandbox --no-first-run --no-default-browser-check --disable-gpu --test-type "$@"
-CHROME_SHIM
-  chmod +x /usr/local/bin/google-chrome
-  ln -sf /usr/local/bin/google-chrome /usr/local/bin/google-chrome-stable
+exec /opt/google/chrome/google-chrome.real --no-sandbox --no-first-run --no-default-browser-check --disable-gpu --test-type "$@"
+CHROME
+  chmod +x /opt/google/chrome/google-chrome
 fi
+
+# --- stale dev-VM runtime locks baked by the rootfs export (apps were running
+#     on the dev VM at export time): a Chrome SingletonLock and a LibreOffice
+#     .lock both point at the VM hostname, making a fresh launch think another
+#     instance owns the profile. Drop them. ---
+rm -f /home/user/.config/google-chrome/Singleton*  2>/dev/null || true
+rm -f /home/user/.config/libreoffice/*/.lock        2>/dev/null || true
+
+# --- file manager + default-application helpers: the bare XFCE install ships no
+#     file manager and no "preferred application" config, so the panel/menu
+#     category shortcuts (Web Browser / Terminal Emulator / File Manager) fail
+#     with "Failed to execute default …" / "Choose Preferred Application". Install
+#     Thunar and wire the exo-open defaults to the apps that ARE installed. ---
+if ! command -v thunar >/dev/null 2>&1; then
+  mkdir -p /var/cache/apt/archives/partial /var/lib/apt/lists/partial /var/log/apt
+  apt-get update -qq && apt-get install -y --no-install-recommends thunar \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    || echo "WARN: thunar install failed"
+fi
+install -d -o user -g user /home/user/.config/xfce4
+cat > /home/user/.config/xfce4/helpers.rc <<'HELPERS'
+TerminalEmulator=xfce4-terminal
+FileManager=thunar
+WebBrowser=google-chrome
+HELPERS
+chown user:user /home/user/.config/xfce4/helpers.rc
 
 # --- dirs excluded from the rootfs tar that the runtime needs back, with the
 #     sticky perms docker would otherwise recreate them as root:0755 ---

--- a/ale_run/environments/images/ale_ubuntu22_docker/cleanup.sh
+++ b/ale_run/environments/images/ale_ubuntu22_docker/cleanup.sh
@@ -111,6 +111,38 @@ rm -rf /home/user/.config/agenthle-artifacts /root/.config/agenthle-artifacts 2>
 rm -f  /home/user/.openhands/.env /home/user/.hermes/.env /home/user/.openclaw/.env 2>/dev/null || true
 rm -rf /home/user/ale-test /home/user/.ale-src 2>/dev/null || true
 
+# --- scrub dev-VM cruft: the image is a rootfs export of a shared dev VM, so it
+#     carries per-user config and other files that don't belong in the benchmark
+#     image. Remove them WITHOUT touching the prebaked agent harnesses (codex in
+#     /usr/local, openclaw, hermes/gemini/claude in ~/.local, .openclaw/.grok/
+#     .bun/.cargo/.rustup/.npm-global) or the /opt task software. ---
+#
+#   per-user config / state that shouldn't ship in a published image:
+rm -rf /home/user/.config/gcloud-agenthle-artifacts 2>/dev/null || true
+rm -f  /home/user/.netrc 2>/dev/null || true
+rm -f  /home/user/.hermes/auth.json 2>/dev/null || true
+rm -rf /home/user/.hermes/sessions 2>/dev/null || true
+rm -rf /home/user/.config/google-chrome/Default 2>/dev/null || true       # dev browser profile
+rm -f  /home/user/.config/google-chrome/Singleton* 2>/dev/null || true
+rm -f  /home/user/.bash_history /home/user/.python_history \
+       /home/user/.zsh_history /home/user/.node_repl_history /root/.bash_history 2>/dev/null || true
+rm -rf /root/.ssh 2>/dev/null || true
+#
+#   extra user accounts carried over from the shared dev VM (homes + accounts):
+for u in weichenzhang bytedance User; do userdel -r "$u" 2>/dev/null || rm -rf "/home/$u"; done
+rm -rf /home/{{your_email* 2>/dev/null || true   # a stray templated home dir
+for u in weichenzhang bytedance User; do
+  sed -i "\|^$u:|d" /etc/passwd /etc/shadow /etc/group /etc/gshadow 2>/dev/null || true
+done
+sed -i '/^{{your_email/d' /etc/passwd /etc/shadow /etc/group /etc/gshadow 2>/dev/null || true
+#
+#   benchmark-irrelevant dev cruft / build workspaces / caches / stray files:
+rm -rf /home/user/codex-build 2>/dev/null || true                  # codex BUILD dir (codex runs from /usr/local)
+rm -f  /home/user/reference.frc 2>/dev/null || true                # ~580MB stray simulation output
+rm -rf /home/user/.config/Code /home/user/.config/Sabaki 2>/dev/null || true   # dev editor / app state
+rm -rf /home/user/.agenthle_hidden_eval_assets 2>/dev/null || true # leftover per-task eval asset (no Linux task should rely on a baked home-dir copy)
+rm -rf /home/user/.cache /home/user/.npm /root/.cache 2>/dev/null || true       # package/build caches
+
 # --- sanity: paths the ale-ubuntu22-docker Image entry promises must exist ---
 echo "--- verify image-promised paths ---"
 fail=0
@@ -123,6 +155,16 @@ for p in /usr/local/bin/node \
 done
 command -v Xvfb >/dev/null && echo "OK   Xvfb" || { echo "MISS Xvfb"; fail=1; }
 command -v startxfce4 >/dev/null && echo "OK   startxfce4 (XFCE desktop)" || echo "WARN startxfce4 missing (bare Xvfb, no WM)"
+# the scrub must NOT have touched the prebaked agent harnesses
+for b in /usr/local/bin/codex /usr/local/bin/openclaw \
+         /home/user/.local/bin/claude /home/user/.local/bin/gemini /home/user/.local/bin/hermes; do
+  if [ -e "$b" ]; then echo "OK   agent: $b"; else echo "MISS agent: $b"; fail=1; fi
+done
+# the removed dev-VM files/accounts must be GONE
+for s in /home/user/.config/gcloud-agenthle-artifacts /home/user/.netrc \
+         /home/weichenzhang /home/bytedance /root/.ssh; do
+  [ -e "$s" ] && { echo "LEFTOVER (should be gone): $s"; fail=1; } || echo "OK   scrubbed: $s"
+done
 /opt/cua-server/.venv/bin/python -c "import computer_server" 2>/dev/null \
   && echo "OK   computer_server importable" \
   || echo "WARN computer_server import failed without X (expected; entrypoint starts Xvfb)"

--- a/ale_run/environments/images/ale_ubuntu22_docker/export_rootfs.sh
+++ b/ale_run/environments/images/ale_ubuntu22_docker/export_rootfs.sh
@@ -8,8 +8,8 @@
 #
 # Either way the SAME excludes apply, so the two paths produce identical images.
 # Drops everything a container shares with / gets from the host (kernel, init,
-# devices, logs, caches, snap/flatpak desktop bits, swap) + the task data and any
-# baked secrets (see excludes). A container only needs the userspace rootfs.
+# devices, logs, caches, snap/flatpak desktop bits, swap) + the task data and the
+# dev-VM-specific files (see excludes). A container only needs the userspace rootfs.
 #
 # tar's own exit code is recorded to /tmp/ale_export_tar.rc so the caller can
 # tell a benign "files changed while reading" (1) from a fatal error (2): in a
@@ -40,6 +40,20 @@ sudo find / -xdev \( -uid +65535 -o -gid +65535 \) -exec chown -h 0:0 {} + 2>/de
     --exclude=./home/user/.config/agenthle-artifacts \
     --exclude='./home/*/.env' --exclude='./home/*/*/.env' \
     --exclude=./root/.config/agenthle-artifacts \
+    \
+    --exclude=./home/weichenzhang --exclude=./home/bytedance \
+    --exclude=./home/User --exclude='./home/{{*' \
+    --exclude=./root/.ssh \
+    --exclude=./home/user/.config/gcloud-agenthle-artifacts \
+    --exclude=./home/user/.netrc \
+    --exclude=./home/user/.hermes/auth.json --exclude=./home/user/.hermes/sessions \
+    --exclude=./home/user/.config/google-chrome/Default \
+    --exclude='./home/*/.bash_history' --exclude='./home/*/.python_history' \
+    --exclude='./home/*/.zsh_history' --exclude=./root/.bash_history \
+    --exclude=./home/user/codex-build --exclude=./home/user/reference.frc \
+    --exclude=./home/user/.config/Code --exclude=./home/user/.config/Sabaki \
+    --exclude=./home/user/.agenthle_hidden_eval_assets \
+    --exclude=./home/user/.cache --exclude=./home/user/.npm --exclude=./root/.cache \
     -cf - -C / . 2>/tmp/ale_export_tar.err
   echo $? > /tmp/ale_export_tar.rc
 } | if [ "${ALE_EXPORT_RAW:-0}" = 1 ]; then cat; else zstd -T0 -3 -c; fi

--- a/ale_run/executors/sandbox.py
+++ b/ale_run/executors/sandbox.py
@@ -101,6 +101,11 @@ _TAIL_RECONCILE_RETRIES = 3
 _TAIL_RECONCILE_DELAY_S = 1.0
 _TAIL_CHUNK_BYTES = 16 * 1024 * 1024
 
+# _tick_one return sentinels (negative = not a real remote byte size).
+_TICK_FAILED = -2    # download_range failed (transport / remote command error)
+_TICK_NO_FILE = -1   # remote file does not exist (yet)
+_TAIL_LIVE_FAIL_WARN = 3  # consecutive live-tick failures before a WARNING log
+
 
 @dataclass
 class SandboxExecutor(BaseExecutor):
@@ -600,6 +605,7 @@ async def tail_hot_artifacts(
     next tick once the writer flushes a newline.
     """
     offsets: dict[str, int] = {src: _local_offset(dst) for src, dst in targets}
+    fails: dict[str, int] = {src: 0 for src, _ in targets}
     while not stop_event.is_set():
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=interval_s)
@@ -608,29 +614,55 @@ async def tail_hot_artifacts(
             pass
         for src, dst in targets:
             try:
-                await _tick_one(executor, src, dst, offsets)
+                rc = await _tick_one(executor, src, dst, offsets)
             except Exception as e:                                  # noqa: BLE001
-                logger.debug("tail tick failed for %s: %s", src, e)
+                rc = _TICK_FAILED
+                logger.debug("tail tick raised for %s: %s", src, e)
+            # Don't fail silently: a persistently failing pull means the host
+            # mirror is stalling (e.g. download_range broken / VM unreachable).
+            if rc == _TICK_FAILED:
+                fails[src] += 1
+                if fails[src] == _TAIL_LIVE_FAIL_WARN:
+                    logger.warning(
+                        "tail: %d consecutive failed pulls of %s — host mirror "
+                        "stalling (retrying; final reconcile will report)",
+                        fails[src], src,
+                    )
+            else:
+                fails[src] = 0
 
-    # Final reconcile
+    # Final reconcile: keep pulling each file until its size stops growing, so
+    # the host mirror is complete. A failed pull (_TICK_FAILED) must NOT be
+    # mistaken for "stable" — doing so silently dropped large transcripts
+    # (the failure sentinel repeated → looked like an unchanging size → break).
     deadline = time.monotonic() + _TAIL_RECONCILE_TIMEOUT_S
     last_err: str | None = None
     for src, dst in targets:
-        prev_size = -1
+        prev_size: int | None = None
+        target_err: str | None = None
         for _ in range(_TAIL_RECONCILE_RETRIES + 1):
             if time.monotonic() > deadline:
-                last_err = f"reconcile timeout after {_TAIL_RECONCILE_TIMEOUT_S}s"
+                target_err = (
+                    f"reconcile timeout after {_TAIL_RECONCILE_TIMEOUT_S}s for {src}"
+                )
                 break
             try:
                 size = await _tick_one(executor, src, dst, offsets)
             except Exception as e:                                  # noqa: BLE001
-                last_err = str(e)
+                target_err = f"tick raised for {src}: {e}"
                 await asyncio.sleep(_TAIL_RECONCILE_DELAY_S)
                 continue
+            if size == _TICK_FAILED:
+                target_err = f"download_range failed for {src}"
+                await asyncio.sleep(_TAIL_RECONCILE_DELAY_S)
+                continue
+            target_err = None  # a successful pull clears a prior transient error
             if size == prev_size:
-                break
+                break          # size stabilized → host mirror is complete
             prev_size = size
             await asyncio.sleep(_TAIL_RECONCILE_DELAY_S)
+        if target_err and last_err is None:
+            last_err = target_err
     return last_err
 
 
@@ -647,16 +679,16 @@ async def _tick_one(
         src=src, start=start, max_bytes=_TAIL_CHUNK_BYTES,
     )
     if not rr.success:
-        return -2
+        return _TICK_FAILED
     size = rr.new_size
-    if size == -1:
+    if size == _TICK_NO_FILE:
         offsets[src] = 0
         if dst.exists():
             try:
                 dst.unlink()
             except OSError:
                 pass
-        return -1
+        return _TICK_NO_FILE
     if size < start:
         # rotation/truncation
         offsets[src] = 0

--- a/tests/test_range_cmd.py
+++ b/tests/test_range_cmd.py
@@ -1,0 +1,64 @@
+"""Unit tests for the Windows download_range command + range stdout parsing.
+
+- _build_range_cmd_windows must use -EncodedCommand (cmd.exe mangled the old
+  -Command "<nested quotes>" form, so download_range always failed on Windows).
+- _parse_range_stdout must map SIZE=-1 (file absent) to a non-error result
+  (success=True, new_size=-1) so the tail can tell "no file yet" from a real
+  transport failure; SIZE=-2 (remote exception) stays an error.
+
+Run: ``python tests/test_range_cmd.py``.
+"""
+import base64
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ale_run.base_interface import sandbox as S
+
+
+def test_build_cmd_is_encodedcommand_and_quote_free():
+    cmd = S._build_range_cmd_windows("C:\\a b\\transcript.jsonl", 1234, 4 * 1024 * 1024)
+    assert cmd.startswith("powershell -NoProfile -EncodedCommand ")
+    assert '"' not in cmd and "'" not in cmd, "command line must be quote-free (cmd.exe-safe)"
+    b64 = cmd.split()[-1]
+    script = base64.b64decode(b64).decode("utf-16-le")
+    # the real logic survived the encoding
+    assert "ToBase64String" in script
+    assert "1234" in script  # the offset
+    assert "SIZE=" in script
+
+
+def test_parse_file_absent_is_not_an_error():
+    r = S._parse_range_stdout("SIZE=-1\r\nB64=\r\n", expected_start=0)
+    assert r.success is True and r.new_size == -1, (r.success, r.new_size)
+
+
+def test_parse_remote_exception_is_error():
+    r = S._parse_range_stdout("SIZE=-2\r\nB64=\r\nERR=boom\r\n", expected_start=0)
+    assert r.success is False and "boom" in (r.error or "")
+
+
+def test_parse_no_new_bytes():
+    r = S._parse_range_stdout("SIZE=500\nB64=\n", expected_start=500)
+    assert r.success is True and r.new_size == 500 and r.new_data == b""
+
+
+def test_parse_data_roundtrip():
+    payload = b'{"x":1}\n'
+    b64 = base64.b64encode(payload).decode()
+    r = S._parse_range_stdout(f"SIZE=8\nB64={b64}\n", expected_start=0)
+    assert r.success is True and r.new_size == 8 and r.new_data == payload
+
+
+def test_parse_empty_and_malformed():
+    assert S._parse_range_stdout("", expected_start=0).success is False
+    assert S._parse_range_stdout("B64=abc\n", expected_start=0).success is False  # missing SIZE
+    assert S._parse_range_stdout("SIZE=notanint\n", expected_start=0).success is False
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("test_range_cmd: ALL PASS")

--- a/tests/test_sse_read.py
+++ b/tests/test_sse_read.py
@@ -1,0 +1,69 @@
+"""Regression test for _read_first_sse_event.
+
+The cua-server returns read_bytes/download_range results as a single multi-MB
+SSE ``data:`` line. The old reader used ``requests.iter_lines`` (512-byte
+default chunk) which is O(n^2) on such a line — a 5.6 MB reply took ~19s on a
+live VM, blowing the gather budget and silently losing large transcripts +
+screenshots. The reader must be O(n). Run: ``python tests/test_sse_read.py``.
+"""
+import base64
+import json
+import os
+import sys
+import time
+
+# Import this worktree's ale_run (it's a PEP-420 namespace package merged with
+# the editable-installed main checkout; put the worktree root first so the local
+# copy under test wins regardless of cwd).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ale_run.base_interface import sandbox as S
+
+
+class _MockResp:
+    def __init__(self, body: bytes, net_chunk: int = 64 * 1024):
+        self._body = body
+        self._net = net_chunk
+
+    def iter_content(self, chunk_size=1):  # noqa: ARG002 — emulate network slicing
+        for i in range(0, len(self._body), self._net):
+            yield self._body[i : i + self._net]
+
+
+def _sse(d: dict) -> bytes:
+    return b"data: " + json.dumps(d).encode() + b"\n\n"
+
+
+def test_correctness_cases():
+    assert S._read_first_sse_event(_MockResp(_sse({"success": True, "x": 1}))) == {"success": True, "x": 1}
+    # leading comment + event lines before the data line
+    assert S._read_first_sse_event(_MockResp(b": ka\nevent: message\n" + _sse({"n": 2}))) == {"n": 2}
+    # CRLF endings
+    crlf = b"event: message\r\ndata: " + json.dumps({"ok": 3}).encode() + b"\r\n\r\n"
+    assert S._read_first_sse_event(_MockResp(crlf)) == {"ok": 3}
+    # trailing unterminated data line (server closed right after)
+    assert S._read_first_sse_event(_MockResp(b"data: " + json.dumps({"ok": 4}).encode())) == {"ok": 4}
+    # first event only
+    assert S._read_first_sse_event(_MockResp(_sse({"first": True}) + _sse({"second": True}))) == {"first": True}
+    # no data line / malformed json -> None
+    assert S._read_first_sse_event(_MockResp(b": ka\nevent: x\n\n")) is None
+    assert S._read_first_sse_event(_MockResp(b"data: {nope\n\n")) is None
+
+
+def test_large_payload_is_linear():
+    # 16 MiB content -> ~22 MiB base64 on one data line, delivered in 64 KiB slices
+    big = base64.b64encode(b"\0" * (16 * 1024 * 1024)).decode()
+    body = b"data: " + json.dumps({"success": True, "content_b64": big}).encode() + b"\n\n"
+    t = time.monotonic()
+    r = S._read_first_sse_event(_MockResp(body))
+    dt = time.monotonic() - t
+    assert r["success"] is True
+    assert len(r["content_b64"]) == len(big)
+    # O(n): a 22 MB single line must parse well under a second (was ~35s via iter_lines)
+    assert dt < 2.0, f"too slow: {dt:.2f}s (O(n^2) regression?)"
+
+
+if __name__ == "__main__":
+    test_correctness_cases()
+    test_large_payload_is_linear()
+    print("test_sse_read: ALL PASS")

--- a/tests/test_tail_reconcile.py
+++ b/tests/test_tail_reconcile.py
@@ -1,0 +1,91 @@
+"""Regression tests for tail_hot_artifacts reconcile robustness.
+
+Before the fix, a failed pull returned the sentinel ``-2`` and the reconcile's
+``if size == prev_size: break`` treated two repeated ``-2`` as a *stable size*
+→ it returned ``None`` (success) and NO ``incremental_pull_final_failed`` event
+was emitted, so a transcript that never reached the host was lost silently.
+The reconcile must now report an error when pulls keep failing.
+
+Run: ``python tests/test_tail_reconcile.py``.
+"""
+import asyncio
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ale_run.executors import sandbox as S
+from ale_run.base_interface.sandbox import RangeResult
+
+S._TAIL_RECONCILE_DELAY_S = 0.0  # speed up the bounded reconcile retries
+
+
+class _MockExec:
+    def __init__(self, *, content=b"", fail=False, missing=False):
+        self.content, self.fail, self.missing = content, fail, missing
+        self.calls = 0
+
+    async def download_range(self, *, src, start, max_bytes):
+        self.calls += 1
+        if self.fail:
+            return RangeResult(success=False, error="simulated transport error")
+        if self.missing:
+            return RangeResult(success=True, new_size=-1)
+        return RangeResult(success=True, new_size=len(self.content),
+                           new_data=self.content[start:start + max_bytes])
+
+
+def _run(content=b"", fail=False, missing=False):
+    ex = _MockExec(content=content, fail=fail, missing=missing)
+    d = tempfile.mkdtemp()
+    dst = os.path.join(d, "transcript.jsonl")
+    stop = asyncio.Event()
+    stop.set()  # skip the live loop; exercise the reconcile directly
+    err = asyncio.run(S.tail_hot_artifacts(
+        executor=ex, targets=[("C:\\x\\transcript.jsonl", __import__("pathlib").Path(dst))],
+        stop_event=stop,
+    ))
+    return err, dst, ex
+
+
+def test_persistent_failure_is_reported():
+    # THE BUG: repeated download_range failure must surface an error, not None.
+    err, _, ex = _run(fail=True)
+    assert err is not None, "persistent pull failure was silently swallowed (regression!)"
+    assert "failed" in err.lower()
+    assert ex.calls >= S._TAIL_RECONCILE_RETRIES + 1  # it actually retried, didn't break early
+
+
+def test_success_mirrors_and_no_error():
+    content = b'{"a":1}\n{"b":2}\n'
+    err, dst, _ = _run(content=content)
+    assert err is None, f"unexpected error: {err}"
+    with open(dst, "rb") as f:
+        got = f.read()
+    assert got == content, f"mirror mismatch: {got!r}"
+
+
+def test_missing_file_is_not_an_error():
+    # remote file genuinely absent (-1) is a stable, non-error outcome.
+    err, dst, _ = _run(missing=True)
+    assert err is None, f"absent file wrongly reported as error: {err}"
+    assert not os.path.exists(dst) or os.path.getsize(dst) == 0
+
+
+def test_jsonl_boundary_safe():
+    # a half-written trailing record (no newline) must NOT be committed.
+    content = b'{"done":1}\n{"partial":'
+    err, dst, _ = _run(content=content)
+    assert err is None
+    with open(dst, "rb") as f:
+        got = f.read()
+    assert got == b'{"done":1}\n', f"committed a partial line: {got!r}"
+
+
+if __name__ == "__main__":
+    test_persistent_failure_is_reported()
+    test_success_mirrors_and_no_error()
+    test_missing_file_is_not_an_error()
+    test_jsonl_boundary_safe()
+    print("test_tail_reconcile: ALL PASS")


### PR DESCRIPTION
Batch of fixes. The main one unblocks the host-side pull of sandbox files (claude-code transcript, screenshots, token usage) from the cua-server on Windows; the other two are follow-up fixes to the `ale_ubuntu22_docker` image (relocated here off local `main`, which was carrying them unpushed).

## `fix(sandbox)`: Windows transcript/screenshot pull (the main fix)
Large Windows transcripts were silently lost on the heaviest GUI tasks. Root causes, found by measuring against a live GCE win10 VM:

1. **O(n²) SSE read.** `_read_first_sse_event` used `requests.iter_lines()` (512-byte default chunk) — O(n²) on the single multi-MB `data:` line cua-server returns for `read_bytes`/`download_range`. A 5.6 MB reply took ~19s; the post-run gather then blew its 120s/file + 300s deadlines and dropped the transcript. Replaced with an O(n) `iter_content(1 MiB)` + bytearray scan (5.6 MB: ~1s; 22 MB mock: 0.089s, ~387×). A 40 MB `download_to_local` went from 196s-and-fail → ~9.5s on the live VM.
2. **`download_range` broken on Windows.** `_build_range_cmd_windows` passed a nested-double-quoted PowerShell script via `-Command`; the cua-server runs commands through `cmd.exe`, which mangled the quotes → the command always failed (the incremental tail was dead). Now passed via `-EncodedCommand` (base64/UTF-16LE), which is cmd-safe. `_parse_range_stdout` now maps `SIZE=-1` (file absent) to a non-error result so the tail distinguishes "no file yet" from a real failure.
3. **Silent reconcile failure.** `tail_hot_artifacts`' reconcile treated the failure sentinel (`-2`) as a stable size and returned success with no `incremental_pull_final_failed` event — so a lost transcript was invisible. It now reports the failure; the live loop warns after consecutive failures.
4. **Chunk size.** `_DOWNLOAD_CHUNK_BYTES` 4 MiB → 8 MiB: with the O(n) reader, `read_bytes` throughput rises with chunk size (measured 4→8→16 MiB: 4.3/6.9/12 MB/s), so a larger chunk halves round-trips and adds deadline headroom.

Tests (host-side, mock cua-server; also verified end-to-end against a live GCE win10 cua-server):
- `tests/test_sse_read.py` — SSE reader correctness + O(n) on a 22 MB line
- `tests/test_range_cmd.py` — `-EncodedCommand` build + range stdout parsing
- `tests/test_tail_reconcile.py` — failure is reported, not silently "stable"

## `fix(local-docker)`: image fixes
- **XFCE desktop usable** — Chrome/Thunar/terminal launch from the menu/dock; drop a stale LibreOffice lock.
- **Scrub dev-VM cruft** — the image is a rootfs export of a shared dev VM; strip per-user config/state, extra accounts, and build cruft from both the rootfs export and the cleanup pass, without touching the prebaked agent harnesses or `/opt` task software. Adds a sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)