### PR TITLE
fix: keep reference archive password out of agent-shipped source

### DIFF
--- a/ale_run/environments/task_data/baked_in_sandbox.py
+++ b/ale_run/environments/task_data/baked_in_sandbox.py
@@ -17,15 +17,16 @@ into ``<base>/reference/``. A legacy layout that wraps everything in a
 single top-level ``reference/`` dir is also tolerated — stage_reference
 detects and flattens it, so graders always find ``<base>/reference/<file>``.
 
-The password is a project-wide constant (this is throwaway benchmark
-infrastructure — the encryption stops the agent from reading the
-answer, not external attackers). Both linux and windows images have
-``7z`` 26.01 on PATH (installer adds it to system PATH).
+The project-wide password is read from the host environment only when
+evaluation begins. It is intentionally not embedded in the source tree
+that the executor ships into the sandbox. Both linux and windows images
+have ``7z`` 26.01 on PATH (installer adds it to system PATH).
 """
 from __future__ import annotations
 
 import base64
 import logging
+import os
 from typing import Any
 
 from ...base_interface import SandboxHandle, TaskDataSpec
@@ -34,10 +35,7 @@ from . import join, shell_q, task_subdir
 logger = logging.getLogger(__name__)
 
 
-# Project-wide reference-archive password. Plain string — not a secret
-# in the security sense (anyone with image access could read it anyway),
-# but stops the agent from passively reading the answer.
-_REFERENCE_PASSWORD = "rdi-ucberkeley-Gov8EV7wGHYAc7XQBzhd"
+REFERENCE_ARCHIVE_PASSWORD_ENV = "ALE_REFERENCE_ARCHIVE_PASSWORD"
 
 
 async def _repoint_evaluator_venv_home(
@@ -157,18 +155,25 @@ async def stage_reference(
     if not await sandbox.exists(archive):
         return {"skipped": True, "reason": "no_reference_7z"}
 
+    password = os.environ.get(REFERENCE_ARCHIVE_PASSWORD_ENV)
+    if not password:
+        raise ValueError(
+            f"{REFERENCE_ARCHIVE_PASSWORD_ENV} is required to decrypt "
+            "baked task reference data. Copy secret/.env.example to "
+            "secret/.env before running the experiment."
+        )
+
     await sandbox.rm([target, tmp])
     await sandbox.mkdir(tmp)
 
-    pwd = _REFERENCE_PASSWORD
     a, t = shell_q(sandbox, archive), shell_q(sandbox, tmp)
     if sandbox.is_linux:
-        cmd = f"7z x -p{shell_q(sandbox, pwd)} {a} -o{t} -y"
+        cmd = f"7z x -p{shell_q(sandbox, password)} {a} -o{t} -y"
     else:
         # PowerShell with single-quoted strings (no interpolation).
         cmd = (
             'powershell -NoProfile -Command "'
-            f"7z x -p'{pwd}' {a} -o{t} -y"
+            f"7z x -p'{password}' {a} -o{t} -y"
             '"'
         )
     r = await sandbox.run_command(cmd, timeout=300)

--- a/ale_run/orchestration/lifecycle.py
+++ b/ale_run/orchestration/lifecycle.py
@@ -727,7 +727,9 @@ def _build_executor(
 def _collect_env_passthrough() -> dict[str, str]:
     """Env vars to propagate into the substrate so deployers see API keys.
 
-    Keep this list small — only well-known LLM keys we know deployers need.
+    Keep this list small — only well-known agent credentials deployers need.
+    Host-only orchestration values such as ``ALE_REFERENCE_ARCHIVE_PASSWORD``
+    must not be added here because this mapping is sent into the sandbox.
 
     Special handling for ``CURSOR_AUTH_JSON_PATH``: if it points to an
     existing file on the host, the file's content is also passed as

--- a/docs/ale-docs-site/pages/configure.html
+++ b/docs/ale-docs-site/pages/configure.html
@@ -132,12 +132,23 @@ config:
       referenced as <code>${env:NAME}</code> by the selected environment:
     </p>
     <pre><code>OPENROUTER_API_KEY=...
+ALE_REFERENCE_ARCHIVE_PASSWORD=rdi-ucberkeley-Gov8EV7wGHYAc7XQBzhd
 GCP_PROJECT=...
 GCP_SA_KEY=secret/gcp_key.json</code></pre>
     <p>
-      GCP variables are required only by the Google Cloud profile. Local
-      profiles still need whichever API key their agent preset uses. Judge-based
-      tasks can also require evaluator keys under
+      <code>ALE_REFERENCE_ARCHIVE_PASSWORD</code> is required when the selected
+      environment uses <code>task_data_source: baked_in_sandbox</code>. It is a
+      public benchmark-wide archive key, not a private credential. ALE reads it
+      on the host after agent execution and intentionally does not forward it
+      into the agent sandbox environment or embed it in runtime source copied
+      there.
+    </p>
+    <p>
+      Start by copying <code>secret/.env.example</code> to
+      <code>secret/.env</code>, then fill in the API and provider credentials
+      needed by your run. GCP variables are required only by the Google Cloud
+      profile. Local profiles still need whichever API key their agent preset
+      uses. Judge-based tasks can also require evaluator keys under
       <code>secret/eval_time/</code>.
     </p>
 

--- a/secret/.env.example
+++ b/secret/.env.example
@@ -20,6 +20,11 @@ OPENAI_API_KEY=
 # Optional — only needed if you re-enable ale_claw's `web_search` tool.
 BRAVE_API_KEY=
 
+# ---- Baked task data -------------------------------------------------------
+# Public project-wide key used by the host after agent execution.
+# It is intentionally not forwarded into the agent sandbox environment.
+ALE_REFERENCE_ARCHIVE_PASSWORD=rdi-ucberkeley-Gov8EV7wGHYAc7XQBzhd
+
 # ---- GCP (only needed if provider.kind=gcloud) -----------------------------
 # Reference these from your yaml with `${env:GCP_PROJECT}` etc.
 GCP_PROJECT=

--- a/tests/ale_run/test_baked_in_sandbox.py
+++ b/tests/ale_run/test_baked_in_sandbox.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ale_run.base_interface import TaskDataSpec
+from ale_run.environments.task_data import baked_in_sandbox
+from ale_run.orchestration.lifecycle import (
+    _collect_env_passthrough,
+    stage_reference as lifecycle_stage_reference,
+)
+
+
+class _Sandbox:
+    is_linux = True
+    task_data_root = "/data"
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+        self.removed: list[list[str]] = []
+
+    async def exists(self, path: str) -> bool:
+        return path.endswith("/reference.7z")
+
+    async def rm(self, paths: list[str]) -> None:
+        self.removed.append(paths)
+
+    async def mkdir(self, path: str) -> None:
+        _ = path
+
+    async def run_command(
+        self,
+        command: str,
+        *,
+        timeout: float = 60,
+    ) -> SimpleNamespace:
+        _ = timeout
+        self.commands.append(command)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    async def list_dir(self, path: str) -> list[dict[str, str]]:
+        _ = path
+        return [{"relpath": "result.txt"}]
+
+
+def _task_data() -> TaskDataSpec:
+    return TaskDataSpec(
+        requires_task_data=True,
+        domain_name="demo",
+        task_name="hello",
+        variant_name="base",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stage_reference_reads_password_from_host_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox = _Sandbox()
+    monkeypatch.setenv(
+        baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
+        "host-only-password",
+    )
+
+    report = await baked_in_sandbox.stage_reference(
+        sandbox,
+        _task_data(),
+        source="baked_in_sandbox",
+    )
+
+    assert report["staged"] == ["reference"]
+    assert "host-only-password" in sandbox.commands[0]
+
+
+@pytest.mark.asyncio
+async def test_stage_reference_requires_host_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox = _Sandbox()
+    monkeypatch.delenv(
+        baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
+        raising=False,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
+    ):
+        await baked_in_sandbox.stage_reference(
+            sandbox,
+            _task_data(),
+            source="baked_in_sandbox",
+        )
+
+    assert sandbox.commands == []
+    assert sandbox.removed == []
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_does_not_suppress_missing_host_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox = _Sandbox()
+    monkeypatch.delenv(
+        baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
+        raising=False,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
+    ):
+        await lifecycle_stage_reference(
+            env=SimpleNamespace(sandbox=sandbox),
+            provider=None,
+            artifacts=None,
+            task_meta={"task_data": _task_data()},
+            run_id="run",
+            task_id="demo/hello",
+            writer=SimpleNamespace(),
+        )
+
+
+def test_reference_password_is_not_forwarded_to_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "agent-key")
+    monkeypatch.setenv(
+        baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
+        "host-only-password",
+    )
+
+    env = _collect_env_passthrough()
+
+    assert env["OPENAI_API_KEY"] == "agent-key"
+    assert baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV not in env
+
+
+def test_reference_password_is_not_embedded_in_shipped_python() -> None:
+    repo_root = Path(__file__).parents[2]
+    env_example = (repo_root / "secret" / ".env.example").read_text(
+        encoding="utf-8",
+    )
+    prefix = f"{baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV}="
+    password = next(
+        line.removeprefix(prefix) for line in env_example.splitlines() if line.startswith(prefix)
+    )
+
+    leaked_paths = [
+        path.relative_to(repo_root)
+        for path in (repo_root / "ale_run").rglob("*.py")
+        if password in path.read_text(encoding="utf-8")
+    ]
+
+    assert password
+    assert leaked_paths == []


### PR DESCRIPTION
## Context

`SandboxExecutor` copies the runtime `ale_run/**/*.py` source tree into each guest at `/home/user/.ale-src` before starting the agent. The baked task-data backend previously stored the project-wide `reference.7z` password as a Python constant in that shipped source tree.

As a result, an agent could discover the password locally without doing any external research, then decrypt evaluator reference data before evaluation. The password is not treated as a private credential: it is a public benchmark-wide value and agents are still allowed to find it online. The bug is that the benchmark harness itself exposed it directly inside the sandbox.

## Changes

- Remove the password literal from all Python source shipped into the guest.
- Define `ALE_REFERENCE_ARCHIVE_PASSWORD` in `secret/.env.example`, which users copy to the host-side `secret/.env`.
- Read the password from the host environment only when `stage_reference` begins after agent execution.
- Keep the variable out of `_collect_env_passthrough()`, so it is not written into the agent's transient `_secrets.json` environment.
- Fail explicitly when a reference archive exists but the host password is missing. This configuration error is intentionally not swallowed by the existing optional-reference `RuntimeError` handling.
- Check configuration before deleting any existing reference extraction state.
- Document the required variable and its host-only boundary in the website's **Configure credentials** section.

The password necessarily enters the guest in the post-agent `7z` extraction command because evaluation occurs inside the guest. This change prevents passive discovery from the shipped source and agent environment; it does not attempt to prevent online lookup or defend against an agent process that persists beyond its managed lifecycle.

## Validation

### Automated regression coverage

- `5 passed`: `tests/ale_run/test_baked_in_sandbox.py`
  - host environment lookup
  - missing-password hard failure
  - lifecycle propagation of configuration errors
  - exclusion from agent environment passthrough
  - absence of the password from shipped Python source
- `30 passed`: `tests/ale_run/test_qemu_provider.py`
- Ruff checks pass for the changed Python files.
- `docs/ale-docs-site/pages/configure.html` parses successfully with Python's `html.parser`.

### Real QEMU end-to-end smoke

Ran the published Ubuntu and Windows demo tasks as two independent retained QEMU guests through the full agent lifecycle:

| Task | Guest | Result | Output collection | Reference staging |
| --- | --- | --- | --- | --- |
| `demo/hello` | Ubuntu | `completed`, score `1.0` | QEMU shared-folder pull, 1 file / 19 bytes | `reference_stage_completed` |
| `demo/hello_win` | Windows | `completed`, score `1.0` | QEMU shared-folder pull, 1 file / 19 bytes | `reference_stage_completed` |

Both evaluators successfully decrypted the baked `reference.7z` after the agent finished and accepted the produced output.

Post-run inspection through each guest's CUA API confirmed:

- no password literal in `/home/user/.ale-src` or `C:\Users\User\.ale-src`;
- no password literal in either agent work directory;
- no password literal in the demo task-data trees after reference extraction;
- `ALE_REFERENCE_ARCHIVE_PASSWORD` absent from the guest environment;
- no remaining `_secrets.json` sidecars;
- no password literal in gathered host run artifacts.

## Non-goals

- No changes to Codex process-completion or timeout behavior.
- No password rotation or attempt to make the public archive password confidential.
- No changes to task reference archive layout or evaluation timing.
