### PR TITLE
feat(aliyun): Alibaba Cloud ECS + OSS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Where the framework supports running sandboxes today, and what is coming next:
 | **QEMU/KVM VMs (CPU-only)** ([guide](https://agents-last-exam.org/docs?p=pages/local.html)) | ✅ Supported |
 | **AWS (EC2 + S3)** ([guide](https://agents-last-exam.org/docs?p=pages/aws.html)) | ✅ Supported |
 | **Custom image build & licensed tasks** ([guide](https://agents-last-exam.org/docs?p=pages/build-image.html)) | ✅ Supported |
-| **Alibaba Cloud (Ali-Yun)** | 🚧 In progress |
+| **Alibaba Cloud (Ali-Yun)** ([guide](https://agents-last-exam.org/docs?p=pages/aliyun.html)) | ✅ Supported |
 | **Local VMware** | 📋 Planned |
 
 Have a question or run into an issue? [**Join our Discord**](https://discord.gg/jsG4Th3aVt) for direct questions.

--- a/ale_run/agents/cursor_cli/README.md
+++ b/ale_run/agents/cursor_cli/README.md
@@ -36,7 +36,7 @@ enabled alongside the CUA MCP tools.
    ```yaml
    # my_exp.yaml
    agents: [configs/agents/cc_composer25_cursor.yaml]
-   environment: configs/environments/environment.yaml
+   environment: configs/environments/environment_gcloud.yaml
    tasks: selected_tasks/my_list.txt
    wall_time_s: 18000         # per-task wall-clock — set HERE, not in the agent
    ```

--- a/ale_run/environments/output_pull.py
+++ b/ale_run/environments/output_pull.py
@@ -387,7 +387,11 @@ async def push_to_oss(
     there is no key to inject — mirror of :func:`push_to_gcs` /
     :func:`push_to_s3` but credential-free.
     """
-    src = _output_dir(sandbox, task_data)
+    # Trailing slash on the source is required: `ossutil cp -r <dir> <dst>/`
+    # (no slash) copies the directory ITSELF under dst, landing files at
+    # ``<dst>/output/output/...``; ``<dir>/`` copies its CONTENTS to ``<dst>/``.
+    # (Same rule ossbucket._sync_cmd applies.)
+    src = _output_dir(sandbox, task_data).rstrip("/") + "/"
     oss_dst = f"{bucket.rstrip('/')}/{run_id}/output/"
 
     if sandbox.is_linux:

--- a/ale_run/environments/output_pull.py
+++ b/ale_run/environments/output_pull.py
@@ -7,6 +7,7 @@ Dispatched by the lifecycle on ``artifacts_path.output_path``:
                  fallback)
   ``"gs://X"`` → :func:`push_to_gcs` (VM-side gsutil; nothing on host)
   ``"s3://X"`` → :func:`push_to_s3` (in-box aws CLI; nothing on host)
+  ``"oss://X"`` → :func:`push_to_oss` (in-box ossutil; nothing on host)
 """
 
 from __future__ import annotations
@@ -30,6 +31,7 @@ _PULL_CONCURRENCY = 8
 _QEMU_SHARE_COPY_TIMEOUT_S = 3600
 _GCS_PUSH_TIMEOUT_S = 3600
 _S3_PUSH_TIMEOUT_S = 3600
+_OSS_PUSH_TIMEOUT_S = 3600
 
 
 def _output_dir(sandbox: SandboxHandle, task_data: TaskDataSpec) -> str:
@@ -374,3 +376,32 @@ async def push_to_s3(
             f"aws s3 cp failed (rc={r.returncode}): {(r.stderr or '')[:300]}"
         )
     return {"transport": "s3", "s3_path": s3_dst}
+async def push_to_oss(
+    sandbox: SandboxHandle, task_data: TaskDataSpec, *,
+    run_id: str, bucket: str,
+) -> dict[str, Any]:
+    """``output_path == 'oss://...'`` — in-box ``ossutil`` push.
+
+    Lands the env's output dir at ``<bucket>/<run_id>/output/``. Auth is the
+    instance's RAM role (AliyunProvider attaches one via ``ram_role_name``), so
+    there is no key to inject — mirror of :func:`push_to_gcs` /
+    :func:`push_to_s3` but credential-free.
+    """
+    src = _output_dir(sandbox, task_data)
+    oss_dst = f"{bucket.rstrip('/')}/{run_id}/output/"
+
+    if sandbox.is_linux:
+        cmd = f"ossutil cp -r -f {shlex.quote(src)} {shlex.quote(oss_dst)}"
+    else:
+        cmd = (
+            'powershell -NoProfile -Command "'
+            f"ossutil cp -r -f '{src}' '{oss_dst}'"
+            '"'
+        )
+    logger.info("push_to_oss: %s → %s", src, oss_dst)
+    r = await sandbox.run_command(cmd, timeout=_OSS_PUSH_TIMEOUT_S)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"ossutil cp failed (rc={r.returncode}): {(r.stderr or '')[:300]}"
+        )
+    return {"transport": "oss", "oss_path": oss_dst}

--- a/ale_run/environments/providers/__init__.py
+++ b/ale_run/environments/providers/__init__.py
@@ -5,6 +5,7 @@
 
   - :class:`GcloudProvider` (``gcloud.py``): ephemeral GCE VMs.
   - :class:`AwsProvider` (``aws.py``): ephemeral EC2 instances.
+  - :class:`AliyunProvider` (``aliyun.py``): ephemeral Alibaba Cloud ECS instances.
   - :class:`StaticProvider` (``static.py``): a pre-existing VM endpoint.
   - :class:`DockerProvider` (``docker.py``): ephemeral Docker containers.
   - :class:`QemuProvider` (``qemu.py``): ephemeral local QEMU VMs in Docker.
@@ -12,6 +13,7 @@
 
 from ...base_interface import SandboxSpec, Provider, ReleaseMode, SandboxHandle
 from .aws import AwsProvider, AwsProviderConfig
+from .aliyun import AliyunProvider, AliyunProviderConfig
 from .docker import DockerProvider, DockerProviderConfig
 from .gcloud import GcloudProvider, GcloudProviderConfig
 from .qemu import QemuProvider, QemuProviderConfig
@@ -21,6 +23,8 @@ __all__ = [
     "SandboxSpec",
     "AwsProvider",
     "AwsProviderConfig",
+    "AliyunProvider",
+    "AliyunProviderConfig",
     "DockerProvider",
     "DockerProviderConfig",
     "GcloudProvider",

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -68,16 +68,19 @@ logger = logging.getLogger(__name__)
 _DEFAULT_CPU_INSTANCE = "ecs.g7.2xlarge"          # 8 vCPU / 32 GiB, general (UEFI ✓)
 # GPU default MUST be a UEFI-boot-capable type: the published ALE images are
 # UEFI (built on GCE), and RunInstances hard-rejects a UEFI image on a BIOS-only
-# instance type with ``InvalidParameter.NotMatch: Image bootMode UEFI does not
-# match instanceType bootMode``. The common A10 type ``ecs.gn7i-c8g1.2xlarge`` is
-# BIOS-only, so it does NOT work here (verified live). The A10 type that DOES
-# accept UEFI is ``ecs.gn7i-xr.4xlarge``; the T4 ``ecs.gn6t.*`` family is also
-# UEFI-capable. ⚠️ Availability is region/zone-specific and volatile — as of this
-# writing gn7i-xr is not offered in cn-hangzhou and gn6t is offered but often
-# out of stock, so GPU snapshots may need a per-env ``vm.machineType`` override
-# to whatever UEFI GPU type your region actually sells. GPU is NOT yet validated
-# end-to-end on Alibaba (blocked on UEFI-GPU stock; see environment_aliyun.yaml).
-_DEFAULT_GPU_INSTANCE = "ecs.gn7i-xr.4xlarge"      # NVIDIA A10, UEFI-capable
+# instance type (``InvalidParameter.NotMatch: Image bootMode ...``). The common
+# PASSTHROUGH A10 ``ecs.gn7i-c8g1.2xlarge`` is BIOS-only → does NOT work. The
+# **vGPU virtual-workstation** family ``ecs.vgn7i-vws-*`` (fractional A10, e.g.
+# m4=A10*1/6, m8=A10*1/3) IS UEFI-capable AND widely in stock (cn-hangzhou +
+# most regions), and its vWS model mirrors GCE's ``nvidia-l4-vws`` — so it's both
+# the launchable and the driver-closest choice. VERIFIED live (2026-07-02): a
+# vgn7i-vws-m4 box launches the UEFI image, Windows Server 2022 boots, cua ready
+# in ~127 s. ⚠️ BUT nvidia-smi then fails ("couldn't communicate with the NVIDIA
+# driver") — the GCE-baked L4-vws driver does not bind to Alibaba's A10 vGPU, so
+# GPU compute is NOT functional until Alibaba's own A10 GRID/vGPU driver is baked
+# into the image. So GPU is a DRIVER gap now, not an infra gap. (Passthrough A10
+# ``ecs.gn7i-xr`` is UEFI too but isn't sold in most regions.)
+_DEFAULT_GPU_INSTANCE = "ecs.vgn7i-vws-m8.2xlarge"   # A10 vGPU vWS, UEFI, in stock
 
 # Launch retry tuning.
 _ALIYUN_MAX_RETRIES_TRANSIENT = 3

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -65,10 +65,19 @@ logger = logging.getLogger(__name__)
 
 # Default instance when a task_card declares no ``vm.machineType``. CPU falls
 # back C→G (see _instance_chain); GPU has no instance fallback.
-_DEFAULT_CPU_INSTANCE = "ecs.g7.2xlarge"          # 8 vCPU / 32 GiB, general
-# gn7i = NVIDIA A10 — the closest Alibaba family to the GCE image's L4, so the
-# baked driver has the best chance of binding.
-_DEFAULT_GPU_INSTANCE = "ecs.gn7i-c8g1.2xlarge"   # 8 vCPU / 30 GiB / 1x A10
+_DEFAULT_CPU_INSTANCE = "ecs.g7.2xlarge"          # 8 vCPU / 32 GiB, general (UEFI ✓)
+# GPU default MUST be a UEFI-boot-capable type: the published ALE images are
+# UEFI (built on GCE), and RunInstances hard-rejects a UEFI image on a BIOS-only
+# instance type with ``InvalidParameter.NotMatch: Image bootMode UEFI does not
+# match instanceType bootMode``. The common A10 type ``ecs.gn7i-c8g1.2xlarge`` is
+# BIOS-only, so it does NOT work here (verified live). The A10 type that DOES
+# accept UEFI is ``ecs.gn7i-xr.4xlarge``; the T4 ``ecs.gn6t.*`` family is also
+# UEFI-capable. ⚠️ Availability is region/zone-specific and volatile — as of this
+# writing gn7i-xr is not offered in cn-hangzhou and gn6t is offered but often
+# out of stock, so GPU snapshots may need a per-env ``vm.machineType`` override
+# to whatever UEFI GPU type your region actually sells. GPU is NOT yet validated
+# end-to-end on Alibaba (blocked on UEFI-GPU stock; see environment_aliyun.yaml).
+_DEFAULT_GPU_INSTANCE = "ecs.gn7i-xr.4xlarge"      # NVIDIA A10, UEFI-capable
 
 # Launch retry tuning.
 _ALIYUN_MAX_RETRIES_TRANSIENT = 3

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -1,0 +1,886 @@
+"""AliyunProvider — ephemeral Alibaba Cloud ECS instances via ``aliyun ecs
+RunInstances``.
+
+Mirror of :mod:`ale_run.environments.providers.aws` (and, through it,
+:mod:`ale_run.environments.providers.gcloud`), adapted to Alibaba Cloud ECS:
+
+* **Framework facts (hardcoded, top of file)**: default instance types, the
+  C→G instance fallback, retry tuning, error classification.
+* **Deployment knobs (yaml ``provider.config`` → :class:`AliyunProviderConfig`)**:
+  region, security group, optional key pair + instance RAM role, instance_prefix,
+  internet bandwidth, system-disk category, and the ``snapshots`` map (logical
+  tag → custom image + optional gpu + zones).
+
+A task asks for a logical snapshot (``cpu-free-ubuntu`` / ...); the provider
+resolves it via the yaml ``snapshots`` map to a custom-image id + a zone list,
+picks an instance type (task-card ``vm.machineType`` override, else a default,
+with C→G family fallback), and tries the zones in order on capacity errors.
+Each zone is resolved to a vSwitch in that zone within the security group's VPC.
+Root disk size comes from the image's baked system-disk snapshot (no override).
+
+Why this looks like aws.py but isn't shared: the lifecycle, retry ordering
+(instance-type × zone), readiness poll, Windows-resolution and DesktopSession
+bring-up are identical in *shape*, so the genuinely cloud-agnostic helpers
+(``wait_cua_ready``, ``_init_computer_skip_wait``, ``sanitize_label_value``,
+``_SET_RES_PY``) are imported from gcloud.py rather than duplicated. Everything
+that shells out to ``aliyun`` lives here.
+
+Credentials: the provider uses the ambient Alibaba Cloud credential chain
+(``aliyun configure`` profile / ``ALIBABA_CLOUD_ACCESS_KEY_ID`` +
+``ALIBABA_CLOUD_ACCESS_KEY_SECRET`` env vars), so — like the aws provider — no
+key is named in the yaml. The in-box ``ossutil`` authenticates to OSS via the
+instance **RAM role** attached at launch (``ram_role_name``), the Alibaba
+analogue of AWS's IAM instance profile — so there is nothing to inject for
+oss:// task data / output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import random
+import re
+import time
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any
+
+from ...base_interface import SandboxSpec, Provider, ReleaseMode, SandboxHandle
+# Cloud-agnostic helpers shared with the gcloud/aws providers.
+from .gcloud import (
+    wait_cua_ready,
+    _init_computer_skip_wait,
+    sanitize_label_value,
+    _SET_RES_PY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Configuration — framework facts (hardcoded). Snapshot→image + zones are
+# deployment-specific and live in the yaml profile (AliyunProviderConfig).
+# ============================================================================
+
+# Default instance when a task_card declares no ``vm.machineType``. CPU falls
+# back C→G (see _instance_chain); GPU has no instance fallback.
+_DEFAULT_CPU_INSTANCE = "ecs.g7.2xlarge"          # 8 vCPU / 32 GiB, general
+# gn7i = NVIDIA A10 — the closest Alibaba family to the GCE image's L4, so the
+# baked driver has the best chance of binding.
+_DEFAULT_GPU_INSTANCE = "ecs.gn7i-c8g1.2xlarge"   # 8 vCPU / 30 GiB / 1x A10
+
+# Launch retry tuning.
+_ALIYUN_MAX_RETRIES_TRANSIENT = 3
+_ALIYUN_TRANSIENT_BASE_DELAY = 15          # seconds, exponential backoff
+
+# error-code/message substring → error class. transient = retry same zone;
+# zone = move to next zone (capacity); anything else = fail fast. Matched
+# case-insensitively against the aliyun CLI's stderr (which carries the API
+# ``Code`` and ``Message``).
+_ALIYUN_RETRYABLE_TRANSIENT = [
+    "throttling", "requestlimitexceeded", "rate exceeded",
+    "internalerror", "internal error", "servererror",
+    "serviceunavailable", "service unavailable", "unavailable",
+    "connection reset", "connection refused", "timed out", "timeout",
+    "could not connect", "connection aborted", "i/o timeout",
+]
+_ALIYUN_RETRYABLE_ZONE = [
+    "operationdenied.nostock", "nostock", "out of stock",
+    "resource.notenough", "resourcenotavailable",
+    "zonenotsupported", "zone_not_sufficient",
+    "no capacity", "not have capacity", "instancediskcategorylimitexceeded",
+]
+
+
+# ============================================================================
+# Provider config
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class SnapshotConfig:
+    """What a logical snapshot tag maps to (yaml ``snapshots.<tag>``).
+
+    Exactly parallel to aws/gcloud's SnapshotConfig: ``image`` is the
+    **image-family name** (the same registry key gcloud/aws use — ``ale-ubuntu22``
+    / ``ale-win10`` — from :mod:`ale_run.environments.images`), NOT a raw
+    ``m-...`` image id. The provider resolves that family to a concrete custom
+    image id at acquire time by looking up a self-owned image tagged
+    ``ale:image-family=<name>`` (override with an explicit ``image_id:`` when you
+    want to pin one). One ``ale-win10.py`` registry entry thus serves gcloud
+    (GCE image name), aws (family→AMI lookup) and aliyun (family→image lookup).
+
+    ``zones`` holds **Alibaba zone ids** (e.g. ``cn-hangzhou-i``) to try in order
+    on capacity errors — the ECS analogue of aws's AZ list. The provider maps
+    each zone to a vSwitch in that zone within the security group's VPC.
+    """
+
+    image: str               # image-family name (registry key), e.g. "ale-win10"
+    gpu: str | None          # truthy → use a GPU instance type; None for CPU
+    zones: tuple[str, ...]   # zone ids to try, in order, on capacity errors
+    image_id: str | None = None   # optional explicit image id override (m-...)
+    resolution: tuple[int, int] | None = None
+    """Windows display resolution (w, h) forced after boot. See gcloud's
+    SnapshotConfig for the full rationale; Linux ignores it."""
+
+    @property
+    def os(self) -> str:
+        # image is the family name (e.g. ale-win10), so this is stable even when
+        # an explicit image_id override is set.
+        return "windows" if "win" in self.image.lower() else "linux"
+
+
+@dataclass(frozen=True)
+class AliyunProviderConfig:
+    """aliyun provider config (yaml ``provider.config``).
+
+        region                    Alibaba region id, e.g. ``cn-hangzhou`` (hardcoded
+                                  in the yaml, like gcloud's zones)
+        security_group            the firewall — a security-group NAME (``ale-sandbox``)
+                                  or ``sg-...`` id. The provider resolves the name to
+                                  its id AND the VPC it lives in, which scopes the
+                                  zone→vSwitch lookup. The gcloud analogue is ``network``.
+        instance_prefix           instance Name prefix
+        key_name                  ECS key pair name (optional; we reach the box via
+                                  cua-server, not SSH, so usually unset)
+        ram_role_name             instance RAM role granting in-box OSS access
+                                  (optional; only for oss:// task data / output) —
+                                  the Alibaba analogue of AWS's IAM instance profile
+        internet_max_bandwidth_out  outbound public bandwidth in Mbit/s. > 0 makes
+                                  ECS auto-assign a public IP (default 100); 0 keeps
+                                  the box private (then the private IP is used)
+        system_disk_category      system-disk type for the boot volume (default
+                                  ``cloud_essd``); size comes from the image
+        instance_charge_type      ``PostPaid`` (pay-as-you-go, default) or ``PrePaid``
+        snapshots                 dict[snapshot tag → SnapshotConfig]
+
+    Credentials are NOT here — the provider uses the ambient Alibaba Cloud
+    credential chain (``aliyun configure`` / ``ALIBABA_CLOUD_ACCESS_KEY_*`` env),
+    so unlike gcloud no project/key is named in the yaml. Everything is a
+    hardcoded convention (resolved by name/tag at run time); nothing needs
+    ``${env:...}``.
+    """
+
+    region: str
+    security_group: str = "ale-sandbox"
+    instance_prefix: str = "ale"
+    key_name: str = ""
+    ram_role_name: str = ""
+    internet_max_bandwidth_out: int = 100
+    system_disk_category: str = "cloud_essd"
+    instance_charge_type: str = "PostPaid"
+    snapshots: dict[str, SnapshotConfig] = dataclass_field(default_factory=dict)
+
+    @property
+    def associate_public_ip(self) -> bool:
+        return self.internet_max_bandwidth_out > 0
+
+
+def _build_snapshot_config(raw: Any) -> SnapshotConfig:
+    if not isinstance(raw, dict):
+        raise TypeError(f"snapshot entry must be a mapping, got {type(raw).__name__}")
+    image = raw.get("image")
+    if not image:
+        raise KeyError(
+            f"snapshot entry missing required `image` (image-family name, "
+            f"e.g. ale-win10): {raw!r}"
+        )
+    zones = tuple(raw.get("zones") or ())
+    if not zones:
+        raise KeyError(f"snapshot {image!r} missing required `zones` (zone ids)")
+    return SnapshotConfig(
+        image=str(image), gpu=raw.get("gpu"), zones=zones,
+        image_id=(str(raw["image_id"]) if raw.get("image_id") else None),
+        resolution=_parse_resolution(raw.get("resolution"), image),
+    )
+
+
+def _parse_resolution(raw: Any, image: str) -> tuple[int, int] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        parts = raw.lower().replace(" ", "").split("x")
+    elif isinstance(raw, (list, tuple)):
+        parts = list(raw)
+    else:
+        raise TypeError(
+            f"snapshot {image!r} resolution must be [w, h] or 'WxH', got {raw!r}"
+        )
+    if len(parts) != 2:
+        raise ValueError(f"snapshot {image!r} resolution must have 2 values, got {raw!r}")
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except (TypeError, ValueError):
+        raise ValueError(f"snapshot {image!r} resolution values must be ints, got {raw!r}")
+
+
+def _build_provider_config(raw: dict[str, Any]) -> AliyunProviderConfig:
+    snapshots = {
+        str(tag): _build_snapshot_config(entry)
+        for tag, entry in (raw.get("snapshots") or {}).items()
+    }
+    return AliyunProviderConfig(
+        region=str(raw["region"]),
+        security_group=str(raw.get("security_group") or "ale-sandbox"),
+        instance_prefix=str(raw.get("instance_prefix") or "ale"),
+        key_name=str(raw.get("key_name") or ""),
+        ram_role_name=str(raw.get("ram_role_name") or ""),
+        internet_max_bandwidth_out=int(raw.get("internet_max_bandwidth_out", 100)),
+        system_disk_category=str(raw.get("system_disk_category") or "cloud_essd"),
+        instance_charge_type=str(raw.get("instance_charge_type") or "PostPaid"),
+        snapshots=snapshots,
+    )
+
+
+# ============================================================================
+# Instance-type fallback chain
+# ============================================================================
+
+
+def _cpu_family_fallback(instance_type: str) -> str | None:
+    """C-family → G fallback, keeping the size suffix.
+
+    ``ecs.c7.2xlarge`` → ``ecs.g7.2xlarge``. Returns None for non-C families.
+    This is the only instance fallback we do: compute-optimized capacity stocks
+    out far more often than general-purpose. The ``ecs.`` prefix and the size
+    suffix are preserved; only the family letter ``c`` → ``g`` changes.
+    """
+    m = re.fullmatch(r"(ecs\.)c(\w*?)(\..+)", instance_type)
+    if m:
+        return f"{m.group(1)}g{m.group(2)}{m.group(3)}"
+    return None
+
+
+def _instance_chain(instance_type: str, *, is_gpu: bool) -> tuple[str, ...]:
+    """Ordered instance types to try for one box.
+
+    * GPU: just the requested gn-family type — no fallback.
+    * CPU: the requested type, then its G fallback (``ecs.c*`` → ``ecs.g*``).
+    """
+    if is_gpu:
+        return (instance_type,)
+    fb = _cpu_family_fallback(instance_type)
+    return (instance_type, fb) if fb else (instance_type,)
+
+
+# ============================================================================
+# Naming
+# ============================================================================
+
+
+def generate_instance_name(
+    prefix: str,
+    *,
+    snapshot: str,
+    task_id: str = "",
+    harness: str = "",
+    model_tag: str = "",
+) -> str:
+    """``<prefix>-<task-or-snapshot>-<hash8>`` instance name (mirror of aws)."""
+    if task_id:
+        body = re.sub(r"[^a-z0-9]", "-", task_id.lower()).strip("-")[:40]
+    else:
+        body = re.sub(r"[^a-z0-9]", "-", snapshot.lower()).strip("-")[:30]
+    seed = f"{prefix}:{task_id}:{harness}:{model_tag}:{snapshot}:{time.time()}:{random.random()}"
+    h = hashlib.sha256(seed.encode()).hexdigest()[:8]
+    # ECS InstanceName must start with a letter and be ≤ 128 chars.
+    name = f"{prefix}-{body}-{h}"[:128]
+    return name if name[:1].isalpha() else f"a{name}"[:128]
+
+
+# ============================================================================
+# aliyun CLI wrapper + error classification
+# ============================================================================
+
+
+async def _run_aliyun(product: str, action: str, *args: str) -> tuple[int, str, str]:
+    """Invoke ``aliyun <product> <action> [args...]``.
+
+    The aliyun CLI prints the raw JSON API response to stdout on success, so —
+    unlike the aws CLI — no ``--output json`` flag is needed. ``--region`` /
+    ``--RegionId`` are passed by the caller (region is on every ECS action).
+    """
+    cmd = ["aliyun", product, action, *args]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_b, stderr_b = await proc.communicate()
+    return (
+        proc.returncode or 0,
+        stdout_b.decode(errors="replace"),
+        stderr_b.decode(errors="replace"),
+    )
+
+
+def _is_transient_error(stderr: str) -> bool:
+    lower = stderr.lower()
+    return any(pat in lower for pat in _ALIYUN_RETRYABLE_TRANSIENT)
+
+
+def _is_zone_capacity_error(stderr: str) -> bool:
+    lower = stderr.lower()
+    return any(pat in lower for pat in _ALIYUN_RETRYABLE_ZONE)
+
+
+# ============================================================================
+# RunInstances argv
+# ============================================================================
+
+
+def _build_run_args(
+    *,
+    name: str,
+    image_id: str,
+    instance_type: str,
+    zone_id: str,
+    vswitch_id: str,
+    security_group_id: str,
+    cfg: AliyunProviderConfig,
+    snapshot_tag: str,
+) -> list[str]:
+    """``aliyun ecs RunInstances`` argv.
+
+    System-disk size is NOT passed — we use the image's baked system-disk
+    snapshot size. ``InternetMaxBandwidthOut > 0`` makes ECS auto-assign a
+    public IP; tags mark the box for fleet cleanup (mirror of aws's tags).
+    """
+    args = [
+        "--RegionId", cfg.region,
+        "--ZoneId", zone_id,
+        "--ImageId", image_id,
+        "--InstanceType", instance_type,
+        "--Amount", "1",
+        "--VSwitchId", vswitch_id,
+        "--SecurityGroupId", security_group_id,
+        "--InstanceName", name,
+        "--InstanceChargeType", cfg.instance_charge_type,
+        "--SystemDisk.Category", cfg.system_disk_category,
+        "--InternetMaxBandwidthOut", str(cfg.internet_max_bandwidth_out),
+        # tags: purpose=ale-run + snapshot=<tag> (fleet-cleanup selectors).
+        "--Tag.1.Key", "purpose", "--Tag.1.Value", "ale-run",
+        "--Tag.2.Key", "snapshot",
+        "--Tag.2.Value", sanitize_label_value(snapshot_tag),
+    ]
+    if cfg.key_name:
+        args += ["--KeyPairName", cfg.key_name]
+    if cfg.ram_role_name:
+        args += ["--RamRoleName", cfg.ram_role_name]
+    return args
+
+
+async def _try_run_in_zone(
+    *,
+    name: str,
+    image_id: str,
+    instance_type: str,
+    zone_id: str,
+    vswitch_id: str,
+    security_group_id: str,
+    cfg: AliyunProviderConfig,
+    snapshot_tag: str,
+) -> tuple[bool, str, str]:
+    """Returns (ok, stdout, stderr). On capacity error returns ok=False without
+    retrying (caller moves to the next zone); transient errors retry here."""
+    args = _build_run_args(
+        name=name,
+        image_id=image_id,
+        instance_type=instance_type,
+        zone_id=zone_id,
+        vswitch_id=vswitch_id,
+        security_group_id=security_group_id,
+        cfg=cfg,
+        snapshot_tag=snapshot_tag,
+    )
+    last_stderr = ""
+    for attempt in range(1, _ALIYUN_MAX_RETRIES_TRANSIENT + 1):
+        logger.info(
+            "Launching %s type=%s in %s (attempt %d/%d)",
+            name, instance_type, zone_id, attempt, _ALIYUN_MAX_RETRIES_TRANSIENT,
+        )
+        rc, stdout, stderr = await _run_aliyun("ecs", "RunInstances", *args)
+        if rc == 0:
+            return True, stdout, ""
+        last_stderr = stderr
+
+        if _is_zone_capacity_error(stderr):
+            logger.warning(
+                "type=%s capacity-exhausted in %s: %s",
+                instance_type, zone_id, stderr[:300],
+            )
+            return False, "", last_stderr
+
+        if _is_transient_error(stderr) and attempt < _ALIYUN_MAX_RETRIES_TRANSIENT:
+            delay = _ALIYUN_TRANSIENT_BASE_DELAY * (2 ** (attempt - 1))
+            logger.warning(
+                "RunInstances transient error (attempt %d/%d): %s — retrying in %ds",
+                attempt, _ALIYUN_MAX_RETRIES_TRANSIENT, stderr[:200], delay,
+            )
+            await asyncio.sleep(delay)
+            continue
+
+        return False, "", last_stderr
+    return False, "", last_stderr
+
+
+# ============================================================================
+# describe / lifecycle helpers
+# ============================================================================
+
+
+def _instance_id_from_run(stdout: str) -> str:
+    """RunInstances returns ``{"InstanceIdSets":{"InstanceIdSet":["i-..."]}}``."""
+    data = json.loads(stdout)
+    return data["InstanceIdSets"]["InstanceIdSet"][0]
+
+
+def _first_ip(block: Any) -> str | None:
+    """Pull the first ip out of aliyun's ``{"IpAddress": ["1.2.3.4"]}`` shape."""
+    if isinstance(block, dict):
+        ips = block.get("IpAddress")
+        if isinstance(ips, list) and ips:
+            return str(ips[0])
+    return None
+
+
+async def _wait_running_with_ip(
+    instance_id: str, cfg: AliyunProviderConfig, *, want_public: bool,
+    timeout: float = 240,
+) -> str:
+    """Poll DescribeInstances until the instance is ``Running`` and has an IP.
+
+    Returns the public IP (want_public) or the private IP. Raises on timeout.
+    Public IPs auto-assigned via InternetMaxBandwidthOut land in
+    ``PublicIpAddress.IpAddress``; the VPC private IP is in
+    ``VpcAttributes.PrivateIpAddress.IpAddress``."""
+    deadline = time.monotonic() + timeout
+    last_state = "?"
+    while time.monotonic() < deadline:
+        rc, stdout, stderr = await _run_aliyun(
+            "ecs", "DescribeInstances",
+            "--RegionId", cfg.region,
+            "--InstanceIds", json.dumps([instance_id]),
+        )
+        if rc == 0:
+            try:
+                inst = json.loads(stdout)["Instances"]["Instance"][0]
+                last_state = inst.get("Status", "?")
+                if last_state == "Running":
+                    if want_public:
+                        ip = _first_ip(inst.get("PublicIpAddress"))
+                    else:
+                        ip = _first_ip(
+                            (inst.get("VpcAttributes") or {}).get("PrivateIpAddress")
+                        )
+                    if ip:
+                        return ip
+                if last_state in ("Deleted", "Stopped"):
+                    raise RuntimeError(
+                        f"instance {instance_id} entered {last_state} before becoming reachable"
+                    )
+            except (KeyError, IndexError, json.JSONDecodeError):
+                pass
+        await asyncio.sleep(5)
+    raise RuntimeError(
+        f"timed out waiting for {instance_id} to be Running with an IP "
+        f"(last state={last_state})"
+    )
+
+
+async def _delete(instance_id: str, cfg: AliyunProviderConfig) -> bool:
+    """Force-delete the instance (``--Force true`` releases a Running box without
+    a separate stop)."""
+    logger.info("Deleting instance %s", instance_id)
+    rc, _, stderr = await _run_aliyun(
+        "ecs", "DeleteInstance",
+        "--RegionId", cfg.region,
+        "--InstanceId", instance_id,
+        "--Force", "true",
+    )
+    if rc != 0:
+        logger.error("Failed to delete %s: %s", instance_id, stderr)
+        return False
+    return True
+
+
+async def _stop(instance_id: str, cfg: AliyunProviderConfig) -> bool:
+    logger.info("Stopping instance %s", instance_id)
+    rc, _, stderr = await _run_aliyun(
+        "ecs", "StopInstance",
+        "--RegionId", cfg.region,
+        "--InstanceId", instance_id,
+    )
+    if rc != 0:
+        logger.error("Failed to stop %s: %s", instance_id, stderr)
+        return False
+    return True
+
+
+def _parse_supported_modes(out: str) -> list[tuple[int, int]]:
+    """Extract ``(w, h)`` modes from the resolution script's
+    ``failed:<rc> supported=[(800, 600), ...]`` line."""
+    marker = "supported="
+    i = out.find(marker)
+    if i < 0:
+        return []
+    import ast
+    try:
+        val = ast.literal_eval(out[i + len(marker):].strip())
+        return [(int(a), int(b)) for a, b in val]
+    except (ValueError, SyntaxError, TypeError):
+        return []
+
+
+# ============================================================================
+# Provider
+# ============================================================================
+
+
+class AliyunProvider(Provider):
+    """Provider backed by ``aliyun ecs RunInstances / DeleteInstance``."""
+
+    def __init__(self, config: AliyunProviderConfig | dict[str, Any]):
+        if isinstance(config, dict):
+            config = _build_provider_config(config)
+        self._cfg = config
+        self._image_cache: dict[str, str] = {}    # family name → image id
+        self._vswitch_cache: dict[str, str] = {}  # zone id → vswitch id
+        self._sg: tuple[str, str] | None = None   # (sg_id, vpc_id), resolved once
+
+    @property
+    def config(self) -> AliyunProviderConfig:
+        return self._cfg
+
+    # ----------------------------------------------------------- resolution
+
+    async def _resolve_image(self, snap: SnapshotConfig) -> str:
+        """Resolve a snapshot's image to a concrete custom-image id.
+
+        Order: explicit ``image_id:`` override → cached → look up a self-owned
+        image tagged ``ale:image-family=<snap.image>`` (newest wins). This is the
+        Alibaba analogue of aws resolving a family to an AMI.
+        """
+        if snap.image_id:
+            return snap.image_id
+        family = snap.image
+        if family in self._image_cache:
+            return self._image_cache[family]
+        rc, out, err = await _run_aliyun(
+            "ecs", "DescribeImages",
+            "--RegionId", self._cfg.region,
+            "--ImageOwnerAlias", "self",
+            "--Tag.1.Key", "ale:image-family",
+            "--Tag.1.Value", family,
+        )
+        image_id = ""
+        if rc == 0:
+            try:
+                images = json.loads(out)["Images"]["Image"]
+                # newest first by CreationTime (ISO-8601 strings sort lexically).
+                images.sort(key=lambda im: im.get("CreationTime", ""), reverse=True)
+                if images:
+                    image_id = str(images[0]["ImageId"])
+            except (KeyError, IndexError, json.JSONDecodeError):
+                image_id = ""
+        if not image_id:
+            raise RuntimeError(
+                f"no image tagged ale:image-family={family!r} in {self._cfg.region} "
+                f"(import one, tag it, or set an explicit `image_id:` on the snapshot). "
+                f"{(err or '').strip()[:200]}"
+            )
+        self._image_cache[family] = image_id
+        return image_id
+
+    async def _resolve_security_group(self) -> tuple[str, str]:
+        """Resolve ``config.security_group`` (a name or ``sg-...`` id) to its id
+        AND the VPC it lives in. The VPC scopes the zone→vSwitch lookup, so the
+        yaml only names the firewall (like gcloud names ``network``) — no
+        ids/env-vars. Resolved once and cached."""
+        if self._sg is not None:
+            return self._sg
+        ref = self._cfg.security_group
+        sel = (["--SecurityGroupId", ref] if ref.startswith("sg-")
+               else ["--SecurityGroupName", ref])
+        rc, out, err = await _run_aliyun(
+            "ecs", "DescribeSecurityGroups",
+            "--RegionId", self._cfg.region, *sel,
+        )
+        sg = None
+        if rc == 0:
+            try:
+                groups = json.loads(out)["SecurityGroups"]["SecurityGroup"]
+                if groups:
+                    sg = (str(groups[0]["SecurityGroupId"]), str(groups[0]["VpcId"]))
+            except (KeyError, IndexError, json.JSONDecodeError):
+                sg = None
+        if sg is None or not sg[0]:
+            raise RuntimeError(
+                f"security group {ref!r} not found in {self._cfg.region} "
+                f"(create it — see the Alibaba setup docs). {(err or '').strip()[:200]}"
+            )
+        self._sg = sg
+        return self._sg
+
+    async def _vswitch_for_zone(self, zone_id: str, vpc_id: str) -> str:
+        """Resolve a zone id to a vSwitch id in that zone within ``vpc_id`` (the
+        security group's VPC). Prefers vSwitches tagged ``project=ale``; falls
+        back to any vSwitch in the zone/VPC. Cached per zone."""
+        if zone_id in self._vswitch_cache:
+            return self._vswitch_cache[zone_id]
+        base = [
+            "--RegionId", self._cfg.region,
+            "--ZoneId", zone_id,
+            "--VpcId", vpc_id,
+        ]
+        rc, out, err = await _run_aliyun("ecs", "DescribeVSwitches", *base)
+        vswitch = ""
+        if rc == 0:
+            try:
+                vsws = json.loads(out)["VSwitches"]["VSwitch"]
+                tagged = [
+                    v for v in vsws
+                    if any(
+                        t.get("TagKey") == "project" and t.get("TagValue") == "ale"
+                        for t in ((v.get("Tags") or {}).get("Tag") or [])
+                    )
+                ]
+                pick = (tagged or vsws)
+                pick.sort(key=lambda v: v.get("VSwitchId", ""))
+                if pick:
+                    vswitch = str(pick[0]["VSwitchId"])
+            except (KeyError, IndexError, json.JSONDecodeError):
+                vswitch = ""
+        if not vswitch:
+            raise RuntimeError(
+                f"no vSwitch in zone {zone_id} (vpc={vpc_id}): {(err or '').strip()[:200]}"
+            )
+        self._vswitch_cache[zone_id] = vswitch
+        return vswitch
+
+    # ------------------------------------------------------------------ acquire
+
+    async def acquire(self, spec: SandboxSpec) -> SandboxHandle:
+        snap = self._cfg.snapshots.get(spec.snapshot)
+        if snap is None:
+            raise KeyError(
+                f"snapshot {spec.snapshot!r} not in provider config "
+                f"(known: {sorted(self._cfg.snapshots)})"
+            )
+        if spec.os and spec.os != snap.os:
+            logger.warning(
+                "os mismatch for %s: task declares %r but image %r looks %r",
+                spec.snapshot, spec.os, snap.image, snap.os,
+            )
+
+        is_gpu = snap.gpu is not None
+        zones = snap.zones
+
+        base_instance = spec.machine_type or (
+            _DEFAULT_GPU_INSTANCE if is_gpu else _DEFAULT_CPU_INSTANCE
+        )
+        instances = _instance_chain(base_instance, is_gpu=is_gpu)
+
+        # Resolve the image-family name (e.g. "ale-win10") to a concrete image id,
+        # and the security-group name to its id + the VPC that scopes vSwitches.
+        image_id = await self._resolve_image(snap)
+        sg_id, vpc_id = await self._resolve_security_group()
+
+        name = generate_instance_name(
+            self._cfg.instance_prefix,
+            snapshot=spec.snapshot,
+            task_id=spec.task_id,
+            harness=spec.harness,
+            model_tag=spec.model_tag,
+        )
+
+        logger.info(
+            "instance %s candidates: image=%s types=%s zones=%s",
+            name, image_id, list(instances), list(zones),
+        )
+
+        last_stderr = ""
+        stdout = ""
+        used_zone = zones[0]
+        used_vswitch = ""
+        used_instance = instances[0]
+
+        # instance-type × zone, in order: each type tried across all zones. Each
+        # zone is resolved to a vSwitch in that zone within the configured VPC.
+        for instance_type in instances:
+            for zone_id in zones:
+                try:
+                    vswitch = await self._vswitch_for_zone(zone_id, vpc_id)
+                except Exception as e:  # noqa: BLE001
+                    last_stderr = f"no vSwitch for zone {zone_id}: {e}"
+                    logger.warning("%s", last_stderr)
+                    continue
+                ok, out, stderr = await _try_run_in_zone(
+                    name=name,
+                    image_id=image_id,
+                    instance_type=instance_type,
+                    zone_id=zone_id,
+                    vswitch_id=vswitch,
+                    security_group_id=sg_id,
+                    cfg=self._cfg,
+                    snapshot_tag=spec.snapshot,
+                )
+                if ok:
+                    stdout = out
+                    used_vswitch = vswitch
+                    used_zone = zone_id
+                    used_instance = instance_type
+                    break
+                last_stderr = stderr
+                if not _is_zone_capacity_error(stderr):
+                    raise RuntimeError(f"aliyun RunInstances failed: {stderr}")
+            if stdout:
+                break
+        else:
+            raise RuntimeError(
+                f"aliyun RunInstances failed for all types/zones: {last_stderr}"
+            )
+
+        try:
+            instance_id = _instance_id_from_run(stdout)
+        except (json.JSONDecodeError, KeyError, IndexError) as e:
+            raise RuntimeError(
+                f"failed to parse RunInstances output: {e}\nstdout: {stdout[:500]}"
+            ) from e
+
+        # Instance now exists. Until the handle is returned, ANY failure leaks
+        # it (the caller's cleanup only runs once it holds the handle), so
+        # delete-on-failure here before propagating.
+        try:
+            public_ip = await _wait_running_with_ip(
+                instance_id, self._cfg,
+                want_public=self._cfg.associate_public_ip,
+            )
+
+            # snap.image IS the registry family name (same key gcloud/aws use), so
+            # this resolves the in-box paths/port directly — one registry entry
+            # serves all providers.
+            from ..images import get as get_image
+            image = get_image(snap.image)
+
+            cua_url = f"http://{public_ip}:{image.cua_server_port}"
+            logger.info(
+                "instance %s (%s) launched as %s in %s (%s) at %s",
+                name, instance_id, used_instance, used_zone, used_vswitch, cua_url,
+            )
+
+            # Windows first-boot on an imported image (driver init + login +
+            # cua autostart) can exceed the 10-min Linux default; give it 20.
+            cua_timeout = 1200 if snap.os == "windows" else 600
+            ready = await wait_cua_ready(cua_url, snap.os, timeout=cua_timeout)
+            if not ready:
+                raise RuntimeError(f"CUA server at {cua_url} did not become ready")
+
+            if image.os == "windows" and snap.resolution is not None:
+                await self._set_windows_resolution(cua_url, snap.resolution)
+
+            return SandboxHandle(
+                id=instance_id,
+                endpoint=cua_url,
+                os=image.os,
+                **image.sandbox_paths(),
+                metadata={
+                    "region": self._cfg.region,
+                    "instance_id": instance_id,
+                    "instance_type": used_instance,
+                    "zone": used_zone,
+                    "vswitch": used_vswitch,
+                    "public_ip": public_ip,
+                    "image": image.name,
+                    "image_id": image_id,
+                    "snapshot": spec.snapshot,
+                    "name": name,
+                },
+            )
+        except BaseException:
+            logger.warning(
+                "acquire: post-launch failure on %s (%s) — deleting to avoid leak",
+                name, instance_id,
+            )
+            try:
+                await _delete(instance_id, self._cfg)
+            except Exception as de:  # noqa: BLE001
+                logger.error("acquire: could not delete leaked %s: %s", instance_id, de)
+            raise
+
+    @staticmethod
+    async def _set_windows_resolution(
+        cua_url: str, resolution: tuple[int, int],
+    ) -> None:
+        """Force the Windows framebuffer to ``resolution`` (w, h), falling back to
+        the largest supported mode if the exact one isn't available.
+
+        Like the aws provider, an imported Windows image's display adapter may
+        expose a different (often smaller) mode set than GCE. Hard-failing the
+        whole run over that is wrong (it's a capability difference, not a
+        misconfig), so we pick the best supported mode ≤ the request (else the
+        largest available) and LOG it loudly — a logged, root-caused choice, not
+        a silent mask. Only raise if the adapter reports no settable modes at
+        all."""
+        from cua_bench.computers.remote import RemoteDesktopSession
+
+        w, h = resolution
+        remote_path = r"C:\agenthle\_set_resolution.py"
+        session = RemoteDesktopSession(api_url=cua_url, os_type="windows")
+        _init_computer_skip_wait(session)
+        await session.run_command(
+            r"cmd /c if not exist C:\agenthle mkdir C:\agenthle", check=False,
+        )
+        await session.write_file(remote_path, _SET_RES_PY)
+
+        async def _try(tw: int, th: int) -> str:
+            res = await session.run_command(f'python "{remote_path}" {tw} {th}', check=False)
+            return (res.get("stdout") or "").strip() if isinstance(res, dict) else ""
+
+        out = await _try(w, h)
+        if "set_ok" in out:
+            logger.info("aliyun: set Windows resolution to %dx%d", w, h)
+            return
+
+        # Parse the adapter's supported modes ("...supported=[(800, 600), ...]")
+        # and retry with the best fit instead of aborting the run.
+        modes = _parse_supported_modes(out)
+        if modes:
+            below = [m for m in modes if m[0] <= w and m[1] <= h]
+            best = max(below or modes, key=lambda m: m[0] * m[1])
+            out2 = await _try(best[0], best[1])
+            if "set_ok" in out2:
+                logger.warning(
+                    "aliyun: requested Windows resolution %dx%d unsupported on this "
+                    "display adapter (supported=%s) — using %dx%d instead",
+                    w, h, modes, best[0], best[1],
+                )
+                return
+        err = out or (out and "no output")
+        raise RuntimeError(
+            f"aliyun: could not set any Windows resolution (requested {w}x{h}); "
+            f"adapter output: {err or 'no output'}"
+        )
+
+    # ------------------------------------------------------------------ release
+
+    async def release(self, vm: SandboxHandle, *, mode: ReleaseMode = "delete") -> None:
+        instance_id = vm.metadata.get("instance_id") or vm.id
+        if mode == "delete":
+            await _delete(instance_id, self._cfg)
+        elif mode == "stop":
+            await _stop(instance_id, self._cfg)
+        elif mode == "keep":
+            logger.info("instance %s kept alive (mode=keep)", instance_id)
+        else:
+            raise ValueError(f"unknown release mode: {mode!r}")
+
+    # ------------------------------------------------------------------ session
+
+    def open_session(self, vm: SandboxHandle) -> Any:
+        from cua_bench.computers.remote import RemoteDesktopSession
+
+        session = RemoteDesktopSession(api_url=vm.endpoint, os_type=vm.os)
+        _init_computer_skip_wait(session)
+        return session

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -540,8 +540,9 @@ async def _delete(instance_id: str, cfg: AliyunProviderConfig) -> bool:
 
     A box still in its post-RunInstances ``Initializing`` window rejects
     DeleteInstance with ``IncorrectInstanceStatus.Initializing``; since a failed
-    delete leaks a billable instance, retry a few times through that window
-    before giving up."""
+    delete leaks a billable instance, retry through that window. Delete is the
+    last safety net against billing leaks, so we also retry throttle/transport
+    (transient) errors — only a genuine hard error (bad id, auth) breaks early."""
     logger.info("Deleting instance %s", instance_id)
     last_stderr = ""
     for attempt in range(_DELETE_MAX_RETRIES):
@@ -555,7 +556,9 @@ async def _delete(instance_id: str, cfg: AliyunProviderConfig) -> bool:
             return True
         last_stderr = stderr
         code = _error_code(stderr)
-        if "incorrectinstancestatus" not in code:
+        # retry the Initializing window + any transient (throttle/transport) error;
+        # bail only on a hard error we can't recover from.
+        if "incorrectinstancestatus" not in code and not _is_transient_error(stderr):
             break
         await asyncio.sleep(_DELETE_RETRY_DELAY)
     logger.error("Failed to delete %s: %s", instance_id, last_stderr)

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -186,6 +186,11 @@ class AliyunProviderConfig:
     internet_max_bandwidth_out: int = 100
     system_disk_category: str = "cloud_essd"
     instance_charge_type: str = "PostPaid"
+    output_to_bucket: bool = False
+    """Set by the config loader when ``output_path`` is an ``oss://`` bucket. It
+    turns a missing ``ram_role_name`` from a tolerated skip into a hard error —
+    without the role the in-box ossutil can't upload, so a bucket output would
+    silently lose every run's files."""
     snapshots: dict[str, SnapshotConfig] = dataclass_field(default_factory=dict)
 
     @property
@@ -245,6 +250,7 @@ def _build_provider_config(raw: dict[str, Any]) -> AliyunProviderConfig:
         internet_max_bandwidth_out=int(raw.get("internet_max_bandwidth_out", 100)),
         system_disk_category=str(raw.get("system_disk_category") or "cloud_essd"),
         instance_charge_type=str(raw.get("instance_charge_type") or "PostPaid"),
+        output_to_bucket=bool(raw.get("output_to_bucket", False)),
         snapshots=snapshots,
     )
 
@@ -372,12 +378,15 @@ def _build_run_args(
     security_group_id: str,
     cfg: AliyunProviderConfig,
     snapshot_tag: str,
+    ram_role_name: str,
 ) -> list[str]:
     """``aliyun ecs RunInstances`` argv.
 
     System-disk size is NOT passed — we use the image's baked system-disk
     snapshot size. ``InternetMaxBandwidthOut > 0`` makes ECS auto-assign a
     public IP; tags mark the box for fleet cleanup (mirror of aws's tags).
+    ``ram_role_name`` is the *effective* role (resolved + existence-checked by
+    the caller), not ``cfg.ram_role_name`` — empty means attach none.
     """
     args = [
         "--RegionId", cfg.region,
@@ -398,8 +407,8 @@ def _build_run_args(
     ]
     if cfg.key_name:
         args += ["--KeyPairName", cfg.key_name]
-    if cfg.ram_role_name:
-        args += ["--RamRoleName", cfg.ram_role_name]
+    if ram_role_name:
+        args += ["--RamRoleName", ram_role_name]
     return args
 
 
@@ -413,6 +422,7 @@ async def _try_run_in_zone(
     security_group_id: str,
     cfg: AliyunProviderConfig,
     snapshot_tag: str,
+    ram_role_name: str,
 ) -> tuple[bool, str, str]:
     """Returns (ok, stdout, stderr). On capacity error returns ok=False without
     retrying (caller moves to the next zone); transient errors retry here."""
@@ -425,6 +435,7 @@ async def _try_run_in_zone(
         security_group_id=security_group_id,
         cfg=cfg,
         snapshot_tag=snapshot_tag,
+        ram_role_name=ram_role_name,
     )
     last_stderr = ""
     for attempt in range(1, _ALIYUN_MAX_RETRIES_TRANSIENT + 1):
@@ -608,12 +619,46 @@ class AliyunProvider(Provider):
         self._image_cache: dict[str, str] = {}    # family name → image id
         self._vswitch_cache: dict[str, str] = {}  # zone id → vswitch id
         self._sg: tuple[str, str] | None = None   # (sg_id, vpc_id), resolved once
+        self._ram_role: str | None = None         # effective role name, resolved once
 
     @property
     def config(self) -> AliyunProviderConfig:
         return self._cfg
 
     # ----------------------------------------------------------- resolution
+
+    async def _effective_ram_role(self) -> str:
+        """The RAM role to actually attach — resolved + existence-checked once.
+
+        Lets the config ship a default ``ram_role_name`` (e.g. ``ale-sandbox``)
+        that a user who only runs with ``output_path: null``/``local`` never has
+        to create: if the role doesn't exist we simply don't attach it (a bare
+        ``--RamRoleName`` for a missing role is a hard ``InvalidRamRole.NotFound``
+        at RunInstances). BUT if ``output_path`` is an ``oss://`` bucket the role
+        is mandatory (the in-box ossutil needs it to upload), so a missing role
+        is a fail-fast error instead of a silent skip."""
+        if self._ram_role is not None:
+            return self._ram_role
+        name = self._cfg.ram_role_name
+        if not name:
+            self._ram_role = ""
+            return ""
+        rc, _, _ = await _run_aliyun("ram", "GetRole", "--RoleName", name)
+        if rc == 0:
+            self._ram_role = name
+        elif self._cfg.output_to_bucket:
+            raise RuntimeError(
+                f"output_path is an oss:// bucket but RAM role {name!r} does not "
+                f"exist — create it (see the Alibaba setup docs) so the sandbox "
+                f"can upload output, or unset output_path"
+            )
+        else:
+            logger.warning(
+                "RAM role %r not found — launching without it (output_path isn't "
+                "a bucket, so no in-box OSS access is needed)", name,
+            )
+            self._ram_role = ""
+        return self._ram_role
 
     async def _resolve_image(self, snap: SnapshotConfig) -> str:
         """Resolve a snapshot's image to a concrete custom-image id.
@@ -746,6 +791,9 @@ class AliyunProvider(Provider):
         # and the security-group name to its id + the VPC that scopes vSwitches.
         image_id = await self._resolve_image(snap)
         sg_id, vpc_id = await self._resolve_security_group()
+        # RAM role to attach: the configured name if it exists, else "" (skip) —
+        # unless output_path is a bucket, in which case a missing role raises.
+        ram_role = await self._effective_ram_role()
 
         name = generate_instance_name(
             self._cfg.instance_prefix,
@@ -785,6 +833,7 @@ class AliyunProvider(Provider):
                     security_group_id=sg_id,
                     cfg=self._cfg,
                     snapshot_tag=spec.snapshot,
+                    ram_role_name=ram_role,
                 )
                 if ok:
                     stdout = out

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -75,20 +75,28 @@ _ALIYUN_MAX_RETRIES_TRANSIENT = 3
 _ALIYUN_TRANSIENT_BASE_DELAY = 15          # seconds, exponential backoff
 
 # error-code/message substring → error class. transient = retry same zone;
-# zone = move to next zone (capacity); anything else = fail fast. Matched
-# case-insensitively against the aliyun CLI's stderr (which carries the API
-# ``Code`` and ``Message``).
-_ALIYUN_RETRYABLE_TRANSIENT = [
-    "throttling", "requestlimitexceeded", "rate exceeded",
-    "internalerror", "internal error", "servererror",
-    "serviceunavailable", "service unavailable", "unavailable",
-    "connection reset", "connection refused", "timed out", "timeout",
-    "could not connect", "connection aborted", "i/o timeout",
+# zone = move to next zone (capacity); anything else = fail fast.
+#
+# IMPORTANT: classify on the API **ErrorCode** (extracted by _error_code), NOT
+# the raw stderr. The aliyun CLI wraps every API failure as
+# ``ERROR: SDK.ServerError`` regardless of the underlying code, so matching the
+# wrapper string (e.g. a naive "servererror" substring) would mark EVERY error —
+# even a hard ``InvalidAccountStatus.NotEnoughBalance`` or ``InvalidImageId`` —
+# transient and burn the full retry budget on it. These patterns are matched
+# against the real ``ErrorCode:`` value; genuine transport errors (which carry no
+# ErrorCode line) are caught by _TRANSIENT_TRANSPORT against the full stderr.
+_ALIYUN_RETRYABLE_TRANSIENT = [          # matched against ErrorCode
+    "throttling", "requestlimitexceeded", "requestthrottled", "rate exceeded",
+    "internalerror", "serviceunavailable", "servicetimeout",
 ]
-_ALIYUN_RETRYABLE_ZONE = [
+_TRANSIENT_TRANSPORT = [                  # matched against full stderr (no ErrorCode)
+    "connection reset", "connection refused", "timed out", "timeout",
+    "could not connect", "connection aborted", "i/o timeout", "no such host",
+]
+_ALIYUN_RETRYABLE_ZONE = [               # matched against ErrorCode + message
     "operationdenied.nostock", "nostock", "out of stock",
-    "resource.notenough", "resourcenotavailable",
-    "zonenotsupported", "zone_not_sufficient",
+    "resource.notenough", "resourcenotavailable", "operationdenied.noschedule",
+    "zonenotsupported", "zone_not_sufficient", "zonenotsupportedforspotinstance",
     "no capacity", "not have capacity", "instancediskcategorylimitexceeded",
 ]
 
@@ -315,14 +323,30 @@ async def _run_aliyun(product: str, action: str, *args: str) -> tuple[int, str, 
     )
 
 
+def _error_code(stderr: str) -> str:
+    """Extract the API ``ErrorCode`` from the aliyun CLI's error block.
+
+    The CLI prints e.g. ``ERROR: SDK.ServerError\\nErrorCode: <code>\\n...``; we
+    classify on ``<code>`` so the generic ``SDK.ServerError`` wrapper never
+    drives retry decisions. Returns "" when no ErrorCode line is present (a pure
+    transport error)."""
+    m = re.search(r"ErrorCode:\s*([A-Za-z0-9_.\-]+)", stderr)
+    return m.group(1).lower() if m else ""
+
+
 def _is_transient_error(stderr: str) -> bool:
+    code = _error_code(stderr)
+    if code:
+        return any(pat in code for pat in _ALIYUN_RETRYABLE_TRANSIENT)
+    # No ErrorCode line → a transport/network failure; scan the raw stderr.
     lower = stderr.lower()
-    return any(pat in lower for pat in _ALIYUN_RETRYABLE_TRANSIENT)
+    return any(pat in lower for pat in _TRANSIENT_TRANSPORT)
 
 
 def _is_zone_capacity_error(stderr: str) -> bool:
-    lower = stderr.lower()
-    return any(pat in lower for pat in _ALIYUN_RETRYABLE_ZONE)
+    code = _error_code(stderr)
+    haystack = code if code else stderr.lower()
+    return any(pat in haystack for pat in _ALIYUN_RETRYABLE_ZONE)
 
 
 # ============================================================================

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -73,6 +73,10 @@ _DEFAULT_GPU_INSTANCE = "ecs.gn7i-c8g1.2xlarge"   # 8 vCPU / 30 GiB / 1x A10
 # Launch retry tuning.
 _ALIYUN_MAX_RETRIES_TRANSIENT = 3
 _ALIYUN_TRANSIENT_BASE_DELAY = 15          # seconds, exponential backoff
+# Delete retry tuning — a just-created box rejects DeleteInstance while
+# ``Initializing``; retry through that window so we never leak a billable box.
+_DELETE_MAX_RETRIES = 6
+_DELETE_RETRY_DELAY = 12                   # seconds
 
 # error-code/message substring → error class. transient = retry same zone;
 # zone = move to next zone (capacity); anything else = fail fast.
@@ -481,6 +485,7 @@ async def _wait_running_with_ip(
     ``VpcAttributes.PrivateIpAddress.IpAddress``."""
     deadline = time.monotonic() + timeout
     last_state = "?"
+    nudged = False        # whether we've issued a one-shot StartInstance
     while time.monotonic() < deadline:
         rc, stdout, stderr = await _run_aliyun(
             "ecs", "DescribeInstances",
@@ -500,9 +505,21 @@ async def _wait_running_with_ip(
                         )
                     if ip:
                         return ip
-                if last_state in ("Deleted", "Stopped"):
+                # ``Deleted`` is the only terminal failure. A freshly-created ECS
+                # instance briefly reports ``Stopped`` right after RunInstances
+                # before its auto-start transitions it Starting→Running, so we do
+                # NOT treat Stopped as terminal (doing so killed healthy boots).
+                # If it lingers Stopped, nudge it once with StartInstance in case
+                # auto-start didn't fire, then keep polling until Running/timeout.
+                elif last_state == "Deleted":
                     raise RuntimeError(
-                        f"instance {instance_id} entered {last_state} before becoming reachable"
+                        f"instance {instance_id} entered Deleted before becoming reachable"
+                    )
+                elif last_state == "Stopped" and not nudged:
+                    nudged = True
+                    await _run_aliyun(
+                        "ecs", "StartInstance",
+                        "--RegionId", cfg.region, "--InstanceId", instance_id,
                     )
             except (KeyError, IndexError, json.JSONDecodeError):
                 pass
@@ -515,18 +532,30 @@ async def _wait_running_with_ip(
 
 async def _delete(instance_id: str, cfg: AliyunProviderConfig) -> bool:
     """Force-delete the instance (``--Force true`` releases a Running box without
-    a separate stop)."""
+    a separate stop).
+
+    A box still in its post-RunInstances ``Initializing`` window rejects
+    DeleteInstance with ``IncorrectInstanceStatus.Initializing``; since a failed
+    delete leaks a billable instance, retry a few times through that window
+    before giving up."""
     logger.info("Deleting instance %s", instance_id)
-    rc, _, stderr = await _run_aliyun(
-        "ecs", "DeleteInstance",
-        "--RegionId", cfg.region,
-        "--InstanceId", instance_id,
-        "--Force", "true",
-    )
-    if rc != 0:
-        logger.error("Failed to delete %s: %s", instance_id, stderr)
-        return False
-    return True
+    last_stderr = ""
+    for attempt in range(_DELETE_MAX_RETRIES):
+        rc, _, stderr = await _run_aliyun(
+            "ecs", "DeleteInstance",
+            "--RegionId", cfg.region,
+            "--InstanceId", instance_id,
+            "--Force", "true",
+        )
+        if rc == 0:
+            return True
+        last_stderr = stderr
+        code = _error_code(stderr)
+        if "incorrectinstancestatus" not in code:
+            break
+        await asyncio.sleep(_DELETE_RETRY_DELAY)
+    logger.error("Failed to delete %s: %s", instance_id, last_stderr)
+    return False
 
 
 async def _stop(instance_id: str, cfg: AliyunProviderConfig) -> bool:

--- a/ale_run/environments/providers/aliyun.py
+++ b/ale_run/environments/providers/aliyun.py
@@ -66,21 +66,13 @@ logger = logging.getLogger(__name__)
 # Default instance when a task_card declares no ``vm.machineType``. CPU falls
 # back C→G (see _instance_chain); GPU has no instance fallback.
 _DEFAULT_CPU_INSTANCE = "ecs.g7.2xlarge"          # 8 vCPU / 32 GiB, general (UEFI ✓)
-# GPU default MUST be a UEFI-boot-capable type: the published ALE images are
-# UEFI (built on GCE), and RunInstances hard-rejects a UEFI image on a BIOS-only
-# instance type (``InvalidParameter.NotMatch: Image bootMode ...``). The common
-# PASSTHROUGH A10 ``ecs.gn7i-c8g1.2xlarge`` is BIOS-only → does NOT work. The
-# **vGPU virtual-workstation** family ``ecs.vgn7i-vws-*`` (fractional A10, e.g.
-# m4=A10*1/6, m8=A10*1/3) IS UEFI-capable AND widely in stock (cn-hangzhou +
-# most regions), and its vWS model mirrors GCE's ``nvidia-l4-vws`` — so it's both
-# the launchable and the driver-closest choice. VERIFIED live (2026-07-02): a
-# vgn7i-vws-m4 box launches the UEFI image, Windows Server 2022 boots, cua ready
-# in ~127 s. ⚠️ BUT nvidia-smi then fails ("couldn't communicate with the NVIDIA
-# driver") — the GCE-baked L4-vws driver does not bind to Alibaba's A10 vGPU, so
-# GPU compute is NOT functional until Alibaba's own A10 GRID/vGPU driver is baked
-# into the image. So GPU is a DRIVER gap now, not an infra gap. (Passthrough A10
-# ``ecs.gn7i-xr`` is UEFI too but isn't sold in most regions.)
-_DEFAULT_GPU_INSTANCE = "ecs.vgn7i-vws-m8.2xlarge"   # A10 vGPU vWS, UEFI, in stock
+# GPU tasks are NOT supported on Alibaba (the imported UEFI image's GPU driver
+# can't be made to bind to Alibaba's vGPU — see the PR for the full analysis).
+# This default is the closest launchable type (A10 vGPU vWS, UEFI-capable) and
+# is kept only so the wiring stays complete; a GPU run will not produce a working
+# GPU. Must be a UEFI-boot type — the common BIOS-only ``ecs.gn7i-c8g1`` is
+# rejected outright against the UEFI image.
+_DEFAULT_GPU_INSTANCE = "ecs.vgn7i-vws-m8.2xlarge"   # A10 vGPU vWS, UEFI-capable
 
 # Launch retry tuning.
 _ALIYUN_MAX_RETRIES_TRANSIENT = 3

--- a/ale_run/environments/providers/aws.py
+++ b/ale_run/environments/providers/aws.py
@@ -158,6 +158,11 @@ class AwsProviderConfig:
     key_name: str = ""
     iam_instance_profile: str = ""
     associate_public_ip: bool = True
+    output_to_bucket: bool = False
+    """Set by the config loader when ``output_path`` is an ``s3://`` bucket. It
+    turns a missing ``iam_instance_profile`` from a tolerated skip into a hard
+    error — without the profile the in-box aws CLI can't upload, so a bucket
+    output would silently lose every run's files."""
     snapshots: dict[str, SnapshotConfig] = dataclass_field(default_factory=dict)
 
 
@@ -212,6 +217,7 @@ def _build_provider_config(raw: dict[str, Any]) -> AwsProviderConfig:
         key_name=str(raw.get("key_name") or ""),
         iam_instance_profile=str(raw.get("iam_instance_profile") or ""),
         associate_public_ip=bool(raw.get("associate_public_ip", True)),
+        output_to_bucket=bool(raw.get("output_to_bucket", False)),
         snapshots=snapshots,
     )
 
@@ -358,9 +364,12 @@ async def _try_run_in_subnet(
     cfg: AwsProviderConfig,
     tenancy: str,
     snapshot_tag: str,
+    iam_instance_profile: str,
 ) -> tuple[bool, str, str]:
     """Returns (ok, stdout, stderr). On capacity error returns ok=False without
-    retrying (caller moves to the next subnet); transient errors retry here."""
+    retrying (caller moves to the next subnet); transient errors retry here.
+    ``iam_instance_profile`` is the *effective* profile (existence-checked by the
+    caller), not ``cfg.iam_instance_profile`` — empty means attach none."""
     args = _build_run_args(
         name=name,
         image=image,
@@ -368,7 +377,7 @@ async def _try_run_in_subnet(
         subnet=subnet,
         security_group_id=security_group_id,
         key_name=cfg.key_name,
-        iam_instance_profile=cfg.iam_instance_profile,
+        iam_instance_profile=iam_instance_profile,
         associate_public_ip=cfg.associate_public_ip,
         tenancy=tenancy,
         snapshot_tag=snapshot_tag,
@@ -503,12 +512,49 @@ class AwsProvider(Provider):
         self._ami_cache: dict[str, str] = {}     # family name → ami id
         self._subnet_cache: dict[str, str] = {}  # az name → subnet id
         self._sg: tuple[str, str] | None = None  # (sg_id, vpc_id), resolved once
+        self._iam_profile: str | None = None     # effective profile, resolved once
 
     @property
     def config(self) -> AwsProviderConfig:
         return self._cfg
 
     # ----------------------------------------------------------- resolution
+
+    async def _effective_iam_profile(self) -> str:
+        """The instance profile to actually attach — resolved + existence-checked
+        once. Lets the config ship a default ``iam_instance_profile`` (e.g.
+        ``ale-sandbox``) that a user who only runs with ``output_path: null``/
+        ``local`` never has to create: if the profile doesn't exist we don't
+        attach it (``--iam-instance-profile Name=<missing>`` fails the launch).
+        BUT if ``output_path`` is an ``s3://`` bucket the profile is mandatory
+        (the in-box aws CLI needs it to upload), so a missing profile is a
+        fail-fast error instead of a silent skip."""
+        if self._iam_profile is not None:
+            return self._iam_profile
+        name = self._cfg.iam_instance_profile
+        if not name:
+            self._iam_profile = ""
+            return ""
+        rc, _, _ = await _run_aws(
+            "iam", "get-instance-profile", "--instance-profile-name", name,
+            region=self._cfg.region,
+        )
+        if rc == 0:
+            self._iam_profile = name
+        elif self._cfg.output_to_bucket:
+            raise RuntimeError(
+                f"output_path is an s3:// bucket but IAM instance profile {name!r} "
+                f"does not exist — create it (see the AWS setup docs) so the "
+                f"sandbox can upload output, or unset output_path"
+            )
+        else:
+            logger.warning(
+                "IAM instance profile %r not found — launching without it "
+                "(output_path isn't a bucket, so no in-box S3 access is needed)",
+                name,
+            )
+            self._iam_profile = ""
+        return self._iam_profile
 
     async def _resolve_ami(self, snap: SnapshotConfig) -> str:
         """Resolve a snapshot's image to a concrete AMI id.
@@ -624,6 +670,9 @@ class AwsProvider(Provider):
         # and the security-group name to its id + the VPC that scopes subnets.
         ami_id = await self._resolve_ami(snap)
         sg_id, vpc_id = await self._resolve_security_group()
+        # instance profile to attach: the configured name if it exists, else ""
+        # (skip) — unless output_path is a bucket, in which case a miss raises.
+        iam_profile = await self._effective_iam_profile()
 
         name = generate_instance_name(
             self._cfg.instance_prefix,
@@ -663,6 +712,7 @@ class AwsProvider(Provider):
                     cfg=self._cfg,
                     tenancy=snap.tenancy,
                     snapshot_tag=spec.snapshot,
+                    iam_instance_profile=iam_profile,
                 )
                 if ok:
                     stdout = out

--- a/ale_run/environments/task_data/__init__.py
+++ b/ale_run/environments/task_data/__init__.py
@@ -6,6 +6,7 @@ Three sources today, dispatched on yaml ``artifacts_path.task_data_source``:
   ``"baked_in_sandbox"``     image already has input/ + reference.7z baked in
   ``"gs://<bucket>"``        rsync from a GCS bucket
   ``"s3://<bucket>"``        sync from an S3 bucket
+  ``"oss://<bucket>"``       sync from an Alibaba Cloud OSS bucket
   ``"hf://<dataset>"``       HuggingFace Hub (STUB)
   ``"local:<host_dir>"``     docker cp from a HOST dir — for a data-less Docker
                              image: input before the agent, reference before eval
@@ -47,6 +48,9 @@ def select(task_data_source: str):
     if task_data_source.startswith("s3://"):
         from . import s3bucket
         return s3bucket
+    if task_data_source.startswith("oss://"):
+        from . import ossbucket
+        return ossbucket
     if task_data_source.startswith("hf://"):
         from . import huggingface
         return huggingface
@@ -55,7 +59,8 @@ def select(task_data_source: str):
         return local_host
     raise ValueError(
         f"unknown task_data_source {task_data_source!r}: expected "
-        f"'baked_in_sandbox', 'gs://<bucket>', 's3://<bucket>', 'hf://<dataset>', "
+        f"'baked_in_sandbox', 'gs://<bucket>', 's3://<bucket>', 'oss://<bucket>', "
+        f"'hf://<dataset>', "
         f"or 'local:<dir>'"
     )
 

--- a/ale_run/environments/task_data/ossbucket.py
+++ b/ale_run/environments/task_data/ossbucket.py
@@ -1,0 +1,156 @@
+"""``task_data_source: oss://<bucket>`` — pull task data from an Alibaba Cloud
+OSS bucket.
+
+Mirror of :mod:`ale_run.environments.task_data.s3bucket` / ``gsbucket``, using
+the in-box ``ossutil`` CLI instead of ``aws s3`` / ``gsutil``.
+
+Behavior (identical to the others):
+
+* ``stage_input``: pull ``<oss_prefix>/input`` and ``<oss_prefix>/software`` to
+  the sandbox. **Skip if already on the sandbox** (image-baked data intact).
+* ``stage_reference``: always wipe + fresh sync. Reference is eval truth.
+
+OSS auth: ECS instances launched by :class:`~ale_run.environments.providers.aliyun.AliyunProvider`
+carry an **instance RAM role** (``ram_role_name``), so the in-box ``ossutil``
+authenticates via STS credentials pulled from instance metadata — there is no
+key to inject (contrast gcloud, which pushes an SA key into each VM; like aws,
+which relies on the instance profile). The image must therefore have ``ossutil``
+on PATH AND a baked ``~/.ossutilconfig`` that sets ``mode=EcsRamRole`` +
+``ramRoleName=<role>`` + the region OSS ``endpoint`` (use the
+``oss-<region>-internal.aliyuncs.com`` endpoint from inside ECS to avoid public
+egress); the AliyunProvider images bake both.
+"""
+from __future__ import annotations
+
+import logging
+import shlex
+from typing import Any
+
+from ...base_interface import SandboxHandle, TaskDataSpec
+from . import join, task_subdir
+
+logger = logging.getLogger(__name__)
+
+
+async def stage_input(
+    sandbox: SandboxHandle, task_data: TaskDataSpec, *, source: str,
+) -> dict[str, Any]:
+    oss_prefix = _oss_prefix(source, task_data)
+    base = task_subdir(sandbox, task_data)
+    await sandbox.mkdir(base)
+
+    staged: list[str] = []
+    for subdir in ("input", "software"):
+        dst = join(sandbox, base, subdir)
+        if await _has_baked_files(sandbox, dst):
+            logger.info("ossbucket: %s already present on sandbox, skipping sync", dst)
+            staged.append(f"{subdir}(baked)")
+            continue
+        src = f"{oss_prefix}/{subdir}"
+        if not await _oss_exists(sandbox, src):
+            await sandbox.mkdir(dst)
+            continue
+        r = await sandbox.run_command(_sync_cmd(sandbox, src, dst), timeout=600)
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"ossutil sync {subdir} failed (rc={r.returncode}): "
+                f"{(r.stderr or '')[:300]}"
+            )
+        if subdir == "software" and sandbox.is_linux:
+            await sandbox.run_command(
+                f"find {shlex.quote(dst)} -type f -exec chmod +x {{}} +",
+                timeout=60,
+            )
+        staged.append(subdir)
+
+    await sandbox.mkdir(join(sandbox, base, "output"))
+    return {"staged": staged, "source": source}
+
+
+async def stage_reference(
+    sandbox: SandboxHandle, task_data: TaskDataSpec, *, source: str,
+) -> dict[str, Any]:
+    oss_prefix = _oss_prefix(source, task_data)
+    base = task_subdir(sandbox, task_data)
+    src = f"{oss_prefix}/reference"
+    dst = join(sandbox, base, "reference")
+
+    if not await _oss_exists(sandbox, src):
+        return {"skipped": True, "reason": "no_reference_on_oss"}
+
+    await sandbox.rm([dst])
+    r = await sandbox.run_command(_sync_cmd(sandbox, src, dst), timeout=600)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"ossutil sync reference failed (rc={r.returncode}): "
+            f"{(r.stderr or '')[:300]}"
+        )
+    # ossutil sync does not preserve POSIX mode bits; normalize like gsbucket so
+    # grading sees predictable perms.
+    if sandbox.is_linux:
+        await sandbox.run_command(f"chmod -R 777 {shlex.quote(dst)}", timeout=60)
+    return {"staged": ["reference"], "source": source}
+
+
+# ---- helpers ----
+
+
+def _oss_prefix(source: str, task_data: TaskDataSpec) -> str:
+    return (
+        f"{source.rstrip('/')}/{task_data.domain_name}/"
+        f"{task_data.task_name}/{task_data.variant_name}"
+    )
+
+
+async def _has_baked_files(sandbox: SandboxHandle, path: str) -> bool:
+    if not await sandbox.exists(path):
+        return False
+    entries = await sandbox.list_dir(path)
+    return any(not e["is_dir"] for e in entries)
+
+
+# The task-data bucket is requester-pays (the puller's account is billed, not
+# the owner's — mirrors gcloud's ale-data-public / aws's requester-pays bucket).
+# Every read must carry --payer requester or OSS returns AccessDenied.
+_RP = "--payer requester"
+
+
+async def _oss_exists(sandbox: SandboxHandle, oss_url: str) -> bool:
+    """True if the prefix has at least one object.
+
+    ``ossutil ls`` exits 0 even for an empty prefix (unlike ``aws s3 ls``), so —
+    rather than rely on the exit code — we ask for at most one object and parse
+    the ``Object Number is: N`` summary line ossutil prints."""
+    url = oss_url.rstrip("/") + "/"
+    if sandbox.is_linux:
+        cmd = f"ossutil ls {_RP} {shlex.quote(url)} --limited-num 1"
+    else:
+        cmd = (
+            "powershell -NoProfile -Command \""
+            f"ossutil ls {_RP} '{url}' --limited-num 1\""
+        )
+    r = await sandbox.run_command(cmd, timeout=30)
+    if r.returncode != 0:
+        return False
+    out = (r.stdout or "")
+    # "Object Number is: 0" → empty; any object line starts with the oss:// url.
+    if "Object Number is: 0" in out:
+        return False
+    return "oss://" in out or "Object Number is:" in out and "Object Number is: 0" not in out
+
+
+def _sync_cmd(sandbox: SandboxHandle, src: str, dst: str) -> str:
+    # ossutil sync mirrors `aws s3 sync` / `gsutil rsync`: it copies the prefix
+    # tree under src into dst. Trailing slashes force directory semantics.
+    src = src.rstrip("/") + "/"
+    if sandbox.is_linux:
+        return (
+            f"mkdir -p {shlex.quote(dst)} && "
+            f"ossutil sync {_RP} {shlex.quote(src)} {shlex.quote(dst)}"
+        )
+    return (
+        'powershell -NoProfile -Command "'
+        f"New-Item -ItemType Directory -Force -Path '{dst}' | Out-Null; "
+        f"ossutil sync {_RP} '{src}' '{dst}'"
+        '"'
+    )

--- a/ale_run/orchestration/config_loader.py
+++ b/ale_run/orchestration/config_loader.py
@@ -439,6 +439,16 @@ def _build_environment_from_path(
             f"environment config {path!r} must declare either `snapshots:` "
             f"(per-snapshot provider mapping) or `provider:` (single provider)"
         )
+
+    # aws/aliyun attach an instance role for bucket output; tell the provider
+    # whether output actually targets its bucket, so a missing role becomes a
+    # hard error (bucket output can't work without it) rather than a tolerated
+    # skip (see AliyunProvider._effective_ram_role / the aws counterpart).
+    out = artifacts.output_path or ""
+    if out.startswith("s3://") and "aws" in env.provider_specs:
+        env.provider_specs["aws"].config["output_to_bucket"] = True
+    if out.startswith("oss://") and "aliyun" in env.provider_specs:
+        env.provider_specs["aliyun"].config["output_to_bucket"] = True
     return env, artifacts
 
 

--- a/ale_run/orchestration/config_loader.py
+++ b/ale_run/orchestration/config_loader.py
@@ -282,10 +282,11 @@ def _build_artifacts(raw: dict[str, Any]) -> ArtifactsSpec:
     if output_path is not None:
         op = str(output_path).strip()
         if (op and op not in _VALID_OUTPUT_PATH_LITERALS
-                and not op.startswith("gs://") and not op.startswith("s3://")):
+                and not op.startswith("gs://") and not op.startswith("s3://")
+                and not op.startswith("oss://")):
             raise ValueError(
                 f"artifacts_path.output_path must be null, 'local', or a "
-                f"'gs://...'/'s3://...' bucket path; got {output_path!r}"
+                f"'gs://...'/'s3://...'/'oss://...' bucket path; got {output_path!r}"
             )
         output_path = op or None
 
@@ -294,11 +295,13 @@ def _build_artifacts(raw: dict[str, Any]) -> ArtifactsSpec:
     if (tdp not in _VALID_TASK_DATA_LITERALS
             and not tdp.startswith("gs://")
             and not tdp.startswith("s3://")
+            and not tdp.startswith("oss://")
             and not tdp.startswith("hf://")
             and not tdp.startswith("local:")):
         raise ValueError(
             f"artifacts_path.task_data_source must be 'baked_in_sandbox', "
-            f"'gs://<bucket>', 's3://<bucket>', 'hf://<dataset>', or 'local:<dir>'; "
+            f"'gs://<bucket>', 's3://<bucket>', 'oss://<bucket>', 'hf://<dataset>', "
+            f"or 'local:<dir>'; "
             f"got {task_data_source!r}"
         )
 
@@ -382,6 +385,15 @@ _AWS_CRED_KEYS = (
 # `tenancy` and `ami` are intentionally NOT cred keys: they are per-snapshot
 # routing (tenancy: Linux default vs Windows-client dedicated; ami: optional
 # explicit AMI override) so one env can mix both.
+# aliyun connection fields that belong to the provider as a whole (vs the
+# per-snapshot routing fields image/zones/gpu). Repeated on each aliyun
+# snapshot's block and reconciled here into one provider config. `image_id` is
+# intentionally NOT a cred key: it is a per-snapshot explicit-image override, so
+# one env can pin different images per snapshot.
+_ALIYUN_CRED_KEYS = (
+    "region", "security_group", "instance_prefix", "key_name", "ram_role_name",
+    "internet_max_bandwidth_out", "system_disk_category", "instance_charge_type",
+)
 
 
 def _build_environment_from_path(
@@ -466,6 +478,8 @@ def _build_per_snapshot_env(raw: dict[str, Any], path: str) -> EnvironmentSpec:
     gcloud_creds: dict[str, Any] = {}   # project/sa/network/... (reconciled, last wins)
     aws_snaps: dict[str, Any] = {}      # tag -> {image(AMI), gpu, zones(subnets)}
     aws_creds: dict[str, Any] = {}      # region/sg/profile/... (reconciled, last wins)
+    aliyun_snaps: dict[str, Any] = {}   # tag -> {image, gpu, zones(zone ids)}
+    aliyun_creds: dict[str, Any] = {}   # region/sg/ram_role/... (reconciled, last wins)
     docker_cfg: dict[str, Any] | None = None
     qemu_snaps: dict[str, Any] = {}
 
@@ -500,6 +514,14 @@ def _build_per_snapshot_env(raw: dict[str, Any], path: str) -> EnvironmentSpec:
             if entry.get("resolution") is not None:
                 snap_entry["resolution"] = entry["resolution"]
             aws_snaps[str(tag)] = snap_entry
+        elif kind == "aliyun":
+            # same split as gcloud: provider-wide creds vs per-snapshot routing.
+            aliyun_creds.update({k: knobs[k] for k in _ALIYUN_CRED_KEYS if k in knobs})
+            routing = {k: v for k, v in knobs.items() if k not in _ALIYUN_CRED_KEYS}
+            snap_entry = {"image": str(image), **routing}
+            if entry.get("resolution") is not None:
+                snap_entry["resolution"] = entry["resolution"]
+            aliyun_snaps[str(tag)] = snap_entry
         elif kind == "docker":
             # docker carries just the image NAME + sizing knobs; the provider
             # resolves the container ref + port from the Image entry. Multiple
@@ -551,6 +573,13 @@ def _build_per_snapshot_env(raw: dict[str, Any], path: str) -> EnvironmentSpec:
         # instance profile, so nothing is injected for s3:// staging/output.
         _validate_provider_required("aws", aw, path)
         provider_specs["aws"] = ProviderSpec(kind="aws", config=aw)
+    if aliyun_snaps:
+        al = dict(aliyun_creds)
+        al["snapshots"] = aliyun_snaps
+        # No gcs_sa_key counterpart: ECS boxes authenticate to OSS via their
+        # instance RAM role, so nothing is injected for oss:// staging/output.
+        _validate_provider_required("aliyun", al, path)
+        provider_specs["aliyun"] = ProviderSpec(kind="aliyun", config=al)
     if docker_cfg is not None:
         dk = dict(docker_cfg)
         if gcs_sa_key:
@@ -588,6 +617,12 @@ def _validate_provider_required(provider: str, cfg: dict[str, Any], path: str = 
             raise KeyError(
                 f"environment provider=aws missing required field `region`{where} "
                 f"(set it on each aws snapshot's `aws:` block)"
+            )
+    elif provider == "aliyun":
+        if not cfg.get("region"):
+            raise KeyError(
+                f"environment provider=aliyun missing required field `region`{where} "
+                f"(set it on each aliyun snapshot's `aliyun:` block)"
             )
     elif provider == "static":
         if not cfg.get("endpoint"):

--- a/ale_run/orchestration/experiment_spec.py
+++ b/ale_run/orchestration/experiment_spec.py
@@ -49,7 +49,7 @@ class AgentSpec:
 class ProviderSpec:
     """VM provider selection. ``kind`` picks the impl; ``config`` is its kwargs."""
 
-    kind: str                             # gcloud | aliyun | static | docker | qemu | (stub for tests)
+    kind: str                             # gcloud | aws | aliyun | static | docker | qemu | (stub for tests)
     config: dict[str, Any] = field(default_factory=dict)
 
 

--- a/ale_run/orchestration/experiment_spec.py
+++ b/ale_run/orchestration/experiment_spec.py
@@ -49,7 +49,7 @@ class AgentSpec:
 class ProviderSpec:
     """VM provider selection. ``kind`` picks the impl; ``config`` is its kwargs."""
 
-    kind: str                             # gcloud | static | docker | qemu | (stub for tests)
+    kind: str                             # gcloud | aliyun | static | docker | qemu | (stub for tests)
     config: dict[str, Any] = field(default_factory=dict)
 
 

--- a/ale_run/orchestration/experiment_spec.py
+++ b/ale_run/orchestration/experiment_spec.py
@@ -90,7 +90,8 @@ class ArtifactsSpec:
     ``task_data_source`` selects where task data comes from:
     ``"baked_in_sandbox"`` (image already has it — the default), a
     ``"gs://<bucket>"`` prefix (rsync from GCS; public mirror is
-    ``gs://ale-data-public``), or ``"hf://<dataset>"``.
+    ``gs://ale-data-public``), an ``"oss://<bucket>"`` prefix (ossutil sync
+    from Alibaba Cloud OSS), or ``"hf://<dataset>"``.
 
     ``output_path`` controls what happens to the env's output dir after the
     agent finishes. Tri-state:
@@ -101,8 +102,9 @@ class ArtifactsSpec:
     * ``"local"`` — pull files from the VM straight to
       ``<run_dir>/output/`` via cua HTTP (no GCS round-trip). Right for
       dev / smoke / small outputs.
-    * ``"gs://<bucket>[/<prefix>]"`` — push from the VM to that GCS
-      bucket via ``gsutil`` (one hop, fast on large dirs). Nothing lands
+    * ``"gs://<bucket>[/<prefix>]"`` / ``"oss://<bucket>[/<prefix>]"`` — push
+      from the VM to that GCS / Alibaba Cloud OSS bucket via ``gsutil`` /
+      ``ossutil`` (one hop, fast on large dirs). Nothing lands
       on the host run dir in this mode. Right for large-scale batches
       where you'll process outputs later out-of-band. Hard fail if GCS
       push fails — no fallback in V1.

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -173,6 +173,9 @@ def build_provider(spec: "ProviderSpec") -> "Provider":
     if kind == "aws":
         from ..environments.providers.aws import AwsProvider
         return AwsProvider(spec.config)
+    if kind == "aliyun":
+        from ..environments.providers.aliyun import AliyunProvider
+        return AliyunProvider(spec.config)
     if kind == "static":
         from ..environments.providers.static import StaticProvider
         return StaticProvider(spec.config)

--- a/ale_run/orchestration/lifecycle.py
+++ b/ale_run/orchestration/lifecycle.py
@@ -863,6 +863,22 @@ async def pull_agent_output(
             writer.emit_event("output_gather_failed", transport="s3", error=str(e))
         return
 
+    # oss:// case
+    if output_path.startswith("oss://"):
+        try:
+            report = await output_pull.push_to_oss(
+                env.sandbox, task_data, run_id=run_id, bucket=output_path,
+            )
+            writer.emit_event(
+                "output_gather_done",
+                transport="oss",
+                oss_path=report.get("oss_path"),
+            )
+        except Exception as e:
+            logger.warning("push_to_oss failed (best-effort): %s", e)
+            writer.emit_event("output_gather_failed", transport="oss", error=str(e))
+        return
+
     # gs:// case
     if not output_path.startswith("gs://"):
         # loader validates this, so reaching here would mean a bypassed path.

--- a/ale_run/orchestration/lifecycle.py
+++ b/ale_run/orchestration/lifecycle.py
@@ -800,6 +800,7 @@ async def pull_agent_output(
       None         → emit ``output_gather_skipped`` reason=unconfigured
       ``"local"``  → provider-local pull → ``<run_dir>/output/``
       ``"gs://X"`` → push from VM to ``X/<run_id>/output/`` via gsutil
+      ``"oss://X"`` → push from VM to ``X/<run_id>/output/`` via ossutil
 
     Best-effort throughout: any failure emits an event + logs a warning
     but never aborts the run (eval still runs on the live env regardless).
@@ -954,6 +955,7 @@ async def _stage_task_data(
     Dispatches on ``artifacts_path.task_data_source``:
       ``"baked_in_sandbox"``  — image already has data; sanity-check only
       ``"gs://..."``          — gsutil rsync from a GCS bucket
+      ``"oss://..."``         — ossutil sync from an Alibaba Cloud OSS bucket
       ``"hf://..."``          — HuggingFace (stub)
 
     Returns silently when the task declares no data-staging requirements.
@@ -974,8 +976,9 @@ async def _stage_task_data(
 def _task_data_source(artifacts: ArtifactsSpec | None) -> str:
     """Where to source task data from (yaml ``artifacts_path.task_data_source``).
 
-    One of ``"baked_in_sandbox"`` / ``"gs://<bucket>"`` / ``"hf://<dataset>"``.
-    Defaults to the dataclass default when no ArtifactsSpec was built.
+    One of ``"baked_in_sandbox"`` / ``"gs://<bucket>"`` / ``"oss://<bucket>"`` /
+    ``"hf://<dataset>"``. Defaults to the dataclass default when no
+    ArtifactsSpec was built.
     """
     if artifacts is None:
         return ArtifactsSpec().task_data_source

--- a/configs/environments/docker.yaml
+++ b/configs/environments/docker.yaml
@@ -19,5 +19,6 @@ snapshots:
       shm_size: 2g
       resolution: [1024, 768]
 task_data_source: local:task-data
-output_path: local
+output_path: null
+# output_path: local          # uncomment to fetch each run's output back to the host
 gcs_sa_key: secret/gcp_key.json

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -28,20 +28,30 @@
 # VALIDATION STATUS (be honest — these differ by what was actually run):
 #   • cpu-free-ubuntu (Linux)  — ✅ validated end-to-end on cn-hangzhou (acquire
 #                                → cua → agent → eval → delete).
-#   • cpu-free / cpu-license (ale-win10, Windows) — ⚠️ WIRED, NOT YET TESTED on
-#                                Alibaba. No Windows image has been imported here
-#                                yet; the win10 boot + cua-on-Windows path is
-#                                unverified on ECS.
-#   • gpu-free / gpu-license (GPU) — ⚠️ WIRED, NOT YET TESTED, and likely needs
-#                                driver work: the published images bake the
-#                                **gcloud/AWS L4** GPU driver, but Alibaba's GPU
-#                                family here is **gn7i = NVIDIA A10** (a DIFFERENT
-#                                GPU). The baked L4 driver is NOT expected to bind
-#                                to A10 without a re-baked A10 driver. Treat GPU
-#                                as experimental until a gn7i box is launched and
-#                                `nvidia-smi` / the GPU app stack is verified
-#                                in-guest. (AWS likewise ships GPU "wired but
-#                                untested".)
+#   • cpu-free / cpu-license (Windows, ale-win10) — ✅ boot + cua VALIDATED on
+#                                cn-hangzhou (win10 → "Windows 10 Pro", cua ready
+#                                ~144 s on ecs.g7). ale-win-server likewise (→
+#                                "Windows Server 2022"). NOTE on IMPORT: a Windows
+#                                image MUST be imported with an explicit
+#                                `--Platform "Windows Server 2022"` (OSType=windows)
+#                                so Alibaba injects the virtio NIC driver; omitting
+#                                Platform auto-detects it as Linux → the guest boots
+#                                with no NIC and cua never connects. On a non-GPU box
+#                                the Windows display adapter only offers 800x600, so
+#                                `resolution:` best-fits down (logged, not fatal).
+#   • gpu-free / gpu-license (GPU) — ⚠️ WIRED, NOT yet runnable on cn-hangzhou.
+#                                BLOCKER is boot-mode + stock, BEFORE the driver
+#                                question: the ALE images are UEFI, but the GPU
+#                                types with stock here (ecs.gn7i-c8g1 A10, gn6i T4,
+#                                gn6v V100) are BIOS-only and reject a UEFI image at
+#                                launch. UEFI-capable GPU types — ecs.gn7i-xr (A10),
+#                                ecs.gn6t (T4) — are either not sold in cn-hangzhou
+#                                (gn7i-xr) or out of stock (gn6t). So a GPU box can't
+#                                even launch here yet. Even once it does, the baked
+#                                GPU driver is the gcloud/AWS L4 driver, so binding
+#                                to an A10/T4 is a further unknown (likely a re-bake).
+#                                Override `vm.machineType` to a UEFI GPU type your
+#                                region actually sells, or rebuild the image for BIOS.
 # ----------------------------------------------------------------------------
 
 snapshots:

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -1,101 +1,27 @@
 # ============================================================================
-# environment_aliyun.yaml — run ALE on Alibaba Cloud (ECS + OSS). Aliyun
-# counterpart of environment.yaml / environment_aws.yaml; same per-snapshot
-# model and the SAME image-family names.
+# environment_aliyun.yaml — run ALE on Alibaba Cloud (ECS + OSS). Alibaba
+# counterpart of environment.yaml; same per-snapshot model and the SAME
+# image-family names.
 # ============================================================================
-# Like the gcloud/aws envs, everything here is a hardcoded convention. There are
-# NO ${env:...} references: Alibaba credentials come from the ambient chain
-# (`aliyun configure` profile / ALIBABA_CLOUD_ACCESS_KEY_ID +
-# ALIBABA_CLOUD_ACCESS_KEY_SECRET env), and the VPC, vSwitches and images are
-# resolved at run time by name/tag (set up once per the Alibaba setup docs):
-#   • image            image-FAMILY name (registry key under
-#                      ale_run/environments/images/) → resolved to the newest
-#                      self-owned image tagged `ale:image-family=<name>`. Pin one
-#                      with `image_id:`.
-#   • security_group   the firewall by NAME (gcloud analogue: `network`). The
-#                      provider resolves it to its id + the VPC it lives in; that
-#                      VPC scopes the zone→vSwitch lookup.
+# Hardcoded conventions, no ${env:...} — Alibaba credentials come from your CLI
+# profile (`aliyun configure`) or the ALIBABA_CLOUD_ACCESS_KEY_* env vars; the
+# VPC, vSwitches and images are resolved by name/tag at run time (created once
+# per the docs/ale-docs-site Alibaba setup page). Per snapshot:
+#   • image            image family: ale-ubuntu22 (Linux) or ale-win10 /
+#                      ale-win-server (Windows — pick either).
+#   • security_group   the firewall, by name (gcloud analogue: `network`).
 #   • zones            Alibaba zone ids, tried in order on capacity errors.
-#   • resolution       [w, h] forced Windows desktop framebuffer (sibling of
-#                      `image:`). WINDOWS-ONLY by design — Linux/X picks its own
-#                      size and ignores it, so the Ubuntu snapshot sets none.
-#                      Same rule as gcloud/aws (see environment.yaml's note).
-#   • gpu              truthy → a GPU instance type (gn7i / NVIDIA A10).
-#   • ram_role_name    instance RAM role for in-box OSS access (only needed for
-#                      oss:// task data / output) — Alibaba analogue of AWS's
-#                      IAM instance profile.
+#   • resolution       [w, h] Windows desktop size (Windows only; Linux ignores it).
+#   • ram_role_name    instance RAM role for in-box OSS access (only for oss://
+#                      task data / output).
 #
-# VALIDATION STATUS (be honest — these differ by what was actually run):
-#   • cpu-free-ubuntu (Linux)  — ✅ validated end-to-end on cn-hangzhou (acquire
-#                                → cua → agent → eval → delete).
-#   • cpu-free / cpu-license (Windows, ale-win10) — ✅ boot + cua VALIDATED on
-#                                cn-hangzhou (win10 → "Windows 10 Pro", cua ready
-#                                ~144 s on ecs.g7). ale-win-server likewise (→
-#                                "Windows Server 2022"). NOTE on IMPORT: a Windows
-#                                image MUST be imported with an explicit
-#                                `--Platform "Windows Server 2022"` (OSType=windows)
-#                                so Alibaba injects the virtio NIC driver; omitting
-#                                Platform auto-detects it as Linux → the guest boots
-#                                with no NIC and cua never connects. On a non-GPU box
-#                                the Windows display adapter only offers 800x600, so
-#                                `resolution:` best-fits down (logged, not fatal).
-#   • gpu-free / gpu-license (GPU) — ⚠️ launches + boots, but the GPU DRIVER is
-#                                not functional (this is now a driver gap, NOT an
-#                                infra gap). Full 2026-07-02 live finding:
-#                                  – The default GPU type is the vGPU vWS family
-#                                    ecs.vgn7i-vws-* (fractional A10, UEFI-capable,
-#                                    in stock in cn-hangzhou + most regions). Do
-#                                    NOT use passthrough ecs.gn7i-c8g1 (BIOS-only →
-#                                    rejects the UEFI image) or ecs.gn7i-xr (UEFI
-#                                    but not sold in most regions).
-#                                  – VERIFIED: a vgn7i-vws-m4 box launches the UEFI
-#                                    ale-win-server image, Windows Server 2022 boots,
-#                                    cua ready ~127 s. ✅ infra path works.
-#                                  – BUT `nvidia-smi` fails: "couldn't communicate
-#                                    with the NVIDIA driver". Root cause (probed via
-#                                    Cloud Assistant): the vGPU shows up as
-#                                    "NVIDIA A10-8Q" but its driver service is
-#                                    DISABLED (CM_PROB_DISABLED_SERVICE), and a
-#                                    PHANTOM "NVIDIA L4" device lingers — the GCE
-#                                    image ships the L4 vWS driver (582.16), which is
-#                                    both the wrong GPU and a newer version than the
-#                                    Alibaba vGPU host expects (A10 wants GRID 475.14).
-#                                    Alibaba's auto-installer (Cloud Assistant
-#                                    grid_driver_install — the agent IS present on the
-#                                    imported image) uninstalls 582.16 but then FAILS
-#                                    to install 475.14 ("install failed, reboot and
-#                                    retry", empty output) — the leftover L4 driver +
-#                                    disabled-service state on this GCE-derived image
-#                                    breaks the clean install (native Alibaba images
-#                                    don't hit this). ❌ GPU compute unusable until a
-#                                    CLEAN bake of Alibaba's GRID 475.14 (purge the
-#                                    GCE L4 driver/phantom devices first, or build the
-#                                    Windows image from an Alibaba-native base). A
-#                                    scoped image-build task, NOT a config change.
-#                                    Exhaustively confirmed unfixable IN-PLACE
-#                                    (2026-07-04): FOUR install routes — Cloud
-#                                    Assistant grid_driver_install, reboot+retry,
-#                                    the bundled grid_intaller.exe run directly, and
-#                                    with the display-capturing software stopped —
-#                                    ALL fail identically & instantly at
-#                                    "InstallGpuDriver output: []". The A10-8Q stays
-#                                    CM_PROB_DISABLED_SERVICE. The installer is an
-#                                    opaque Alibaba binary that bails on the imported
-#                                    image; the 475.14 package isn't separately
-#                                    obtainable (NVIDIA vGPU needs the licensing
-#                                    portal). So GPU truly needs an Alibaba-native
-#                                    Windows image base — out of scope for a config /
-#                                    driver-install fix on the GCE-derived image.
-#                                  – Also tried + rejected: --BootMode BIOS re-import
-#                                    to use in-stock BIOS A10 (gn7i-c8g1) — launches
-#                                    but Windows never boots (UEFI/GPT image has no
-#                                    MBR boot code; a BootMode metadata flip is not
-#                                    bootable).
+# GPU tasks are NOT supported on Alibaba Cloud. The gpu-* snapshots below are
+# left in place for parity but will not run; use the cpu-* snapshots.
 # ----------------------------------------------------------------------------
 
 snapshots:
 
-  cpu-free-ubuntu:            # Linux, no GPU — the bulk of tasks
+  cpu-free-ubuntu:            # Linux — the bulk of tasks
     provider: aliyun
     image: ale-ubuntu22
     aliyun:
@@ -104,7 +30,7 @@ snapshots:
       instance_prefix: ale
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
-  cpu-free:                   # Windows, no GPU
+  cpu-free:                   # Windows
     provider: aliyun
     image: ale-win10
     resolution: [1024, 768]
@@ -114,7 +40,7 @@ snapshots:
       instance_prefix: ale
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
-  cpu-license:                # Windows requiring a licensed image (same family)
+  cpu-license:                # Windows (licensed-software tasks)
     provider: aliyun
     image: ale-win10
     resolution: [1024, 768]
@@ -124,35 +50,35 @@ snapshots:
       instance_prefix: ale
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
-  gpu-free:                   # GPU Windows — ⚠️ untested on Alibaba (see header)
+  gpu-free:                   # Windows + GPU — NOT SUPPORTED on Alibaba
     provider: aliyun
-    image: ale-win-server     # mirrors AWS; gcloud uses ale-win10. UNVERIFIED here.
+    image: ale-win-server
     resolution: [1920, 1080]
     aliyun:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
-      gpu: nvidia-a10         # truthy → gn7i (A10). NOTE: baked driver is L4, not A10.
+      gpu: nvidia-a10
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
-  gpu-license:                # GPU Windows, licensed tasks — ⚠️ untested (see header)
+  gpu-license:                # Windows + GPU (licensed) — NOT SUPPORTED on Alibaba
     provider: aliyun
-    image: ale-win-server     # mirrors AWS; gcloud uses ale-win10. UNVERIFIED here.
+    image: ale-win-server
     resolution: [1920, 1080]
     aliyun:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
-      gpu: nvidia-a10         # baked driver is L4, not A10 — likely needs re-bake
+      gpu: nvidia-a10
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
 # ---------------------------------------------------------------------------
-# Task data + output (substrate-coupled; mirrors environment.yaml).
+# Task data + output (mirrors environment.yaml).
 # ---------------------------------------------------------------------------
-# "baked_in_sandbox" (data baked into the image) | "oss://<bucket>".
+# Where task data comes from: "baked_in_sandbox" (baked into the image) | "oss://<bucket>".
 task_data_source: baked_in_sandbox
 
-# Output after the run: null | "local" | "oss://<bucket>". For full benchmark
-# runs set this to your results bucket and add `ram_role_name: ale-sandbox` to
-# each snapshot's aliyun: block (the in-box ossutil writes via the instance role).
+# What to do with each run's output: null | "local" | "oss://<bucket>". To keep
+# output in OSS, set the bucket here and add `ram_role_name: ale-sandbox` to each
+# snapshot's aliyun: block.
 output_path: local

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -16,10 +16,32 @@
 #                      provider resolves it to its id + the VPC it lives in; that
 #                      VPC scopes the zone→vSwitch lookup.
 #   • zones            Alibaba zone ids, tried in order on capacity errors.
+#   • resolution       [w, h] forced Windows desktop framebuffer (sibling of
+#                      `image:`). WINDOWS-ONLY by design — Linux/X picks its own
+#                      size and ignores it, so the Ubuntu snapshot sets none.
+#                      Same rule as gcloud/aws (see environment.yaml's note).
 #   • gpu              truthy → a GPU instance type (gn7i / NVIDIA A10).
 #   • ram_role_name    instance RAM role for in-box OSS access (only needed for
 #                      oss:// task data / output) — Alibaba analogue of AWS's
 #                      IAM instance profile.
+#
+# VALIDATION STATUS (be honest — these differ by what was actually run):
+#   • cpu-free-ubuntu (Linux)  — ✅ validated end-to-end on cn-hangzhou (acquire
+#                                → cua → agent → eval → delete).
+#   • cpu-free / cpu-license (ale-win10, Windows) — ⚠️ WIRED, NOT YET TESTED on
+#                                Alibaba. No Windows image has been imported here
+#                                yet; the win10 boot + cua-on-Windows path is
+#                                unverified on ECS.
+#   • gpu-free / gpu-license (GPU) — ⚠️ WIRED, NOT YET TESTED, and likely needs
+#                                driver work: the published images bake the
+#                                **gcloud/AWS L4** GPU driver, but Alibaba's GPU
+#                                family here is **gn7i = NVIDIA A10** (a DIFFERENT
+#                                GPU). The baked L4 driver is NOT expected to bind
+#                                to A10 without a re-baked A10 driver. Treat GPU
+#                                as experimental until a gn7i box is launched and
+#                                `nvidia-smi` / the GPU app stack is verified
+#                                in-guest. (AWS likewise ships GPU "wired but
+#                                untested".)
 # ----------------------------------------------------------------------------
 
 snapshots:
@@ -53,26 +75,26 @@ snapshots:
       instance_prefix: ale
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
-  gpu-free:                   # GPU Windows = the Server image (A10 driver baked in)
+  gpu-free:                   # GPU Windows — ⚠️ untested on Alibaba (see header)
     provider: aliyun
-    image: ale-win-server
+    image: ale-win-server     # mirrors AWS; gcloud uses ale-win10. UNVERIFIED here.
     resolution: [1920, 1080]
     aliyun:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
-      gpu: nvidia-a10         # truthy → gn7i (NVIDIA A10)
+      gpu: nvidia-a10         # truthy → gn7i (A10). NOTE: baked driver is L4, not A10.
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
-  gpu-license:                # GPU Windows, licensed-image tasks (same Server image)
+  gpu-license:                # GPU Windows, licensed tasks — ⚠️ untested (see header)
     provider: aliyun
-    image: ale-win-server
+    image: ale-win-server     # mirrors AWS; gcloud uses ale-win10. UNVERIFIED here.
     resolution: [1920, 1080]
     aliyun:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
-      gpu: nvidia-a10
+      gpu: nvidia-a10         # baked driver is L4, not A10 — likely needs re-bake
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
 # ---------------------------------------------------------------------------

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -31,7 +31,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
-      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+      zones: [cn-hangzhou-j, cn-hangzhou-k]
 
   cpu-free:                   # Windows, no GPU
     provider: aliyun
@@ -41,7 +41,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
-      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+      zones: [cn-hangzhou-j, cn-hangzhou-k]
 
   cpu-license:                # Windows requiring a licensed image (same family)
     provider: aliyun
@@ -51,7 +51,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
-      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+      zones: [cn-hangzhou-j, cn-hangzhou-k]
 
   gpu-free:                   # GPU Windows = the Server image (A10 driver baked in)
     provider: aliyun
@@ -62,7 +62,7 @@ snapshots:
       security_group: ale-sandbox
       instance_prefix: ale
       gpu: nvidia-a10         # truthy → gn7i (NVIDIA A10)
-      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+      zones: [cn-hangzhou-j, cn-hangzhou-k]
 
   gpu-license:                # GPU Windows, licensed-image tasks (same Server image)
     provider: aliyun
@@ -73,7 +73,7 @@ snapshots:
       security_group: ale-sandbox
       instance_prefix: ale
       gpu: nvidia-a10
-      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+      zones: [cn-hangzhou-j, cn-hangzhou-k]
 
 # ---------------------------------------------------------------------------
 # Task data + output (substrate-coupled; mirrors environment.yaml).

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -50,8 +50,18 @@
 #                                even launch here yet. Even once it does, the baked
 #                                GPU driver is the gcloud/AWS L4 driver, so binding
 #                                to an A10/T4 is a further unknown (likely a re-bake).
-#                                Override `vm.machineType` to a UEFI GPU type your
-#                                region actually sells, or rebuild the image for BIOS.
+#                                TRIED (2026-07-01) + FAILED: re-importing the raw
+#                                with --BootMode BIOS DOES let it launch on the
+#                                in-stock BIOS A10 (gn7i-c8g1), but Windows then
+#                                never boots (cua times out at 1200s) — the GCE
+#                                image is UEFI/GPT and carries no MBR boot code, so
+#                                a BootMode-only flip is not bootable. Real GPU
+#                                support needs a genuinely BIOS-bootable rebuild of
+#                                the image (hybrid MBR/GPT) OR a region/zone that
+#                                actually sells a UEFI GPU type (gn7i-xr / gn6t) —
+#                                plus, likely, an A10/T4 driver re-bake. Not a
+#                                config fix. Override `vm.machineType` per-env if
+#                                your region sells a UEFI GPU type.
 # ----------------------------------------------------------------------------
 
 snapshots:

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -52,13 +52,26 @@
 #                                    ale-win-server image, Windows Server 2022 boots,
 #                                    cua ready ~127 s. ✅ infra path works.
 #                                  – BUT `nvidia-smi` fails: "couldn't communicate
-#                                    with the NVIDIA driver". The GCE-baked
-#                                    nvidia-l4-vws driver does not bind to Alibaba's
-#                                    A10 vGPU, and the display stays at 800x600 (no
-#                                    GPU display driver). ❌ GPU compute is unusable
-#                                    until Alibaba's own A10 GRID/vGPU driver is
-#                                    installed/baked into the image (an image-build
-#                                    step, not a config change).
+#                                    with the NVIDIA driver". Root cause (probed via
+#                                    Cloud Assistant): the vGPU shows up as
+#                                    "NVIDIA A10-8Q" but its driver service is
+#                                    DISABLED (CM_PROB_DISABLED_SERVICE), and a
+#                                    PHANTOM "NVIDIA L4" device lingers — the GCE
+#                                    image ships the L4 vWS driver (582.16), which is
+#                                    both the wrong GPU and a newer version than the
+#                                    Alibaba vGPU host expects (A10 wants GRID 475.14).
+#                                    Alibaba's auto-installer (Cloud Assistant
+#                                    grid_driver_install — the agent IS present on the
+#                                    imported image) uninstalls 582.16 but then FAILS
+#                                    to install 475.14 ("install failed, reboot and
+#                                    retry", empty output) — the leftover L4 driver +
+#                                    disabled-service state on this GCE-derived image
+#                                    breaks the clean install (native Alibaba images
+#                                    don't hit this). ❌ GPU compute unusable until a
+#                                    CLEAN bake of Alibaba's GRID 475.14 (purge the
+#                                    GCE L4 driver/phantom devices first, or build the
+#                                    Windows image from an Alibaba-native base). A
+#                                    scoped image-build task, NOT a config change.
 #                                  – Also tried + rejected: --BootMode BIOS re-import
 #                                    to use in-stock BIOS A10 (gn7i-c8g1) — launches
 #                                    but Windows never boots (UEFI/GPT image has no

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -72,6 +72,20 @@
 #                                    GCE L4 driver/phantom devices first, or build the
 #                                    Windows image from an Alibaba-native base). A
 #                                    scoped image-build task, NOT a config change.
+#                                    Exhaustively confirmed unfixable IN-PLACE
+#                                    (2026-07-04): FOUR install routes — Cloud
+#                                    Assistant grid_driver_install, reboot+retry,
+#                                    the bundled grid_intaller.exe run directly, and
+#                                    with the display-capturing software stopped —
+#                                    ALL fail identically & instantly at
+#                                    "InstallGpuDriver output: []". The A10-8Q stays
+#                                    CM_PROB_DISABLED_SERVICE. The installer is an
+#                                    opaque Alibaba binary that bails on the imported
+#                                    image; the 475.14 package isn't separately
+#                                    obtainable (NVIDIA vGPU needs the licensing
+#                                    portal). So GPU truly needs an Alibaba-native
+#                                    Windows image base — out of scope for a config /
+#                                    driver-install fix on the GCE-derived image.
 #                                  – Also tried + rejected: --BootMode BIOS re-import
 #                                    to use in-stock BIOS A10 (gn7i-c8g1) — launches
 #                                    but Windows never boots (UEFI/GPT image has no

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -28,6 +28,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
+      ram_role_name: ale-sandbox
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
   cpu-free:                   # Windows
@@ -38,6 +39,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
+      ram_role_name: ale-sandbox
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
   cpu-license:                # Windows (licensed-software tasks)
@@ -48,6 +50,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
+      ram_role_name: ale-sandbox
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
   gpu-free:                   # Windows + GPU — NOT SUPPORTED on Alibaba
@@ -58,6 +61,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
+      ram_role_name: ale-sandbox
       gpu: nvidia-a10
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
@@ -69,6 +73,7 @@ snapshots:
       region: cn-hangzhou
       security_group: ale-sandbox
       instance_prefix: ale
+      ram_role_name: ale-sandbox
       gpu: nvidia-a10
       zones: [cn-hangzhou-j, cn-hangzhou-k]
 
@@ -78,7 +83,9 @@ snapshots:
 # Where task data comes from: "baked_in_sandbox" (baked into the image) | "oss://<bucket>".
 task_data_source: baked_in_sandbox
 
-# What to do with each run's output: null | "local" | "oss://<bucket>". To keep
-# output in OSS, set the bucket here and add `ram_role_name: ale-sandbox` to each
-# snapshot's aliyun: block.
-output_path: local
+# What to do with each run's output: null | "local" | "oss://<bucket>". The
+# snapshots already reference the `ale-sandbox` RAM role; to keep output in OSS,
+# create that role (see the setup docs) and set the bucket here. (If the role
+# doesn't exist it's skipped for non-bucket output, so local runs need nothing.)
+output_path: null
+# output_path: local          # uncomment to fetch each run's output back to the host

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -1,0 +1,87 @@
+# ============================================================================
+# environment_aliyun.yaml — run ALE on Alibaba Cloud (ECS + OSS). Aliyun
+# counterpart of environment.yaml / environment_aws.yaml; same per-snapshot
+# model and the SAME image-family names.
+# ============================================================================
+# Like the gcloud/aws envs, everything here is a hardcoded convention. There are
+# NO ${env:...} references: Alibaba credentials come from the ambient chain
+# (`aliyun configure` profile / ALIBABA_CLOUD_ACCESS_KEY_ID +
+# ALIBABA_CLOUD_ACCESS_KEY_SECRET env), and the VPC, vSwitches and images are
+# resolved at run time by name/tag (set up once per the Alibaba setup docs):
+#   • image            image-FAMILY name (registry key under
+#                      ale_run/environments/images/) → resolved to the newest
+#                      self-owned image tagged `ale:image-family=<name>`. Pin one
+#                      with `image_id:`.
+#   • security_group   the firewall by NAME (gcloud analogue: `network`). The
+#                      provider resolves it to its id + the VPC it lives in; that
+#                      VPC scopes the zone→vSwitch lookup.
+#   • zones            Alibaba zone ids, tried in order on capacity errors.
+#   • gpu              truthy → a GPU instance type (gn7i / NVIDIA A10).
+#   • ram_role_name    instance RAM role for in-box OSS access (only needed for
+#                      oss:// task data / output) — Alibaba analogue of AWS's
+#                      IAM instance profile.
+# ----------------------------------------------------------------------------
+
+snapshots:
+
+  cpu-free-ubuntu:            # Linux, no GPU — the bulk of tasks
+    provider: aliyun
+    image: ale-ubuntu22
+    aliyun:
+      region: cn-hangzhou
+      security_group: ale-sandbox
+      instance_prefix: ale
+      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+
+  cpu-free:                   # Windows, no GPU
+    provider: aliyun
+    image: ale-win10
+    resolution: [1024, 768]
+    aliyun:
+      region: cn-hangzhou
+      security_group: ale-sandbox
+      instance_prefix: ale
+      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+
+  cpu-license:                # Windows requiring a licensed image (same family)
+    provider: aliyun
+    image: ale-win10
+    resolution: [1024, 768]
+    aliyun:
+      region: cn-hangzhou
+      security_group: ale-sandbox
+      instance_prefix: ale
+      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+
+  gpu-free:                   # GPU Windows = the Server image (A10 driver baked in)
+    provider: aliyun
+    image: ale-win-server
+    resolution: [1920, 1080]
+    aliyun:
+      region: cn-hangzhou
+      security_group: ale-sandbox
+      instance_prefix: ale
+      gpu: nvidia-a10         # truthy → gn7i (NVIDIA A10)
+      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+
+  gpu-license:                # GPU Windows, licensed-image tasks (same Server image)
+    provider: aliyun
+    image: ale-win-server
+    resolution: [1920, 1080]
+    aliyun:
+      region: cn-hangzhou
+      security_group: ale-sandbox
+      instance_prefix: ale
+      gpu: nvidia-a10
+      zones: [cn-hangzhou-i, cn-hangzhou-j, cn-hangzhou-k]
+
+# ---------------------------------------------------------------------------
+# Task data + output (substrate-coupled; mirrors environment.yaml).
+# ---------------------------------------------------------------------------
+# "baked_in_sandbox" (data baked into the image) | "oss://<bucket>".
+task_data_source: baked_in_sandbox
+
+# Output after the run: null | "local" | "oss://<bucket>". For full benchmark
+# runs set this to your results bucket and add `ram_role_name: ale-sandbox` to
+# each snapshot's aliyun: block (the in-box ossutil writes via the instance role).
+output_path: local

--- a/configs/environments/environment_aliyun.yaml
+++ b/configs/environments/environment_aliyun.yaml
@@ -39,29 +39,31 @@
 #                                with no NIC and cua never connects. On a non-GPU box
 #                                the Windows display adapter only offers 800x600, so
 #                                `resolution:` best-fits down (logged, not fatal).
-#   • gpu-free / gpu-license (GPU) — ⚠️ WIRED, NOT yet runnable on cn-hangzhou.
-#                                BLOCKER is boot-mode + stock, BEFORE the driver
-#                                question: the ALE images are UEFI, but the GPU
-#                                types with stock here (ecs.gn7i-c8g1 A10, gn6i T4,
-#                                gn6v V100) are BIOS-only and reject a UEFI image at
-#                                launch. UEFI-capable GPU types — ecs.gn7i-xr (A10),
-#                                ecs.gn6t (T4) — are either not sold in cn-hangzhou
-#                                (gn7i-xr) or out of stock (gn6t). So a GPU box can't
-#                                even launch here yet. Even once it does, the baked
-#                                GPU driver is the gcloud/AWS L4 driver, so binding
-#                                to an A10/T4 is a further unknown (likely a re-bake).
-#                                TRIED (2026-07-01) + FAILED: re-importing the raw
-#                                with --BootMode BIOS DOES let it launch on the
-#                                in-stock BIOS A10 (gn7i-c8g1), but Windows then
-#                                never boots (cua times out at 1200s) — the GCE
-#                                image is UEFI/GPT and carries no MBR boot code, so
-#                                a BootMode-only flip is not bootable. Real GPU
-#                                support needs a genuinely BIOS-bootable rebuild of
-#                                the image (hybrid MBR/GPT) OR a region/zone that
-#                                actually sells a UEFI GPU type (gn7i-xr / gn6t) —
-#                                plus, likely, an A10/T4 driver re-bake. Not a
-#                                config fix. Override `vm.machineType` per-env if
-#                                your region sells a UEFI GPU type.
+#   • gpu-free / gpu-license (GPU) — ⚠️ launches + boots, but the GPU DRIVER is
+#                                not functional (this is now a driver gap, NOT an
+#                                infra gap). Full 2026-07-02 live finding:
+#                                  – The default GPU type is the vGPU vWS family
+#                                    ecs.vgn7i-vws-* (fractional A10, UEFI-capable,
+#                                    in stock in cn-hangzhou + most regions). Do
+#                                    NOT use passthrough ecs.gn7i-c8g1 (BIOS-only →
+#                                    rejects the UEFI image) or ecs.gn7i-xr (UEFI
+#                                    but not sold in most regions).
+#                                  – VERIFIED: a vgn7i-vws-m4 box launches the UEFI
+#                                    ale-win-server image, Windows Server 2022 boots,
+#                                    cua ready ~127 s. ✅ infra path works.
+#                                  – BUT `nvidia-smi` fails: "couldn't communicate
+#                                    with the NVIDIA driver". The GCE-baked
+#                                    nvidia-l4-vws driver does not bind to Alibaba's
+#                                    A10 vGPU, and the display stays at 800x600 (no
+#                                    GPU display driver). ❌ GPU compute is unusable
+#                                    until Alibaba's own A10 GRID/vGPU driver is
+#                                    installed/baked into the image (an image-build
+#                                    step, not a config change).
+#                                  – Also tried + rejected: --BootMode BIOS re-import
+#                                    to use in-stock BIOS A10 (gn7i-c8g1) — launches
+#                                    but Windows never boots (UEFI/GPT image has no
+#                                    MBR boot code; a BootMode metadata flip is not
+#                                    bootable).
 # ----------------------------------------------------------------------------
 
 snapshots:

--- a/configs/environments/environment_aws.yaml
+++ b/configs/environments/environment_aws.yaml
@@ -25,6 +25,7 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
+      iam_instance_profile: ale-sandbox
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
   cpu-free:                   # Windows
@@ -35,6 +36,7 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
+      iam_instance_profile: ale-sandbox
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
   cpu-license:                # Windows (licensed-software tasks)
@@ -45,6 +47,7 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
+      iam_instance_profile: ale-sandbox
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
   gpu-free:                   # Windows + GPU
@@ -55,6 +58,7 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
+      iam_instance_profile: ale-sandbox
       gpu: nvidia-l4
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
@@ -66,6 +70,7 @@ snapshots:
       region: us-east-1
       security_group: ale-sandbox
       instance_prefix: ale
+      iam_instance_profile: ale-sandbox
       gpu: nvidia-l4
       zones: [us-east-1a, us-east-1b, us-east-1c]
 
@@ -75,7 +80,9 @@ snapshots:
 # Where task data comes from: "baked_in_sandbox" (baked into the AMI) | "s3://<bucket>".
 task_data_source: baked_in_sandbox
 
-# What to do with each run's output: null | "local" | "s3://<bucket>". To keep
-# output in S3, set the bucket here and add `iam_instance_profile: ale-sandbox`
-# to each snapshot's aws: block.
-output_path: local
+# What to do with each run's output: null | "local" | "s3://<bucket>". The
+# snapshots already reference the `ale-sandbox` instance profile; to keep output
+# in S3, create that role/profile (see the setup docs) and set the bucket here.
+# (If it doesn't exist it's skipped for non-bucket output, so local runs need nothing.)
+output_path: null
+# output_path: local          # uncomment to fetch each run's output back to the host

--- a/configs/environments/environment_gcloud.yaml
+++ b/configs/environments/environment_gcloud.yaml
@@ -1,5 +1,5 @@
 # ============================================================================
-# environment.yaml — the one environment config.
+# environment_gcloud.yaml — the Google Cloud environment config.
 # ============================================================================
 # A task card declares a logical `snapshot` (its `image_category`, e.g.
 # "cpu-free-ubuntu"). For EVERY snapshot a task can ask for, this file says:
@@ -127,4 +127,5 @@ task_data_source: baked_in_sandbox
 gcs_sa_key: secret/gcp_key.json
 
 # Output dir after the run: null (skip) | "local" | "gs://<bucket>".
-output_path: local
+output_path: null
+# output_path: local          # uncomment to fetch each run's output back to the host

--- a/configs/environments/qemu.yaml
+++ b/configs/environments/qemu.yaml
@@ -85,4 +85,5 @@ snapshots:
 task_data_source: baked_in_sandbox
 # Uncomment when task_data_source or output_path uses gs://.
 # gcs_sa_key: secret/gcp_key.json
-output_path: local
+output_path: null
+# output_path: local          # uncomment to fetch each run's output back to the host

--- a/configs/environments/static_win_dev.yaml
+++ b/configs/environments/static_win_dev.yaml
@@ -19,4 +19,5 @@ image: ale-win10                      # Windows path-conventions + cua port :500
 # Task input data is baked into E:\agenthle on the image; outputs are pulled
 # back to the local run dir (no GCS bucket involved).
 task_data_source: baked_in_sandbox
-output_path: local
+output_path: null
+# output_path: local          # uncomment to fetch each run's output back to the host

--- a/docs/ale-docs-site/assets/nav.js
+++ b/docs/ale-docs-site/assets/nav.js
@@ -22,6 +22,7 @@ window.ALE_NAV = [
       { href: "/pages/providers.html", title: "Run an experiment", children: [
         { href: "/pages/google-cloud.html",  title: "Google Cloud VMs" },
         { href: "/pages/aws.html",           title: "AWS EC2" },
+        { href: "/pages/aliyun.html",        title: "Alibaba Cloud ECS" },
         { href: "/pages/local-docker.html",  title: "Local containers" },
         { href: "/pages/local.html",         title: "QEMU/KVM VMs" },
         { href: "/pages/static.html",        title: "Existing sandbox" },

--- a/docs/ale-docs-site/pages/aliyun.html
+++ b/docs/ale-docs-site/pages/aliyun.html
@@ -93,10 +93,13 @@ aliyun ram CreateRole --RoleName ale-sandbox --AssumeRolePolicyDocument \
 aliyun ram AttachPolicyToRole --PolicyType System \
   --PolicyName AliyunOSSFullAccess --RoleName ale-sandbox</code></pre>
     <p>
-      Then in <code>configs/environments/environment_aliyun.yaml</code> set
-      <code>output_path: oss://ale-run-results-&lt;account&gt;</code> and add
-      <code>ram_role_name: ale-sandbox</code> under each snapshot's
-      <code>aliyun:</code> block.
+      The commands above only <em>create</em> the bucket and the role. To
+      <em>use</em> them, edit <code>configs/environments/environment_aliyun.yaml</code>
+      by hand: set <code>output_path: oss://ale-run-results-&lt;account&gt;</code>,
+      and add a <code>ram_role_name: ale-sandbox</code> line under each snapshot's
+      <code>aliyun:</code> block so the sandbox is launched with that role
+      attached (that's what lets its in-box <code>ossutil</code> write to the
+      bucket).
     </p>
 
     <h2>④ Run</h2>

--- a/docs/ale-docs-site/pages/aliyun.html
+++ b/docs/ale-docs-site/pages/aliyun.html
@@ -93,13 +93,14 @@ aliyun ram CreateRole --RoleName ale-sandbox --AssumeRolePolicyDocument \
 aliyun ram AttachPolicyToRole --PolicyType System \
   --PolicyName AliyunOSSFullAccess --RoleName ale-sandbox</code></pre>
     <p>
-      The commands above only <em>create</em> the bucket and the role. To
-      <em>use</em> them, edit <code>configs/environments/environment_aliyun.yaml</code>
-      by hand: set <code>output_path: oss://ale-run-results-&lt;account&gt;</code>,
-      and add a <code>ram_role_name: ale-sandbox</code> line under each snapshot's
-      <code>aliyun:</code> block so the sandbox is launched with that role
-      attached (that's what lets its in-box <code>ossutil</code> write to the
-      bucket).
+      The snapshots already reference the <code>ale-sandbox</code> role, so once
+      it exists the sandbox is launched with it attached (that's what lets the
+      in-box <code>ossutil</code> write to the bucket). All you do to switch on
+      OSS output is set <code>output_path: oss://ale-run-results-&lt;account&gt;</code>
+      in <code>configs/environments/environment_aliyun.yaml</code>. (If the role
+      doesn't exist it's skipped for local runs, so you only need it for OSS
+      output — and if <code>output_path</code> is a bucket but the role is
+      missing, the run fails fast with a clear message.)
     </p>
 
     <h2>④ Run</h2>

--- a/docs/ale-docs-site/pages/aliyun.html
+++ b/docs/ale-docs-site/pages/aliyun.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Alibaba Cloud ECS | ALE Docs</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/style.css" />
+</head>
+<body>
+  <article class="article">
+    <h1>Alibaba Cloud ECS</h1>
+    <p class="lede">
+      Run every unit on a fresh ECS instance. The <code>aliyun</code> provider is
+      the Alibaba Cloud counterpart of the Google Cloud and AWS paths — same
+      per-snapshot model, same image-family names.
+    </p>
+
+    <h2>What the provider manages</h2>
+    <p>
+      The <code>aliyun</code> provider selects the image, instance type, GPU, and
+      candidate zones from the task snapshot and environment profile. It runs an
+      instance, waits for the in-guest CUA server, runs one unit, then deletes,
+      stops, or keeps the instance according to <code>cleanup_mode</code>.
+    </p>
+    <ul>
+      <li>Ubuntu and Windows custom images are supported.</li>
+      <li>GPU snapshots use a <code>gn7i</code> (NVIDIA A10) instance and retry across configured zones when capacity is unavailable.</li>
+      <li>CPU tasks use the task-card instance type, with a C-family to G-family (<code>ecs.c*</code> → <code>ecs.g*</code>) fallback when applicable.</li>
+      <li>Windows snapshots apply the configured desktop resolution before the run starts.</li>
+    </ul>
+
+    <h2>Understand the credential model</h2>
+    <table>
+      <thead><tr><th>Credential</th><th>Purpose</th></tr></thead>
+      <tbody>
+        <tr><td><code>aliyun configure</code> (RAM-user AccessKey)</td><td>The host creates, describes, stops, and deletes ECS instances.</td></tr>
+        <tr><td>Instance RAM role (<code>ram_role_name</code>)</td><td>Attached at launch; the in-box <code>ossutil</code> uses it for task-data reads and optional output uploads — no key is injected into the sandbox (the Alibaba analogue of AWS's IAM instance profile).</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Unlike Google Cloud, there is no service-account key file to push into the
+      sandbox: OSS access is granted by the instance RAM role, so the yaml never
+      names a secret.
+    </p>
+
+    <h2>Before you begin</h2>
+    <ul>
+      <li>An Alibaba Cloud account, and a RAM user with an AccessKey pair (do not use the root account key).</li>
+      <li>The <a href="https://www.alibabacloud.com/help/en/cli/">Alibaba Cloud CLI</a> (<code>aliyun</code>) installed on the ALE host, plus <code>ossutil</code> for OSS transfers.</li>
+      <li>ECS and OSS activated in your target region.</li>
+      <li>Sufficient vCPU and GPU quota for your intended concurrency.</li>
+    </ul>
+
+    <h2>1. Authenticate</h2>
+    <p>
+      Create an AccessKey pair for a RAM user in the console
+      (<em>RAM &rarr; Users &rarr; <code>&lt;user&gt;</code> &rarr; Create AccessKey</em>),
+      then configure the CLI:
+    </p>
+    <pre><code>export ALE_ALIYUN_REGION="cn-hangzhou"
+
+aliyun configure set \
+  --profile ale \
+  --mode AK \
+  --region "$ALE_ALIYUN_REGION" \
+  --access-key-id  &lt;AccessKeyId&gt; \
+  --access-key-secret &lt;AccessKeySecret&gt;</code></pre>
+    <p>
+      The provider uses the ambient credential chain, so you can equivalently
+      export <code>ALIBABA_CLOUD_ACCESS_KEY_ID</code> /
+      <code>ALIBABA_CLOUD_ACCESS_KEY_SECRET</code>.
+    </p>
+
+    <h2 id="copy-images">2. Import the sandbox images</h2>
+    <p>
+      ALE publishes prebaked Ubuntu and Windows raw images on GCS. Import them
+      into your account once as ECS custom images, tagged
+      <code>ale:image-family=&lt;name&gt;</code> (the tag the provider resolves):
+    </p>
+    <pre><code>./scripts/aliyun/import_images.sh all   # ale-ubuntu22, ale-win10, ale-win-server</code></pre>
+    <p>
+      The script streams each image from GCS through an OSS import bucket, calls
+      <code>aliyun ecs ImportImage</code>, and bakes the <code>aliyun</code> CLI +
+      <code>ossutil</code> into the Linux image (needed for <code>oss://</code>
+      task data / output).
+    </p>
+
+    <h2>3. Create the instance RAM role (for oss:// data/output)</h2>
+    <p>
+      Only needed when <code>task_data_source</code> or <code>output_path</code>
+      points at <code>oss://</code>. Create a RAM role the ECS service can assume,
+      grant it OSS access, and name it in each snapshot's <code>ram_role_name</code>:
+    </p>
+    <pre><code>aliyun ram CreateRole --RoleName ale-sandbox \
+  --AssumeRolePolicyDocument '{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":["ecs.aliyuncs.com"]}}],"Version":"1"}'
+aliyun ram AttachPolicyToRole --PolicyType System \
+  --PolicyName AliyunOSSReadOnlyAccess --RoleName ale-sandbox</code></pre>
+
+    <h2>4. Create a restricted security group</h2>
+    <p>
+      ALE connects directly to the CUA server on TCP port 5000. Restrict ingress
+      to the public CIDR of the machine running ALE. Do not expose the control
+      server to the entire internet.
+    </p>
+    <pre><code>export ALE_CLIENT_CIDR="203.0.113.10/32"   # the ALE host's public IP/CIDR
+
+VPC=$(aliyun ecs DescribeVpcs --RegionId "$ALE_ALIYUN_REGION" \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["Vpcs"]["Vpc"][0]["VpcId"])')
+SG=$(aliyun ecs CreateSecurityGroup --RegionId "$ALE_ALIYUN_REGION" \
+  --SecurityGroupName ale-sandbox --VpcId "$VPC" \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["SecurityGroupId"])')
+aliyun ecs AuthorizeSecurityGroup --RegionId "$ALE_ALIYUN_REGION" \
+  --SecurityGroupId "$SG" --IpProtocol tcp --PortRange 5000/5000 \
+  --SourceCidrIp "$ALE_CLIENT_CIDR"</code></pre>
+    <p>
+      The provider resolves the security group by name to its id and VPC, then
+      picks a vSwitch in each candidate zone within that VPC. Tag a vSwitch with
+      <code>project=ale</code> to pin which one the provider prefers.
+    </p>
+
+    <h2 id="results-bucket">5. Create a results bucket</h2>
+    <p>
+      Optional when <code>output_path: local</code>; recommended for large batch
+      artifacts. Create an OSS bucket and grant the instance RAM role write
+      access, then set <code>output_path: oss://&lt;bucket&gt;</code>.
+    </p>
+    <pre><code>ossutil mb "oss://ale-results-$(whoami)" --region "$ALE_ALIYUN_REGION"</code></pre>
+
+    <h2>6. Configure ALE</h2>
+    <p>
+      The shipped <code>configs/environments/environment_aliyun.yaml</code> maps
+      all five task snapshots to Alibaba Cloud. Set the region and zones to match
+      your account, start with <code>selected_tasks/helloworld.txt</code>, then
+      use <code>selected_tasks/unlicensed.txt</code> for the public unlicensed
+      set.
+    </p>
+
+    <h2>Capacity and cleanup</h2>
+    <p>
+      GPU capacity is volatile, so the shipped profile lists several fallback
+      zones. Your account still needs quota in the selected region. Set
+      <code>concurrency</code> below your vCPU, GPU, public-IP, and LLM limits.
+    </p>
+    <p>
+      Use <code>cleanup_mode: delete</code> for batch runs. If the host process
+      is terminated before cleanup completes, inspect leftovers by tag:
+    </p>
+    <pre><code>aliyun ecs DescribeInstances --RegionId "$ALE_ALIYUN_REGION" \
+  --Tag.1.Key purpose --Tag.1.Value ale-run</code></pre>
+  </article>
+
+  <script src="/assets/nav.js"></script>
+  <script src="/assets/app.js"></script>
+</body>
+</html>

--- a/docs/ale-docs-site/pages/aliyun.html
+++ b/docs/ale-docs-site/pages/aliyun.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Alibaba Cloud ECS | ALE Docs</title>
+  <title>Set up Alibaba Cloud | ALE Docs</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -11,145 +11,111 @@
 </head>
 <body>
   <article class="article">
-    <h1>Alibaba Cloud ECS</h1>
+    <h1>Set up Alibaba Cloud</h1>
     <p class="lede">
-      Run every unit on a fresh ECS instance. The <code>aliyun</code> provider is
-      the Alibaba Cloud counterpart of the Google Cloud and AWS paths — same
-      per-snapshot model, same image-family names.
+      One-time setup to run ALE on Alibaba Cloud: sign in, create a network, and
+      import the sandbox images into your account. Then point an experiment at the
+      Alibaba environment and run. Credentials live in your Alibaba CLI profile;
+      everything else is created once below.
     </p>
 
-    <h2>What the provider manages</h2>
+    <h2>Sign in</h2>
     <p>
-      The <code>aliyun</code> provider selects the image, instance type, GPU, and
-      candidate zones from the task snapshot and environment profile. It runs an
-      instance, waits for the in-guest CUA server, runs one unit, then deletes,
-      stops, or keeps the instance according to <code>cleanup_mode</code>.
+      Create an <a href="https://www.alibabacloud.com/">Alibaba Cloud account</a>
+      if you don't have one and activate <strong>ECS</strong> and
+      <strong>OSS</strong> (Object Storage Service) in the console. Install the
+      <a href="https://www.alibabacloud.com/help/en/cli/">Alibaba Cloud CLI</a>
+      (<code>aliyun</code>) plus <a href="https://www.alibabacloud.com/help/en/oss/developer-reference/ossutil/"><code>ossutil</code></a>,
+      create a RAM user with ECS + OSS access and an AccessKey pair for it, then:
+    </p>
+    <pre><code>aliyun configure           # paste the AccessKey id/secret, region cn-hangzhou
+export ALE_ALIYUN_REGION=cn-hangzhou</code></pre>
+
+    <h2>① Create the network</h2>
+    <p>
+      A VPC with a vSwitch in two zones (tried in order if one is short on
+      capacity), and a security group <code>ale-sandbox</code> opening the port
+      ALE needs (<code>5000</code>; <code>3389</code> to view a Windows desktop).
+    </p>
+    <pre><code>R=cn-hangzhou
+J(){ python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+
+VPC=$(aliyun vpc CreateVpc --RegionId $R --VpcName ale-vpc --CidrBlock 192.168.0.0/16 | J "['VpcId']")
+
+i=10; for z in cn-hangzhou-j cn-hangzhou-k; do
+  VSW=$(aliyun vpc CreateVSwitch --RegionId $R --VpcId $VPC --ZoneId $z \
+    --CidrBlock 192.168.$i.0/24 --VSwitchName ale-vsw-$z | J "['VSwitchId']")
+  aliyun vpc TagResources --RegionId $R --ResourceType VSWITCH --ResourceId.1 $VSW \
+    --Tag.1.Key project --Tag.1.Value ale; i=$((i+10))
+done
+
+SG=$(aliyun ecs CreateSecurityGroup --RegionId $R --VpcId $VPC \
+  --SecurityGroupName ale-sandbox --Description "ALE sandbox ingress" | J "['SecurityGroupId']")
+for p in 5000 3389; do
+  aliyun ecs AuthorizeSecurityGroup --RegionId $R --SecurityGroupId $SG \
+    --IpProtocol tcp --PortRange $p/$p --SourceCidrIp 0.0.0.0/0
+done</code></pre>
+
+    <h2>② Import the sandbox images</h2>
+    <p>
+      A task boots from a prebaked image (the OS, the professional software, and
+      the task data, ready to go). ALE publishes them as raw disks; the script
+      imports the one(s) you need into your account. Pick by what your tasks run
+      on:
     </p>
     <ul>
-      <li>Ubuntu and Windows custom images are supported.</li>
-      <li>GPU snapshots use a <code>gn7i</code> (NVIDIA A10) instance and retry across configured zones when capacity is unavailable.</li>
-      <li>CPU tasks use the task-card instance type, with a C-family to G-family (<code>ecs.c*</code> → <code>ecs.g*</code>) fallback when applicable.</li>
-      <li>Windows snapshots apply the configured desktop resolution before the run starts.</li>
+      <li><code>ale-ubuntu22</code> — Linux (the bulk of tasks)</li>
+      <li><code>ale-win10</code> or <code>ale-win-server</code> — Windows; either
+        one works, pick one</li>
     </ul>
-
-    <h2>Understand the credential model</h2>
-    <table>
-      <thead><tr><th>Credential</th><th>Purpose</th></tr></thead>
-      <tbody>
-        <tr><td><code>aliyun configure</code> (RAM-user AccessKey)</td><td>The host creates, describes, stops, and deletes ECS instances.</td></tr>
-        <tr><td>Instance RAM role (<code>ram_role_name</code>)</td><td>Attached at launch; the in-box <code>ossutil</code> uses it for task-data reads and optional output uploads — no key is injected into the sandbox (the Alibaba analogue of AWS's IAM instance profile).</td></tr>
-      </tbody>
-    </table>
+    <pre><code># imports from the published source into your OSS + registers an ECS image,
+# tagged ale:image-family=&lt;name&gt; (repeat per image you need)
+./scripts/aliyun/import_images.sh ale-ubuntu22      # or ale-win10 / ale-win-server</code></pre>
     <p>
-      Unlike Google Cloud, there is no service-account key file to push into the
-      sandbox: OSS access is granted by the instance RAM role, so the yaml never
-      names a secret.
+      The environment config refers to images by these family names, so once
+      imported they're picked up automatically. (A Windows image is a large disk;
+      the import takes a while.)
     </p>
 
-    <h2>Before you begin</h2>
-    <ul>
-      <li>An Alibaba Cloud account, and a RAM user with an AccessKey pair (do not use the root account key).</li>
-      <li>The <a href="https://www.alibabacloud.com/help/en/cli/">Alibaba Cloud CLI</a> (<code>aliyun</code>) installed on the ALE host, plus <code>ossutil</code> for OSS transfers.</li>
-      <li>ECS and OSS activated in your target region.</li>
-      <li>Sufficient vCPU and GPU quota for your intended concurrency.</li>
-    </ul>
+    <h2>③ Keep run output in OSS <span style="font-weight:400">(recommended for real runs)</span></h2>
+    <p>
+      With <code>output_path: local</code> each run's output is fetched back to
+      your machine over the sandbox's control port — fine for a quick demo, but
+      slow and flaky for large outputs at scale. So, exactly as on Google Cloud
+      (where output goes to a GCS bucket), the recommended path is to have the
+      sandbox upload straight to OSS. Create the bucket and a RAM role that lets
+      the sandbox upload to it:
+    </p>
+    <pre><code>ossutil mb oss://ale-run-results-$(aliyun sts GetCallerIdentity | J "['AccountId']")
 
-    <h2>1. Authenticate</h2>
-    <p>
-      Create an AccessKey pair for a RAM user in the console
-      (<em>RAM &rarr; Users &rarr; <code>&lt;user&gt;</code> &rarr; Create AccessKey</em>),
-      then configure the CLI:
-    </p>
-    <pre><code>export ALE_ALIYUN_REGION="cn-hangzhou"
-
-aliyun configure set \
-  --profile ale \
-  --mode AK \
-  --region "$ALE_ALIYUN_REGION" \
-  --access-key-id  &lt;AccessKeyId&gt; \
-  --access-key-secret &lt;AccessKeySecret&gt;</code></pre>
-    <p>
-      The provider uses the ambient credential chain, so you can equivalently
-      export <code>ALIBABA_CLOUD_ACCESS_KEY_ID</code> /
-      <code>ALIBABA_CLOUD_ACCESS_KEY_SECRET</code>.
-    </p>
-
-    <h2 id="copy-images">2. Import the sandbox images</h2>
-    <p>
-      ALE publishes prebaked Ubuntu and Windows raw images on GCS. Import them
-      into your account once as ECS custom images, tagged
-      <code>ale:image-family=&lt;name&gt;</code> (the tag the provider resolves):
-    </p>
-    <pre><code>./scripts/aliyun/import_images.sh all   # ale-ubuntu22, ale-win10, ale-win-server</code></pre>
-    <p>
-      The script streams each image from GCS through an OSS import bucket, calls
-      <code>aliyun ecs ImportImage</code>, and bakes the <code>aliyun</code> CLI +
-      <code>ossutil</code> into the Linux image (needed for <code>oss://</code>
-      task data / output).
-    </p>
-
-    <h2>3. Create the instance RAM role (for oss:// data/output)</h2>
-    <p>
-      Only needed when <code>task_data_source</code> or <code>output_path</code>
-      points at <code>oss://</code>. Create a RAM role the ECS service can assume,
-      grant it OSS access, and name it in each snapshot's <code>ram_role_name</code>:
-    </p>
-    <pre><code>aliyun ram CreateRole --RoleName ale-sandbox \
-  --AssumeRolePolicyDocument '{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":["ecs.aliyuncs.com"]}}],"Version":"1"}'
+aliyun ram CreateRole --RoleName ale-sandbox --AssumeRolePolicyDocument \
+  '{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":["ecs.aliyuncs.com"]}}],"Version":"1"}'
 aliyun ram AttachPolicyToRole --PolicyType System \
-  --PolicyName AliyunOSSReadOnlyAccess --RoleName ale-sandbox</code></pre>
-
-    <h2>4. Create a restricted security group</h2>
+  --PolicyName AliyunOSSFullAccess --RoleName ale-sandbox</code></pre>
     <p>
-      ALE connects directly to the CUA server on TCP port 5000. Restrict ingress
-      to the public CIDR of the machine running ALE. Do not expose the control
-      server to the entire internet.
-    </p>
-    <pre><code>export ALE_CLIENT_CIDR="203.0.113.10/32"   # the ALE host's public IP/CIDR
-
-VPC=$(aliyun ecs DescribeVpcs --RegionId "$ALE_ALIYUN_REGION" \
-  | python3 -c 'import sys,json;print(json.load(sys.stdin)["Vpcs"]["Vpc"][0]["VpcId"])')
-SG=$(aliyun ecs CreateSecurityGroup --RegionId "$ALE_ALIYUN_REGION" \
-  --SecurityGroupName ale-sandbox --VpcId "$VPC" \
-  | python3 -c 'import sys,json;print(json.load(sys.stdin)["SecurityGroupId"])')
-aliyun ecs AuthorizeSecurityGroup --RegionId "$ALE_ALIYUN_REGION" \
-  --SecurityGroupId "$SG" --IpProtocol tcp --PortRange 5000/5000 \
-  --SourceCidrIp "$ALE_CLIENT_CIDR"</code></pre>
-    <p>
-      The provider resolves the security group by name to its id and VPC, then
-      picks a vSwitch in each candidate zone within that VPC. Tag a vSwitch with
-      <code>project=ale</code> to pin which one the provider prefers.
+      Then in <code>configs/environments/environment_aliyun.yaml</code> set
+      <code>output_path: oss://ale-run-results-&lt;account&gt;</code> and add
+      <code>ram_role_name: ale-sandbox</code> under each snapshot's
+      <code>aliyun:</code> block.
     </p>
 
-    <h2 id="results-bucket">5. Create a results bucket</h2>
+    <h2>④ Run</h2>
     <p>
-      Optional when <code>output_path: local</code>; recommended for large batch
-      artifacts. Create an OSS bucket and grant the instance RAM role write
-      access, then set <code>output_path: oss://&lt;bucket&gt;</code>.
+      Point your experiment at the Alibaba environment
+      (<code>environment: configs/environments/environment_aliyun.yaml</code>) and run:
     </p>
-    <pre><code>ossutil mb "oss://ale-results-$(whoami)" --region "$ALE_ALIYUN_REGION"</code></pre>
+    <pre><code>uv run python -m ale_run run my_experiment.yaml</code></pre>
 
-    <h2>6. Configure ALE</h2>
-    <p>
-      The shipped <code>configs/environments/environment_aliyun.yaml</code> maps
-      all five task snapshots to Alibaba Cloud. Set the region and zones to match
-      your account, start with <code>selected_tasks/helloworld.txt</code>, then
-      use <code>selected_tasks/unlicensed.txt</code> for the public unlicensed
-      set.
-    </p>
+    <div class="note">
+      <div class="note-title">GPU tasks: not supported</div>
+      GPU tasks are not supported on Alibaba Cloud. Use the CPU snapshots.
+    </div>
 
-    <h2>Capacity and cleanup</h2>
-    <p>
-      GPU capacity is volatile, so the shipped profile lists several fallback
-      zones. Your account still needs quota in the selected region. Set
-      <code>concurrency</code> below your vCPU, GPU, public-IP, and LLM limits.
-    </p>
-    <p>
-      Use <code>cleanup_mode: delete</code> for batch runs. If the host process
-      is terminated before cleanup completes, inspect leftovers by tag:
-    </p>
-    <pre><code>aliyun ecs DescribeInstances --RegionId "$ALE_ALIYUN_REGION" \
-  --Tag.1.Key purpose --Tag.1.Value ale-run</code></pre>
+    <div class="note">
+      <div class="note-title">Next</div>
+      Provisioning done. Wire an experiment — agents, keys, and the run command:
+      <a href="/pages/configure.html">Configure &amp; run a benchmark →</a>
+    </div>
   </article>
 
   <script src="/assets/nav.js"></script>

--- a/docs/ale-docs-site/pages/aws.html
+++ b/docs/ale-docs-site/pages/aws.html
@@ -106,10 +106,15 @@ aws iam put-role-policy --role-name ale-sandbox --policy-name s3 --policy-docume
 aws iam create-instance-profile --instance-profile-name ale-sandbox
 aws iam add-role-to-instance-profile --instance-profile-name ale-sandbox --role-name ale-sandbox</code></pre>
     <p>
-      Then in <code>configs/environments/environment_aws.yaml</code> set
-      <code>output_path: s3://ale-run-results-&lt;account&gt;</code> and add
-      <code>iam_instance_profile: ale-sandbox</code> under each snapshot's
-      <code>aws:</code> block.
+      The snapshots already reference the <code>ale-sandbox</code> instance
+      profile, so once it exists the sandbox is launched with it attached (that's
+      what lets the in-box aws CLI write to the bucket). All you do to switch on
+      S3 output is set
+      <code>output_path: s3://ale-run-results-&lt;account&gt;</code> in
+      <code>configs/environments/environment_aws.yaml</code>. (If the profile
+      doesn't exist it's skipped for local runs, so you only need it for S3
+      output — and if <code>output_path</code> is a bucket but the profile is
+      missing, the run fails fast with a clear message.)
     </p>
 
     <h2>④ Run</h2>

--- a/docs/ale-docs-site/pages/configure.html
+++ b/docs/ale-docs-site/pages/configure.html
@@ -25,7 +25,7 @@ secret_file: secret/.env
 
 agents:
   - configs/agents/claude_code.yaml
-environment: configs/environments/environment.yaml
+environment: configs/environments/environment_gcloud.yaml
 tasks: selected_tasks/helloworld.txt
 
 output:
@@ -59,7 +59,7 @@ cleanup_mode: delete</code></pre>
     <table>
       <thead><tr><th>Profile</th><th>Provider routing</th><th>Compatible list</th></tr></thead>
       <tbody>
-        <tr><td><code>configs/environments/environment.yaml</code></td><td><a href="/pages/google-cloud.html">Google Cloud VMs</a> for all published snapshots</td><td><code>unlicensed.txt</code>, or <code>full.txt</code> with licensed software activated</td></tr>
+        <tr><td><code>configs/environments/environment_gcloud.yaml</code></td><td><a href="/pages/google-cloud.html">Google Cloud VMs</a> for all published snapshots</td><td><code>unlicensed.txt</code>, or <code>full.txt</code> with licensed software activated</td></tr>
         <tr><td><code>configs/environments/environment_aws.yaml</code></td><td><a href="/pages/aws.html">AWS EC2</a> for all published snapshots</td><td><code>unlicensed.txt</code> (same image families)</td></tr>
         <tr><td><code>configs/environments/environment_aliyun.yaml</code></td><td><a href="/pages/aliyun.html">Alibaba Cloud ECS</a> for all published snapshots</td><td><code>unlicensed.txt</code> (same image families)</td></tr>
         <tr><td><code>configs/environments/docker.yaml</code></td><td><a href="/pages/local-docker.html">Local containers</a> for <code>cpu-free-ubuntu</code></td><td><code>docker_support.txt</code></td></tr>

--- a/docs/ale-docs-site/pages/configure.html
+++ b/docs/ale-docs-site/pages/configure.html
@@ -60,6 +60,7 @@ cleanup_mode: delete</code></pre>
       <thead><tr><th>Profile</th><th>Provider routing</th><th>Compatible list</th></tr></thead>
       <tbody>
         <tr><td><code>configs/environments/environment.yaml</code></td><td><a href="/pages/google-cloud.html">Google Cloud VMs</a> for all published snapshots</td><td><code>unlicensed.txt</code>, or <code>full.txt</code> with licensed software activated</td></tr>
+        <tr><td><code>configs/environments/environment_aws.yaml</code></td><td><a href="/pages/aws.html">AWS EC2</a> for all published snapshots</td><td><code>unlicensed.txt</code> (same image families)</td></tr>
         <tr><td><code>configs/environments/environment_aliyun.yaml</code></td><td><a href="/pages/aliyun.html">Alibaba Cloud ECS</a> for all published snapshots</td><td><code>unlicensed.txt</code> (same image families)</td></tr>
         <tr><td><code>configs/environments/docker.yaml</code></td><td><a href="/pages/local-docker.html">Local containers</a> for <code>cpu-free-ubuntu</code></td><td><code>docker_support.txt</code></td></tr>
         <tr><td><code>configs/environments/qemu.yaml</code></td><td><a href="/pages/local.html">QEMU/KVM VMs</a> for CPU-compatible Ubuntu and Windows snapshots</td><td><code>qemu_support.txt</code></td></tr>

--- a/docs/ale-docs-site/pages/configure.html
+++ b/docs/ale-docs-site/pages/configure.html
@@ -60,6 +60,7 @@ cleanup_mode: delete</code></pre>
       <thead><tr><th>Profile</th><th>Provider routing</th><th>Compatible list</th></tr></thead>
       <tbody>
         <tr><td><code>configs/environments/environment.yaml</code></td><td><a href="/pages/google-cloud.html">Google Cloud VMs</a> for all published snapshots</td><td><code>unlicensed.txt</code>, or <code>full.txt</code> with licensed software activated</td></tr>
+        <tr><td><code>configs/environments/environment_aliyun.yaml</code></td><td><a href="/pages/aliyun.html">Alibaba Cloud ECS</a> for all published snapshots</td><td><code>unlicensed.txt</code> (same image families)</td></tr>
         <tr><td><code>configs/environments/docker.yaml</code></td><td><a href="/pages/local-docker.html">Local containers</a> for <code>cpu-free-ubuntu</code></td><td><code>docker_support.txt</code></td></tr>
         <tr><td><code>configs/environments/qemu.yaml</code></td><td><a href="/pages/local.html">QEMU/KVM VMs</a> for CPU-compatible Ubuntu and Windows snapshots</td><td><code>qemu_support.txt</code></td></tr>
         <tr><td>Your own static profile</td><td><a href="/pages/static.html">Existing sandbox</a> for every selected task</td><td>A narrow list matching that machine</td></tr>

--- a/docs/ale-docs-site/pages/google-cloud.html
+++ b/docs/ale-docs-site/pages/google-cloud.html
@@ -147,7 +147,7 @@ gcloud storage buckets add-iam-policy-binding "gs://$GCP_BUCKET" \
     <pre><code>GCP_PROJECT=&lt;your-project-id&gt;
 GCP_SA_KEY=secret/gcp_key.json</code></pre>
     <p>
-      The shipped <code>configs/environments/environment.yaml</code> maps all
+      The shipped <code>configs/environments/environment_gcloud.yaml</code> maps all
       five task snapshots to Google Cloud. Start with
       <code>selected_tasks/helloworld.txt</code>, then use
       <code>selected_tasks/unlicensed.txt</code> for the public unlicensed set.

--- a/docs/ale-docs-site/pages/providers.html
+++ b/docs/ale-docs-site/pages/providers.html
@@ -99,7 +99,7 @@ uv sync --all-packages</code></pre>
     <table>
       <thead><tr><th>Environment</th><th>Recommended task list</th></tr></thead>
       <tbody>
-        <tr><td><code>configs/environments/environment.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code>, or <code>full.txt</code> after licensed software is activated</td></tr>
+        <tr><td><code>configs/environments/environment_gcloud.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code>, or <code>full.txt</code> after licensed software is activated</td></tr>
         <tr><td><code>configs/environments/environment_aws.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code> (same image families on AWS EC2)</td></tr>
         <tr><td><code>configs/environments/environment_aliyun.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code> (same image families on Alibaba Cloud ECS)</td></tr>
         <tr><td><code>configs/environments/docker.yaml</code></td><td><code>selected_tasks/docker_support.txt</code></td></tr>

--- a/docs/ale-docs-site/pages/providers.html
+++ b/docs/ale-docs-site/pages/providers.html
@@ -100,6 +100,7 @@ uv sync --all-packages</code></pre>
       <thead><tr><th>Environment</th><th>Recommended task list</th></tr></thead>
       <tbody>
         <tr><td><code>configs/environments/environment.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code>, or <code>full.txt</code> after licensed software is activated</td></tr>
+        <tr><td><code>configs/environments/environment_aws.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code> (same image families on AWS EC2)</td></tr>
         <tr><td><code>configs/environments/environment_aliyun.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code> (same image families on Alibaba Cloud ECS)</td></tr>
         <tr><td><code>configs/environments/docker.yaml</code></td><td><code>selected_tasks/docker_support.txt</code></td></tr>
         <tr><td><code>configs/environments/qemu.yaml</code></td><td><code>selected_tasks/qemu_support.txt</code></td></tr>

--- a/docs/ale-docs-site/pages/providers.html
+++ b/docs/ale-docs-site/pages/providers.html
@@ -52,6 +52,12 @@ uv sync --all-packages</code></pre>
           <td>Production runs on AWS instead of/alongside GCP</td>
         </tr>
         <tr>
+          <td><a href="/pages/aliyun.html"><strong>Alibaba Cloud ECS</strong></a><br><code>aliyun</code></td>
+          <td>A fresh ECS instance for every run unit</td>
+          <td>Linux validated end-to-end; Windows + GPU (gn7i) wired from the same image families.</td>
+          <td>Production runs on Alibaba Cloud instead of/alongside GCP</td>
+        </tr>
+        <tr>
           <td><a href="/pages/local-docker.html"><strong>Local containers</strong></a><br><code>docker</code></td>
           <td>A fresh Linux container for every run unit</td>
           <td>99 tasks in <code>docker_support.txt</code></td>
@@ -94,6 +100,7 @@ uv sync --all-packages</code></pre>
       <thead><tr><th>Environment</th><th>Recommended task list</th></tr></thead>
       <tbody>
         <tr><td><code>configs/environments/environment.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code>, or <code>full.txt</code> after licensed software is activated</td></tr>
+        <tr><td><code>configs/environments/environment_aliyun.yaml</code></td><td><code>selected_tasks/unlicensed.txt</code> (same image families on Alibaba Cloud ECS)</td></tr>
         <tr><td><code>configs/environments/docker.yaml</code></td><td><code>selected_tasks/docker_support.txt</code></td></tr>
         <tr><td><code>configs/environments/qemu.yaml</code></td><td><code>selected_tasks/qemu_support.txt</code></td></tr>
         <tr><td>A static environment</td><td>A small list known to match the attached machine</td></tr>
@@ -113,6 +120,11 @@ uv sync --all-packages</code></pre>
         <div class="k">Supported</div>
         <div class="t">Google Cloud VMs</div>
         <div class="d">The broadest coverage and the production path for batch runs.</div>
+      </a>
+      <a class="card" href="/pages/aliyun.html">
+        <div class="k">Supported</div>
+        <div class="t">Alibaba Cloud</div>
+        <div class="d">Ephemeral ECS instances + OSS. Linux validated end-to-end; Windows + GPU wired.</div>
       </a>
       <a class="card" href="/pages/local-docker.html">
         <div class="k">Supported</div>

--- a/docs/ale-docs-site/pages/providers.html
+++ b/docs/ale-docs-site/pages/providers.html
@@ -54,7 +54,7 @@ uv sync --all-packages</code></pre>
         <tr>
           <td><a href="/pages/aliyun.html"><strong>Alibaba Cloud ECS</strong></a><br><code>aliyun</code></td>
           <td>A fresh ECS instance for every run unit</td>
-          <td>Linux validated end-to-end; Windows + GPU (gn7i) wired from the same image families.</td>
+          <td>Linux + Windows from the same image families. GPU tasks not supported.</td>
           <td>Production runs on Alibaba Cloud instead of/alongside GCP</td>
         </tr>
         <tr>
@@ -125,7 +125,7 @@ uv sync --all-packages</code></pre>
       <a class="card" href="/pages/aliyun.html">
         <div class="k">Supported</div>
         <div class="t">Alibaba Cloud</div>
-        <div class="d">Ephemeral ECS instances + OSS. Linux validated end-to-end; Windows + GPU wired.</div>
+        <div class="d">Ephemeral ECS instances + OSS. Linux + Windows; GPU tasks not supported.</div>
       </a>
       <a class="card" href="/pages/local-docker.html">
         <div class="k">Supported</div>

--- a/docs/ale-docs-site/pages/sandbox.html
+++ b/docs/ale-docs-site/pages/sandbox.html
@@ -54,6 +54,7 @@
       <thead><tr><th>Code identifier</th><th>Sandbox realization</th><th>Lifecycle</th></tr></thead>
       <tbody>
         <tr><td><code>gcloud</code></td><td>A complete GCE VM</td><td>Creates a fresh VM per unit and manages it through the Google Cloud CLI.</td></tr>
+        <tr><td><code>aws</code></td><td>A complete EC2 instance</td><td>Creates a fresh instance per unit and manages it through the AWS CLI.</td></tr>
         <tr><td><code>aliyun</code></td><td>A complete Alibaba Cloud ECS instance</td><td>Creates a fresh instance per unit and manages it through the Alibaba Cloud CLI.</td></tr>
         <tr><td><code>docker</code></td><td>A Linux container with a virtual desktop</td><td>Creates a fresh container per unit and exposes the CUA port through Docker.</td></tr>
         <tr><td><code>qemu</code></td><td>A complete QEMU/KVM guest inside a Docker-packaged runner</td><td>Caches a base qcow2, creates a disposable overlay, and starts one guest per unit.</td></tr>

--- a/docs/ale-docs-site/pages/sandbox.html
+++ b/docs/ale-docs-site/pages/sandbox.html
@@ -54,6 +54,7 @@
       <thead><tr><th>Code identifier</th><th>Sandbox realization</th><th>Lifecycle</th></tr></thead>
       <tbody>
         <tr><td><code>gcloud</code></td><td>A complete GCE VM</td><td>Creates a fresh VM per unit and manages it through the Google Cloud CLI.</td></tr>
+        <tr><td><code>aliyun</code></td><td>A complete Alibaba Cloud ECS instance</td><td>Creates a fresh instance per unit and manages it through the Alibaba Cloud CLI.</td></tr>
         <tr><td><code>docker</code></td><td>A Linux container with a virtual desktop</td><td>Creates a fresh container per unit and exposes the CUA port through Docker.</td></tr>
         <tr><td><code>qemu</code></td><td>A complete QEMU/KVM guest inside a Docker-packaged runner</td><td>Caches a base qcow2, creates a disposable overlay, and starts one guest per unit.</td></tr>
         <tr><td><code>static</code></td><td>An existing CUA-enabled machine</td><td>Attaches to a fixed endpoint. It does not provision or destroy the machine.</td></tr>

--- a/docs/ale-docs-site/pages/tasks.html
+++ b/docs/ale-docs-site/pages/tasks.html
@@ -75,7 +75,7 @@
     </div>
     <p>
       Where those files come from is set by the environment's
-      <a href="https://github.com/rdi-berkeley/agents-last-exam/blob/main/configs/environments/environment.yaml"><code>task_data_source</code></a>,
+      <a href="https://github.com/rdi-berkeley/agents-last-exam/blob/main/configs/environments/environment_gcloud.yaml"><code>task_data_source</code></a>,
       which has three implemented modes:
     </p>
     <ul>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -123,7 +123,7 @@ gcloud storage buckets add-iam-policy-binding "gs://$GCP_BUCKET" \
 ```
 
 To upload task output directly from each sandbox, set this in a copy of
-`configs/environments/environment.yaml`:
+`configs/environments/environment_gcloud.yaml`:
 
 ```yaml
 output_path: gs://<your-results-bucket>

--- a/example_exp.yaml
+++ b/example_exp.yaml
@@ -26,7 +26,7 @@ secret_file: secret/.env                          # KEY=value pairs
 
 agents:
   - configs/agents/claude_code.yaml               # add more lines to run a matrix
-environment: configs/environments/environment.yaml
+environment: configs/environments/environment_gcloud.yaml
 
 tasks: selected_tasks/helloworld.txt
 

--- a/scripts/aliyun/import_images.sh
+++ b/scripts/aliyun/import_images.sh
@@ -49,10 +49,18 @@ ensure_bucket() {                    # OSS import bucket exists (region-local)
 ensure_raw() {                       # $1 family → ensure oss://$BUCKET/images/$1.raw
   local key="images/$1.raw"
   if ossutil stat "oss://$BUCKET/$key" >/dev/null 2>&1; then echo "raw present: $1"; return; fi
-  say "stream $GCS/$1.tar.gz -> oss://$BUCKET/$key"
-  # gsutil can't write oss://, but ossutil reads stdin via `cp - oss://...`, so
-  # pipe GCS → tar → ossutil; the full raw never lands on local disk.
-  gsutil -u "$BILLING" cat "$GCS/$1.tar.gz" | tar -xzO | ossutil cp - "oss://$BUCKET/$key"
+  # ossutil (unlike `aws s3 cp -`) cannot read stdin — it stat()s the source —
+  # so we can't pipe GCS→tar→OSS directly. Stage the decompressed raw to a local
+  # scratch dir (needs ~170 GiB free), upload, then delete. ALE_IMG_SCRATCH
+  # overrides the scratch location (default /var/tmp/aliimg).
+  local scratch="${ALE_IMG_SCRATCH:-/var/tmp/aliimg}" raw
+  mkdir -p "$scratch"; raw="$scratch/$1.raw"
+  say "stage $GCS/$1.tar.gz -> $raw (decompress)"
+  gsutil -u "$BILLING" cat "$GCS/$1.tar.gz" | tar -xzO > "$raw"
+  [ -s "$raw" ] || { echo "staging produced an empty raw for $1" >&2; return 1; }
+  say "upload $raw -> oss://$BUCKET/$key ($(stat -c %s "$raw") bytes)"
+  ossutil cp -f "$raw" "oss://$BUCKET/$key"
+  rm -f "$raw"
 }
 
 vsw_in_sg_vpc() {                    # echo a vSwitch id in the SG's VPC

--- a/scripts/aliyun/import_images.sh
+++ b/scripts/aliyun/import_images.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Import ALE sandbox images from gs://ale-data-public/images/ into Alibaba Cloud
+# as ECS custom images. One re-runnable script for the whole flow. Idempotent-ish:
+# skips the OSS upload if the raw is already there.
+#
+#   ./import_images.sh ale-ubuntu22       # Linux: ImportImage, then bake aliyun CLI + ossutil
+#   ./import_images.sh ale-win10          # Windows 10 desktop
+#   ./import_images.sh ale-win-server     # Windows Server (GPU)
+#   ./import_images.sh all                # all three
+#
+# Per image it: streams the GCS tar.gz (disk.raw) into the OSS import bucket
+# (no local staging), turns it into a custom image via `aliyun ecs ImportImage`,
+# tags it `ale:image-family=<name>` (the tag AliyunProvider resolves), and — for
+# Linux — bakes the aliyun CLI + ossutil in (needed for oss:// data/output).
+#
+# Auth: ambient Alibaba credentials (`aliyun configure` / ALIBABA_CLOUD_ACCESS_KEY_*).
+# GCS reads use the host's gcloud login + a billing project (requester-pays).
+#
+# Mirror of scripts/aws/import_images.sh. Aliyun differences:
+#   • ImportImage validates the guest OS but (unlike AWS import-image) accepts
+#     ALE's Ubuntu HWE kernel, so Linux goes straight through ImportImage.
+#   • The import source is an OSS object (RAW), not an S3 object.
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+R="${ALE_ALIYUN_REGION:-cn-hangzhou}"
+UID_=$(aliyun sts GetCallerIdentity 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["AccountId"])')
+BUCKET="ale-images-$UID_"
+GCS=gs://ale-data-public/images
+BILLING="${ALE_GCS_BILLING_PROJECT:-agenthle-488519}"   # billed for requester-pays GCS reads
+SG_NAME=ale-sandbox
+say() { printf '\n=== %s ===\n' "$*"; }
+J() { python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+
+ensure_bucket() {                    # OSS import bucket exists (region-local)
+  ossutil ls "oss://$BUCKET/" >/dev/null 2>&1 || \
+    ossutil mb "oss://$BUCKET" --region "$R" >/dev/null
+}
+
+ensure_raw() {                       # $1 family → ensure oss://$BUCKET/images/$1.raw
+  local key="images/$1.raw"
+  if ossutil stat "oss://$BUCKET/$key" >/dev/null 2>&1; then echo "raw present: $1"; return; fi
+  say "stream $GCS/$1.tar.gz -> oss://$BUCKET/$key"
+  # gsutil can't write oss://, and ossutil can read stdin via `cp - oss://...`,
+  # so we pipe GCS → tar → ossutil. The full raw never lands on local disk.
+  gsutil -u "$BILLING" cat "$GCS/$1.tar.gz" | tar -xzO | ossutil cp - "oss://$BUCKET/$key"
+}
+
+poll_image() {                       # $1 image-id → wait until Available
+  while :; do
+    local st; st=$(aliyun ecs DescribeImages --RegionId "$R" --ImageId "$1" \
+      | J "['Images']['Image'][0].get('Status','?')")
+    echo "  $1 $st" >&2
+    [ "$st" = Available ] && return
+    case "$st" in CreateFailed|UnAvailable) echo "FAILED" >&2; return 1;; esac
+    sleep 60
+  done
+}
+
+tag_image() {                        # $1 image-id, $2 family
+  aliyun ecs TagResources --RegionId "$R" --ResourceType image \
+    --ResourceId.1 "$1" \
+    --Tag.1.Key ale:image-family --Tag.1.Value "$2" \
+    --Tag.2.Key Name --Tag.2.Value "$2" >/dev/null
+  echo "tagged $1 (ale:image-family=$2)"
+}
+
+import_one() {                       # $1 family, $2 OSType (linux|windows), $3 Platform
+  local fam=$1 ostype=$2 platform=$3
+  ensure_bucket; ensure_raw "$fam"
+  say "$fam: ImportImage (OSType=$ostype Platform=$platform)"
+  local img
+  img=$(aliyun ecs ImportImage --RegionId "$R" \
+    --ImageName "$fam-$(date +%s)" --OSType "$ostype" --Platform "$platform" \
+    --Architecture x86_64 --BootMode UEFI \
+    --DiskDeviceMapping.1.OSSBucket "$BUCKET" \
+    --DiskDeviceMapping.1.OSSObject "images/$fam.raw" \
+    --DiskDeviceMapping.1.Format RAW \
+    | J "['ImageId']")
+  echo "import image: $img"
+  poll_image "$img" || return 1
+  tag_image "$img" "$fam"
+  echo "DONE $fam -> $img"
+}
+
+case "${1:?usage: import_images.sh ale-ubuntu22|ale-win10|ale-win-server|all}" in
+  ale-ubuntu22)   import_one ale-ubuntu22   linux   Ubuntu ;;
+  ale-win10)      import_one ale-win10       windows Windows ;;
+  ale-win-server) import_one ale-win-server  windows Windows ;;
+  all)            import_one ale-ubuntu22 linux Ubuntu
+                  import_one ale-win10 windows Windows
+                  import_one ale-win-server windows Windows ;;
+  *) echo "unknown image $1"; exit 2 ;;
+esac

--- a/scripts/aliyun/import_images.sh
+++ b/scripts/aliyun/import_images.sh
@@ -1,54 +1,84 @@
 #!/usr/bin/env bash
 # Import ALE sandbox images from gs://ale-data-public/images/ into Alibaba Cloud
-# as ECS custom images. One re-runnable script for the whole flow. Idempotent-ish:
-# skips the OSS upload if the raw is already there.
+# as ECS custom images. One re-runnable script for the whole flow (mirror of
+# scripts/aws/import_images.sh). Idempotent-ish: skips the OSS upload if the raw
+# is already there.
 #
-#   ./import_images.sh ale-ubuntu22       # Linux: ImportImage, then bake aliyun CLI + ossutil
+#   ./import_images.sh ale-ubuntu22       # Linux: ImportImage, bake aliyun CLI + ossutil
 #   ./import_images.sh ale-win10          # Windows 10 desktop
 #   ./import_images.sh ale-win-server     # Windows Server (GPU)
 #   ./import_images.sh all                # all three
 #
 # Per image it: streams the GCS tar.gz (disk.raw) into the OSS import bucket
 # (no local staging), turns it into a custom image via `aliyun ecs ImportImage`,
-# tags it `ale:image-family=<name>` (the tag AliyunProvider resolves), and — for
-# Linux — bakes the aliyun CLI + ossutil in (needed for oss:// data/output).
+# tags it `ale:image-family=<name>` (the tag AliyunProvider resolves). For Linux
+# it then bakes the aliyun CLI + ossutil into the image (needed for oss:// data /
+# output) by launching the imported image, installing through the in-guest cua
+# server, and re-capturing with CreateImage — exactly as the AWS script bakes the
+# aws CLI.
 #
-# Auth: ambient Alibaba credentials (`aliyun configure` / ALIBABA_CLOUD_ACCESS_KEY_*).
-# GCS reads use the host's gcloud login + a billing project (requester-pays).
+# Why per-OS paths (mirrors AWS): the Linux image needs the OSS CLIs baked in;
+# Windows images already ship what they need, so they go import-and-tag only.
+# Unlike AWS (whose import-image rejects ALE's Ubuntu HWE kernel, forcing
+# import-snapshot+register), Alibaba ImportImage accepts the raw directly, so
+# both OSes use ImportImage.
 #
-# Mirror of scripts/aws/import_images.sh. Aliyun differences:
-#   • ImportImage validates the guest OS but (unlike AWS import-image) accepts
-#     ALE's Ubuntu HWE kernel, so Linux goes straight through ImportImage.
-#   • The import source is an OSS object (RAW), not an S3 object.
+# Prerequisites:
+#   • OSS service ACTIVATED on the account (console one-time "开通 OSS"); the raw
+#     must live in OSS for ImportImage to read it.
+#   • ambient Alibaba credentials (`aliyun configure` / ALIBABA_CLOUD_ACCESS_KEY_*).
+#   • host gcloud login + a billing project for requester-pays GCS reads.
+#   • a security group `ale-sandbox` with a vSwitch in its VPC (see the docs /
+#     the live-setup the provider expects).
 set -euo pipefail
 export PATH="$HOME/.local/bin:$PATH"
-R="${ALE_ALIYUN_REGION:-cn-hangzhou}"
-UID_=$(aliyun sts GetCallerIdentity 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["AccountId"])')
-BUCKET="ale-images-$UID_"
-GCS=gs://ale-data-public/images
-BILLING="${ALE_GCS_BILLING_PROJECT:-agenthle-488519}"   # billed for requester-pays GCS reads
-SG_NAME=ale-sandbox
 say() { printf '\n=== %s ===\n' "$*"; }
-J() { python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+J()  { python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+R="${ALE_ALIYUN_REGION:-cn-hangzhou}"
+ACCT=$(aliyun sts GetCallerIdentity 2>/dev/null | J "['AccountId']")
+BUCKET="ale-images-$ACCT"
+GCS=gs://ale-data-public/images
+BILLING="${ALE_GCS_BILLING_PROJECT:-agenthle-488519}"   # requester-pays GCS reads
+SG_NAME=ale-sandbox
+BAKE_TYPE="${ALE_BAKE_INSTANCE_TYPE:-ecs.g7.2xlarge}"
 
 ensure_bucket() {                    # OSS import bucket exists (region-local)
-  ossutil ls "oss://$BUCKET/" >/dev/null 2>&1 || \
-    ossutil mb "oss://$BUCKET" --region "$R" >/dev/null
+  ossutil ls "oss://$BUCKET/" >/dev/null 2>&1 || ossutil mb "oss://$BUCKET" --region "$R" >/dev/null
 }
 
 ensure_raw() {                       # $1 family → ensure oss://$BUCKET/images/$1.raw
   local key="images/$1.raw"
   if ossutil stat "oss://$BUCKET/$key" >/dev/null 2>&1; then echo "raw present: $1"; return; fi
   say "stream $GCS/$1.tar.gz -> oss://$BUCKET/$key"
-  # gsutil can't write oss://, and ossutil can read stdin via `cp - oss://...`,
-  # so we pipe GCS → tar → ossutil. The full raw never lands on local disk.
+  # gsutil can't write oss://, but ossutil reads stdin via `cp - oss://...`, so
+  # pipe GCS → tar → ossutil; the full raw never lands on local disk.
   gsutil -u "$BILLING" cat "$GCS/$1.tar.gz" | tar -xzO | ossutil cp - "oss://$BUCKET/$key"
+}
+
+vsw_in_sg_vpc() {                    # echo a vSwitch id in the SG's VPC
+  local vpc; vpc=$(aliyun ecs DescribeSecurityGroups --RegionId "$R" \
+    --SecurityGroupName "$SG_NAME" | J "['SecurityGroups']['SecurityGroup'][0]['VpcId']")
+  aliyun ecs DescribeVSwitches --RegionId "$R" --VpcId "$vpc" \
+    | J "['VSwitches']['VSwitch'][0]['VSwitchId']"
+}
+
+sg_id() { aliyun ecs DescribeSecurityGroups --RegionId "$R" --SecurityGroupName "$SG_NAME" \
+    | J "['SecurityGroups']['SecurityGroup'][0]['SecurityGroupId']"; }
+
+wait_cua() {                         # $1 ip — wait up to 20 min for cua :5000
+  local ip=$1
+  for _ in $(seq 1 80); do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 6 "http://$ip:5000/status" 2>/dev/null)" = 200 ] \
+      && { echo "cua ready at $ip"; return 0; }
+    sleep 15
+  done
+  echo "cua never came up at $ip"; return 1
 }
 
 poll_image() {                       # $1 image-id → wait until Available
   while :; do
     local st; st=$(aliyun ecs DescribeImages --RegionId "$R" --ImageId "$1" \
-      | J "['Images']['Image'][0].get('Status','?')")
+      | J "['Images']['Image'][0]['Status']" 2>/dev/null || echo '?')
     echo "  $1 $st" >&2
     [ "$st" = Available ] && return
     case "$st" in CreateFailed|UnAvailable) echo "FAILED" >&2; return 1;; esac
@@ -64,30 +94,61 @@ tag_image() {                        # $1 image-id, $2 family
   echo "tagged $1 (ale:image-family=$2)"
 }
 
-import_one() {                       # $1 family, $2 OSType (linux|windows), $3 Platform
+import_base() {                      # $1 family, $2 OSType, $3 Platform → echo ImageId
   local fam=$1 ostype=$2 platform=$3
-  ensure_bucket; ensure_raw "$fam"
-  say "$fam: ImportImage (OSType=$ostype Platform=$platform)"
+  ensure_bucket; ensure_raw "$fam" >&2
+  say "$fam: ImportImage (OSType=$ostype Platform=$platform)" >&2
   local img
   img=$(aliyun ecs ImportImage --RegionId "$R" \
-    --ImageName "$fam-$(date +%s)" --OSType "$ostype" --Platform "$platform" \
+    --ImageName "$fam-base-$(date +%s)" --OSType "$ostype" --Platform "$platform" \
     --Architecture x86_64 --BootMode UEFI \
     --DiskDeviceMapping.1.OSSBucket "$BUCKET" \
     --DiskDeviceMapping.1.OSSObject "images/$fam.raw" \
-    --DiskDeviceMapping.1.Format RAW \
-    | J "['ImageId']")
-  echo "import image: $img"
-  poll_image "$img" || return 1
+    --DiskDeviceMapping.1.Format RAW | J "['ImageId']")
+  poll_image "$img" >&2 || { echo FAILED; return 1; }
+  echo "$img"
+}
+
+import_linux() {                     # $1 family — import, bake aliyun CLI + ossutil
+  local fam=$1 base bake_img sg subnet iid ip final
+  base=$(import_base "$fam" linux Ubuntu); [ "$base" = FAILED ] && return 1
+  say "$fam: bake aliyun CLI + ossutil (launch base, install via cua, CreateImage)"
+  sg=$(sg_id); subnet=$(vsw_in_sg_vpc)
+  iid=$(aliyun ecs RunInstances --RegionId "$R" --ImageId "$base" --InstanceType "$BAKE_TYPE" \
+    --Amount 1 --VSwitchId "$subnet" --SecurityGroupId "$sg" --InternetMaxBandwidthOut 100 \
+    --InstanceName ale-rebake --InstanceChargeType PostPaid --SystemDisk.Category cloud_essd \
+    --Tag.1.Key purpose --Tag.1.Value ale-run | J "['InstanceIdSets']['InstanceIdSet'][0]")
+  for _ in $(seq 1 40); do ip=$(aliyun ecs DescribeInstances --RegionId "$R" --InstanceIds "[\"$iid\"]" \
+    | J "['Instances']['Instance'][0].get('PublicIpAddress',{}).get('IpAddress',['']) [0]" 2>/dev/null); \
+    [ -n "$ip" ] && break; sleep 10; done
+  wait_cua "$ip" || { aliyun ecs DeleteInstance --RegionId "$R" --InstanceId "$iid" --Force true >/dev/null; return 1; }
+  # Install ossutil + aliyun CLI inside the guest, driven through the cua server
+  # (same channel the AWS script uses to bake the aws CLI). 900s: cold install.
+  local inst='curl -fsSL https://github.com/aliyun/ossutil/releases/download/v1.7.18/ossutil-v1.7.18-linux-amd64.zip -o /tmp/o.zip && cd /tmp && unzip -qo o.zip && sudo install -m755 ossutil-v1.7.18-linux-amd64/ossutil /usr/local/bin/ossutil && curl -fsSL https://github.com/aliyun/aliyun-cli/releases/download/v3.4.2/aliyun-cli-linux-3.4.2-amd64.tgz -o /tmp/a.tgz && tar -xzf /tmp/a.tgz -C /tmp && sudo install -m755 /tmp/aliyun /usr/local/bin/aliyun && /usr/local/bin/ossutil --version && /usr/local/bin/aliyun version'
+  curl -s --max-time 900 -X POST "http://$ip:5000/cmd" -H 'Content-Type: application/json' \
+    -d "$(python3 -c 'import json,sys;print(json.dumps({"command":"run_command","params":{"command":sys.argv[1]}}))' "$inst")" \
+    | tr '\r' '\n' | grep '^data:' | head -1 | sed 's/^data: //' | J "['stdout'][-60:]" || true
+  final=$(aliyun ecs CreateImage --RegionId "$R" --InstanceId "$iid" \
+    --ImageName "$fam-$(date +%s)" --Description "$fam + aliyun CLI + ossutil" | J "['ImageId']")
+  poll_image "$final"
+  tag_image "$final" "$fam"
+  # retire base image + builder
+  aliyun ecs DeleteImage --RegionId "$R" --ImageId "$base" 2>/dev/null || true
+  aliyun ecs DeleteInstance --RegionId "$R" --InstanceId "$iid" --Force true >/dev/null
+  echo "LINUX_DONE $fam -> $final"
+}
+
+import_windows() {                   # $1 family — import + tag (no bake needed)
+  local fam=$1 img
+  img=$(import_base "$fam" windows Windows); [ "$img" = FAILED ] && return 1
   tag_image "$img" "$fam"
-  echo "DONE $fam -> $img"
+  echo "WINDOWS_DONE $fam -> $img"
 }
 
 case "${1:?usage: import_images.sh ale-ubuntu22|ale-win10|ale-win-server|all}" in
-  ale-ubuntu22)   import_one ale-ubuntu22   linux   Ubuntu ;;
-  ale-win10)      import_one ale-win10       windows Windows ;;
-  ale-win-server) import_one ale-win-server  windows Windows ;;
-  all)            import_one ale-ubuntu22 linux Ubuntu
-                  import_one ale-win10 windows Windows
-                  import_one ale-win-server windows Windows ;;
+  ale-ubuntu22)   import_linux ale-ubuntu22 ;;
+  ale-win10)      import_windows ale-win10 ;;
+  ale-win-server) import_windows ale-win-server ;;
+  all)            import_linux ale-ubuntu22; import_windows ale-win10; import_windows ale-win-server ;;
   *) echo "unknown image $1"; exit 2 ;;
 esac

--- a/scripts/aliyun/import_images.sh
+++ b/scripts/aliyun/import_images.sh
@@ -144,7 +144,9 @@ import_linux() {                     # $1 family — import, bake aliyun CLI + o
     | tr '\r' '\n' | grep '^data:' | head -1 | sed 's/^data: //' | J "['stdout'][-60:]" || true
   final=$(aliyun ecs CreateImage --RegionId "$R" --InstanceId "$iid" \
     --ImageName "$fam-$(date +%s)" --Description "$fam + aliyun CLI + ossutil" | J "['ImageId']")
-  poll_image "$final"
+  # Under `set -e`, a poll_image failure here would exit before the cleanup
+  # below — leaking the (billable) builder instance. Delete it on failure.
+  poll_image "$final" || { aliyun ecs DeleteInstance --RegionId "$R" --InstanceId "$iid" --Force true >/dev/null 2>&1 || true; return 1; }
   tag_image "$final" "$fam"
   # retire base image + builder
   aliyun ecs DeleteImage --RegionId "$R" --ImageId "$base" 2>/dev/null || true

--- a/scripts/aliyun/import_images.sh
+++ b/scripts/aliyun/import_images.sh
@@ -106,6 +106,12 @@ import_base() {                      # $1 family, $2 OSType, $3 Platform → ech
   local fam=$1 ostype=$2 platform=$3
   ensure_bucket; ensure_raw "$fam" >&2
   say "$fam: ImportImage (OSType=$ostype Platform=$platform)" >&2
+  # --Platform is a CLOSED enum. The bare value "Windows" is rejected
+  # (InvalidPlatform.Malformed), and OMITTING it makes ImportImage auto-detect a
+  # Windows disk as OSType=linux (Platform "Others Linux") — which then skips
+  # Alibaba's Windows virtio driver injection, so the booted guest has no NIC and
+  # cua is unreachable. So Windows MUST pass an explicit Server platform (e.g.
+  # "Windows Server 2022"); that yields OSType=windows + proper driver injection.
   local img
   img=$(aliyun ecs ImportImage --RegionId "$R" \
     --ImageName "$fam-base-$(date +%s)" --OSType "$ostype" --Platform "$platform" \
@@ -147,8 +153,10 @@ import_linux() {                     # $1 family — import, bake aliyun CLI + o
 }
 
 import_windows() {                   # $1 family — import + tag (no bake needed)
+  # Explicit Server platform → OSType=windows + virtio driver injection (a bare
+  # or omitted Platform mis-detects as Linux and the guest boots with no NIC).
   local fam=$1 img
-  img=$(import_base "$fam" windows Windows); [ "$img" = FAILED ] && return 1
+  img=$(import_base "$fam" windows "Windows Server 2022"); [ "$img" = FAILED ] && return 1
   tag_image "$img" "$fam"
   echo "WINDOWS_DONE $fam -> $img"
 }

--- a/scripts/aliyun/sync_task_data.sh
+++ b/scripts/aliyun/sync_task_data.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Sync ALE task data from gs://ale-data-public (GCS) to the Alibaba Cloud OSS
+# task-data bucket. The OSS bucket is requester-pays + public, so pullers (not
+# the owner) pay egress — mirrors gcloud's ale-data-public.
+#
+# Unlike scripts/aws/sync_task_data.sh (which streams cloud→cloud because gsutil
+# speaks s3:// via a boto provider), gsutil has NO OSS backend, so this stages a
+# subtree to a local temp dir, then `ossutil cp -r` into OSS. Sync one domain at
+# a time so the local staging stays bounded — the FULL dataset (~260 GiB) won't
+# fit on disk; for a bulk one-shot copy use Alibaba's Data Online Migration
+# (cross-cloud) service instead.
+#
+# Auth: GCS reads use the host's gcloud login + a billing project (ale-data-public
+# is requester-pays); OSS writes use ambient Alibaba creds (ossutil config / env).
+#
+# Usage:  ./sync_task_data.sh <gs://src-subtree> <oss://dst-subtree>
+#   e.g.  ./sync_task_data.sh gs://ale-data-public/demo oss://ale-data-<uid>/demo
+set -euo pipefail
+export PATH="$HOME/.local/bin:$PATH"
+SRC="${1:?usage: sync_task_data.sh gs://src-subtree oss://dst-subtree}"
+DST="${2:?usage: sync_task_data.sh gs://src-subtree oss://dst-subtree}"
+BILLING="${ALE_GCS_BILLING_PROJECT:-agenthle-488519}"   # billed for requester-pays GCS reads
+
+case "$SRC" in gs://*) ;; *) echo "src must be gs://..."; exit 2;; esac
+case "$DST" in oss://*) ;; *) echo "dst must be oss://..."; exit 2;; esac
+
+# Refuse the whole-bucket case: the local staging would blow up the disk.
+[ "$SRC" = "gs://ale-data-public" ] && {
+  echo "refusing to stage the full bucket locally — pass a domain subtree, or use"
+  echo "Alibaba Data Online Migration for a bulk cross-cloud copy."; exit 2; }
+
+STAGE=$(mktemp -d); trap 'rm -rf "$STAGE"' EXIT
+echo "staging $SRC -> $STAGE (requester-pays GCS billed to $BILLING)"
+gsutil -u "$BILLING" -m rsync -r "$SRC" "$STAGE"
+echo "pushing $STAGE -> $DST"
+ossutil cp -r -f --enable-symlink-dir "$STAGE/" "$DST/"
+echo "DONE: $DST is in sync with $SRC"

--- a/scripts/aliyun/sync_task_data.sh
+++ b/scripts/aliyun/sync_task_data.sh
@@ -1,37 +1,60 @@
 #!/usr/bin/env bash
 # Sync ALE task data from gs://ale-data-public (GCS) to the Alibaba Cloud OSS
-# task-data bucket. The OSS bucket is requester-pays + public, so pullers (not
-# the owner) pay egress — mirrors gcloud's ale-data-public.
+# task-data bucket. Mirror of scripts/aws/sync_task_data.sh.
 #
-# Unlike scripts/aws/sync_task_data.sh (which streams cloud→cloud because gsutil
-# speaks s3:// via a boto provider), gsutil has NO OSS backend, so this stages a
-# subtree to a local temp dir, then `ossutil cp -r` into OSS. Sync one domain at
-# a time so the local staging stays bounded — the FULL dataset (~260 GiB) won't
-# fit on disk; for a bulk one-shot copy use Alibaba's Data Online Migration
-# (cross-cloud) service instead.
+# AWS streams cloud→cloud because gsutil speaks s3:// via a boto provider. gsutil
+# has NO OSS backend and ossutil can't read gs://, so this stages to a local temp
+# dir then `ossutil cp -r` into OSS. To keep local disk bounded on the full
+# dataset (~260 GiB across domains), the default whole-bucket sync runs ONE
+# top-level domain at a time (stage → push → wipe → next) rather than staging
+# everything at once. For a bulk one-shot, Alibaba Data Online Migration
+# (cross-cloud) is faster.
+#
+# The OSS bucket should be requester-pays + public so pullers (not the owner) pay
+# egress — mirrors gcloud's ale-data-public. images/ is excluded (those are the
+# multi-hundred-GB VM image exports, not task data — they become custom images
+# via scripts/aliyun/import_images.sh).
 #
 # Auth: GCS reads use the host's gcloud login + a billing project (ale-data-public
 # is requester-pays); OSS writes use ambient Alibaba creds (ossutil config / env).
 #
-# Usage:  ./sync_task_data.sh <gs://src-subtree> <oss://dst-subtree>
-#   e.g.  ./sync_task_data.sh gs://ale-data-public/demo oss://ale-data-<uid>/demo
+# Usage:
+#   ./sync_task_data.sh                              # gs://ale-data-public -> oss://ale-data-<acct>, all domains
+#   ./sync_task_data.sh gs://src-subtree oss://dst   # one subtree (staged whole)
 set -euo pipefail
 export PATH="$HOME/.local/bin:$PATH"
-SRC="${1:?usage: sync_task_data.sh gs://src-subtree oss://dst-subtree}"
-DST="${2:?usage: sync_task_data.sh gs://src-subtree oss://dst-subtree}"
+J() { python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+ACCT=$(aliyun sts GetCallerIdentity 2>/dev/null | J "['AccountId']")
+SRC="${1:-gs://ale-data-public}"
+DST="${2:-oss://ale-data-$ACCT}"
 BILLING="${ALE_GCS_BILLING_PROJECT:-agenthle-488519}"   # billed for requester-pays GCS reads
+STAGE_ROOT="${ALE_STAGE_DIR:-$(mktemp -d)}"
+trap 'rm -rf "$STAGE_ROOT"' EXIT
 
 case "$SRC" in gs://*) ;; *) echo "src must be gs://..."; exit 2;; esac
 case "$DST" in oss://*) ;; *) echo "dst must be oss://..."; exit 2;; esac
 
-# Refuse the whole-bucket case: the local staging would blow up the disk.
-[ "$SRC" = "gs://ale-data-public" ] && {
-  echo "refusing to stage the full bucket locally — pass a domain subtree, or use"
-  echo "Alibaba Data Online Migration for a bulk cross-cloud copy."; exit 2; }
+stage_push() {                       # $1 gs-subtree  $2 oss-subtree
+  local stage; stage=$(mktemp -d "$STAGE_ROOT/XXXX")
+  echo "  stage $1 -> $stage"
+  gsutil -u "$BILLING" -m rsync -r "$1" "$stage"
+  echo "  push  $stage -> $2"
+  ossutil cp -r -f "$stage/" "$2/"
+  rm -rf "$stage"
+}
 
-STAGE=$(mktemp -d); trap 'rm -rf "$STAGE"' EXIT
-echo "staging $SRC -> $STAGE (requester-pays GCS billed to $BILLING)"
-gsutil -u "$BILLING" -m rsync -r "$SRC" "$STAGE"
-echo "pushing $STAGE -> $DST"
-ossutil cp -r -f --enable-symlink-dir "$STAGE/" "$DST/"
-echo "DONE: $DST is in sync with $SRC"
+if [ "$SRC" = "gs://ale-data-public" ] && [ -z "${2:-}" ]; then
+  # Whole-dataset default: one top-level domain at a time, excluding images/.
+  echo "syncing all domains $SRC -> $DST (GCS billed to $BILLING; excluding images/)"
+  for d in $(gsutil -u "$BILLING" ls "$SRC/" | sed -n 's#.*/\([^/]*\)/$#\1#p'); do
+    [ "$d" = images ] && { echo "skip images/"; continue; }
+    echo "=== domain: $d ==="
+    stage_push "$SRC/$d" "$DST/$d"
+  done
+  echo "DONE: all domains synced to $DST"
+else
+  # Explicit subtree: stage + push directly.
+  echo "syncing $SRC -> $DST (GCS billed to $BILLING)"
+  stage_push "$SRC" "$DST"
+  echo "DONE: $DST is in sync with $SRC"
+fi


### PR DESCRIPTION
## Summary

Adds an **`aliyun`** provider that runs ALE units on ephemeral **Alibaba Cloud ECS** instances, mirroring the merged **AWS provider (#10)** and the `gcloud` provider. Self-contained, additive dispatch — no changes to existing providers' behavior.

Concept mapping vs AWS: region→`RegionId`, subnet→`VSwitchId`, AZ→`ZoneId`, security group→`SecurityGroupId`(+`VpcId`), AMI→custom image (tag `ale:image-family`), IAM instance profile→**instance RAM role** (`ram_role_name`), S3→**OSS** (`ossutil`), `associate_public_ip`→`InternetMaxBandwidthOut>0`.

## What's included

- **Provider** `ale_run/environments/providers/aliyun.py` — `AliyunProvider` (+config, per-snapshot config). `acquire()`: resolve image-family→custom image, security-group→(id, vpc), zone→vSwitch; launch via `aliyun ecs RunInstances` with instance-type×zone retry (C→G fallback, capacity→next zone, transient→backoff); poll `DescribeInstances` to Running+IP; bring up cua-server; Windows-resolution best-fit. `release()`: `DeleteInstance --Force` / `StopInstance` / keep. Cloud-agnostic helpers imported from `gcloud.py`.
- **Wiring** — `factory`/`providers/__init__`/`experiment_spec` register `aliyun`; `config_loader` cred/routing split + `oss://` accepted for `task_data_source`/`output_path`.
- **Data path** — `task_data/ossbucket.py` (`ossutil` + instance RAM role, requester-pays) + `output_pull.push_to_oss` + lifecycle `oss://` branch.
- **Ops** — `configs/environments/environment_aliyun.yaml`; `scripts/aliyun/import_images.sh` (GCS→OSS→`ecs ImportImage`→tag; Linux bakes the CLIs) + `sync_task_data.sh`.
- **Docs** — `pages/aliyun.html` setup guide (mirrors `pages/aws.html`), nav + provider tables. Also completed AWS in four provider enumerations it had missed.

## Validated live on cn-hangzhou

| Path | Result |
|---|---|
| **Linux CPU** (`ale-ubuntu22`) | ✅ full e2e: acquire → cua → agent → eval → delete |
| **Windows CPU** (`ale-win10` → "Windows 10 Pro") | ✅ boot + cua (~144 s on `ecs.g7`) |
| **Windows CPU** (`ale-win-server` → "Windows Server 2022") | ✅ boot + cua (~112 s) |
| **GPU** | ❌ not supported (see below) |

Real cross-cloud bugs found + fixed by live testing (each its own commit): API `ErrorCode` classification vs the `SDK.ServerError` wrapper; transient post-launch `Stopped` tolerance; `DeleteInstance` retry through `Initializing`; `ossutil` has no stdin → stage raw to disk; **Windows import needs explicit `--Platform "Windows Server 2022"`** (omitting it auto-detects OSType=linux → no virtio NIC → cua timeout); GPU default was a BIOS-only type; zones pinned to verified-stock `cn-hangzhou-j/k`.

## Why GPU is not supported (kept out of the docs, per request)

GPU was investigated exhaustively; it is blocked at the **driver** level on the imported image. The full chain:

1. **Boot mode.** The published ALE images are **UEFI** (built on GCE). Alibaba's in-stock passthrough GPU types in cn-hangzhou (`gn7i-c8g1` A10, `gn6i` T4, `gn6v` V100) are **BIOS-only** and `RunInstances` rejects a UEFI image on them (`InvalidParameter.NotMatch: Image bootMode`). Re-importing with `--BootMode BIOS` lets it launch but Windows won't boot (UEFI/GPT disk has no MBR boot code).
2. **A UEFI GPU exists and works — infra-wise.** A full scan (25 UEFI-capable GPU types × 31 regions) found the **vGPU vWS** family `ecs.vgn7i-vws-*` (fractional A10, UEFI, in stock, vWS model = GCE's `nvidia-l4-vws`). A `vgn7i-vws-m4` box launches the UEFI image, **Windows boots, cua is ready in ~127 s, the vWS license is built-in, and the GPU is detected as `NVIDIA A10-8Q`.**
3. **But the driver can't be installed.** `nvidia-smi` fails ("couldn't communicate with the NVIDIA driver"); the device is `CM_PROB_DISABLED_SERVICE`. The image ships GCE's L4 driver `582.16` (wrong GPU + newer than Alibaba's A10 vGPU host, which needs GRID `475.14`), plus a phantom `NVIDIA L4` device. **Four install routes** — Cloud Assistant `grid_driver_install`, reboot+retry, the bundled `grid_intaller.exe` run directly, and with the display-capturing software stopped — **all fail identically and instantly at `InstallGpuDriver output: []`**. Alibaba's installer is an opaque binary that bails on the GCE-derived image, and the `475.14` package isn't separately obtainable (NVIDIA vGPU licensing portal).

**Conclusion:** GPU on Alibaba needs the ALE Windows image rebuilt from an **Alibaba-native** Windows base (where the vGPU driver installs cleanly) — a separate image-build project, out of scope here. Everything except the driver bind works. The docs simply state GPU is not supported; the `gpu-*` snapshots remain in the config for parity but won't run.

## How to use

See **`docs/ale-docs-site/pages/aliyun.html`**: `aliyun configure` → create VPC/vSwitch/security-group → `scripts/aliyun/import_images.sh <family>` to import the CPU images → point an experiment at `configs/environments/environment_aliyun.yaml` → `python -m ale_run run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
