### PR TITLE
feat: improve OpenClaw integration and add Codex run telemetry

### DIFF
--- a/ale_run/agents/codex/AGENTS.md
+++ b/ale_run/agents/codex/AGENTS.md
@@ -197,6 +197,7 @@ Notes:
 | `model_catalog_path` | str | `""` | Host path to a Codex model-catalog JSON (for models not in codex's bundled catalog); read + sanitised host-side, shipped into the sandbox |
 | `model_catalog_content` | str | `""` | Auto-populated from `model_catalog_path` (do not set by hand) — carries the catalog text to the in-sandbox deployer |
 | `feature_overrides` | dict | `{}` | `{feature_key: bool}` written to config.toml `[features]`; force-enable/disable codex features (== tool surface). Empty = codex defaults |
+| `otel_enabled` | bool | `true` | Start a run-local OTLP/HTTP receiver and persist complete Codex telemetry, API timing, prompts, and tool results. Raw requests use a bounded-record WAL that is incrementally mirrored from sandbox VMs; event and summary files are rebuilt from it during finalization |
 
 > `timeout_s` is **not** an agent knob — the episode wall budget is
 > orchestration-owned (the executor wraps `launch()` in `wait_for`).

--- a/ale_run/agents/codex/config.py
+++ b/ale_run/agents/codex/config.py
@@ -156,6 +156,11 @@ class CodexConfig:
     # ``{"multi_agent_v2": True, "multi_agent": False}``.
     feature_overrides: dict[str, bool] = field(default_factory=dict)
 
+    # Capture complete Codex OpenTelemetry logs for every run. The deployer
+    # starts a run-local OTLP/HTTP receiver and stores raw requests, flattened
+    # events, API-call timings, prompts, and tool arguments/results in work_dir.
+    otel_enabled: bool = True
+
     def __post_init__(self) -> None:
         # Load the catalog host-side (build_config) and embed its content so it
         # reaches the in-sandbox deployer. On the in-sandbox reconstruction the

--- a/ale_run/agents/codex/deployer.py
+++ b/ale_run/agents/codex/deployer.py
@@ -43,6 +43,7 @@ from ale_run.base_interface import (
 )
 
 from .config import CodexConfig
+from .telemetry import CodexOtelCollector, recover_telemetry_artifacts
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,11 @@ class CodexDeployer(BaseAgentDeployer):
 
     default_executor: ClassVar[str] = "sandbox"
     supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
-    hot_artifacts: ClassVar[tuple[str, ...]] = ("transcript.jsonl", "stderr.log")
+    hot_artifacts: ClassVar[tuple[str, ...]] = (
+        "transcript.jsonl",
+        "stderr.log",
+        "otel_requests.jsonl",
+    )
 
     # NPM stock fallback version (only relevant when nothing is on PATH and the
     # fork overlay is then applied on top). Last-resort value for ``version``.
@@ -333,7 +338,12 @@ class CodexDeployer(BaseAgentDeployer):
             except OSError:
                 pass
 
-    async def _write_codex_config(self, cfg: CodexConfig) -> None:
+    async def _write_codex_config(
+        self,
+        cfg: CodexConfig,
+        *,
+        otel_endpoint: str | None = None,
+    ) -> None:
         """Write ~/.codex/config.toml with MCP server + provider config."""
         sandbox = self.executor.sandbox
 
@@ -431,6 +441,18 @@ class CodexDeployer(BaseAgentDeployer):
                           for k, v in cfg.feature_overrides.items()),
             )
 
+        if otel_endpoint is not None:
+            config_toml += (
+                "\n[otel]\n"
+                'environment = "ale"\n'
+                "log_user_prompt = true\n"
+                'trace_exporter = "none"\n'
+                'metrics_exporter = "none"\n'
+                "exporter = { otlp-http = { "
+                f'endpoint = "{otel_endpoint}", protocol = "json"'
+                " } }\n"
+            )
+
         # Write config file (codex_config_dir created above).
         config_path = os.path.join(codex_config_dir, "config.toml")
         Path(config_path).write_text(config_toml, encoding="utf-8")
@@ -449,6 +471,7 @@ class CodexDeployer(BaseAgentDeployer):
         transcript_file = wd / "transcript.jsonl"
         stderr_log = wd / "stderr.log"
         pid_file = wd / "codex.pid"
+        collector = CodexOtelCollector(wd) if cfg.otel_enabled else None
 
         for f in (transcript_file, stderr_log, pid_file):
             if f.exists():
@@ -471,42 +494,44 @@ class CodexDeployer(BaseAgentDeployer):
         argv = self._build_argv(cfg)
         env = self._build_env(cfg)
 
-        t0 = time.monotonic()
-        with open(prompt_file, "rb") as pin, \
-             open(transcript_file, "wb") as tout, \
-             open(stderr_log, "wb") as terr:
-            proc = await asyncio.to_thread(
-                subprocess.Popen,
-                argv,
-                stdin=pin,
-                stdout=tout,
-                stderr=terr,
-                env=env,
-                cwd=str(wd),
-                start_new_session=True if hasattr(os, "setsid") else False,
-            )
-        pid_file.write_text(str(proc.pid), encoding="ascii")
-        logger.info("codex: spawned pid=%s", proc.pid)
-
-        # The episode wall budget is orchestration-owned: the executor
-        # wraps launch() in asyncio.wait_for(timeout=timeout_s) (derived
-        # from the task), so we just wait for the child here. If that
-        # budget fires we are cancelled mid-await; reap the child before
-        # propagating so it cannot outlive the run.
         try:
-            while proc.poll() is None:
-                await asyncio.sleep(_POLL_INTERVAL_S)
-        except asyncio.CancelledError:
-            # Reap codex *and its children* — multi-agent sub-processes and
-            # stdio MCP servers — so the wall-budget cancel can't leave orphans.
-            self._terminate_proc_group(proc, force=False)
-            try:
-                await asyncio.wait_for(
-                    asyncio.to_thread(proc.wait), timeout=_TERM_GRACE_S,
+            if collector is not None:
+                collector.start()
+                await self._write_codex_config(cfg, otel_endpoint=collector.endpoint)
+                logger.info("codex: OTel collector listening at %s", collector.endpoint)
+
+            t0 = time.monotonic()
+            with open(prompt_file, "rb") as pin, \
+                 open(transcript_file, "wb") as tout, \
+                 open(stderr_log, "wb") as terr:
+                proc = await asyncio.to_thread(
+                    subprocess.Popen,
+                    argv,
+                    stdin=pin,
+                    stdout=tout,
+                    stderr=terr,
+                    env=env,
+                    cwd=str(wd),
+                    start_new_session=True if hasattr(os, "setsid") else False,
                 )
-            except (asyncio.TimeoutError, asyncio.CancelledError):
-                self._terminate_proc_group(proc, force=True)
-            raise
+            pid_file.write_text(str(proc.pid), encoding="ascii")
+            logger.info("codex: spawned pid=%s", proc.pid)
+
+            try:
+                while proc.poll() is None:
+                    await asyncio.sleep(_POLL_INTERVAL_S)
+            except asyncio.CancelledError:
+                self._terminate_proc_group(proc, force=False)
+                try:
+                    await asyncio.wait_for(
+                        asyncio.to_thread(proc.wait), timeout=_TERM_GRACE_S,
+                    )
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    self._terminate_proc_group(proc, force=True)
+                raise
+        finally:
+            if collector is not None:
+                collector.stop()
 
         duration_s = time.monotonic() - t0
         exit_code = proc.returncode
@@ -636,6 +661,11 @@ class CodexDeployer(BaseAgentDeployer):
         - ``turn.completed``: usage stats
         - ``thread.started``, ``error``, etc.
         """
+        try:
+            recover_telemetry_artifacts(work_dir)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.warning("codex: could not recover telemetry artifacts: %s", exc)
+
         transcript_file = work_dir / "transcript.jsonl"
         if not transcript_file.exists():
             builder.add_step(
@@ -707,6 +737,8 @@ class CodexDeployer(BaseAgentDeployer):
         builder.trajectory.extra.setdefault("codex", {}).update({
             "exit_code": run_result.exit_code,
             "transcript_path": str(transcript_file),
+            "telemetry_path": str(work_dir / "telemetry.jsonl"),
+            "telemetry_summary_path": str(work_dir / "telemetry_summary.json"),
         })
 
     @classmethod

--- a/ale_run/agents/codex/telemetry.py
+++ b/ale_run/agents/codex/telemetry.py
@@ -1,0 +1,453 @@
+"""Per-run OpenTelemetry receiver for Codex CLI observability."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import json
+import os
+import threading
+import uuid
+from collections import Counter, deque
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Iterator
+
+_RAW_CHUNK_BYTES = 512 * 1024
+
+
+class CodexOtelCollector:
+    """Receive Codex OTLP/HTTP JSON logs and persist complete run telemetry."""
+
+    def __init__(self, work_dir: Path):
+        self.work_dir = work_dir
+        self.raw_path = work_dir / "otel_requests.jsonl"
+        self.events_path = work_dir / "telemetry.jsonl"
+        self.summary_path = work_dir / "telemetry_summary.json"
+        self._lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def endpoint(self) -> str:
+        if self._server is None:
+            raise RuntimeError("Codex OTel collector has not been started")
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}/v1/logs"
+
+    def start(self) -> None:
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        for path in (self.raw_path, self.events_path, self.summary_path):
+            path.unlink(missing_ok=True)
+
+        collector = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                if self.path != "/v1/logs":
+                    self.send_error(404)
+                    return
+
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length)
+                if self.headers.get("Content-Encoding", "").lower() == "gzip":
+                    body = gzip.decompress(body)
+
+                collector._store_request(dict(self.headers), body)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="codex-otel-collector",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+        self._write_summary()
+
+    def _store_request(self, headers: dict[str, str], body: bytes) -> None:
+        received_at = datetime.now(timezone.utc).isoformat()
+        try:
+            payload = json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+        events = (
+            list(_flatten_otlp_logs(payload, received_at))
+            if isinstance(payload, dict)
+            else []
+        )
+        request_id = uuid.uuid4().hex
+        chunks = [
+            body[offset : offset + _RAW_CHUNK_BYTES]
+            for offset in range(0, len(body), _RAW_CHUNK_BYTES)
+        ] or [b""]
+        payload_sha256 = hashlib.sha256(body).hexdigest()
+
+        with self._lock:
+            with self.raw_path.open("a", encoding="utf-8") as file:
+                for index, chunk in enumerate(chunks):
+                    record: dict[str, Any] = {
+                        "record_type": "otlp_request_chunk",
+                        "request_id": request_id,
+                        "received_at": received_at,
+                        "chunk_index": index,
+                        "chunk_count": len(chunks),
+                        "payload_encoding": "base64",
+                        "payload": base64.b64encode(chunk).decode("ascii"),
+                    }
+                    if index == 0:
+                        record["headers"] = headers
+                        record["payload_bytes"] = len(body)
+                        record["payload_sha256"] = payload_sha256
+                    file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                file.flush()
+                os.fsync(file.fileno())
+            if events:
+                with self.events_path.open("a", encoding="utf-8") as file:
+                    for event in events:
+                        file.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+    def _write_summary(self, events: list[dict[str, Any]] | None = None) -> None:
+        if events is None:
+            events = _read_jsonl(self.events_path)
+        events.sort(
+            key=lambda event: (
+                event.get("attributes", {}).get("event.timestamp")
+                or event.get("observed_time_unix_nano")
+                or ""
+            )
+        )
+
+        names = Counter(
+            event.get("attributes", {}).get("event.name", "unknown") for event in events
+        )
+        summary = {
+            "event_count": len(events),
+            "events_by_name": dict(sorted(names.items())),
+            "api_calls": _summarize_api_calls(events),
+            "transport_connections": [
+                event
+                for event in events
+                if event.get("attributes", {}).get("event.name") == "codex.websocket_connect"
+            ],
+            "time_to_first_token": [
+                event
+                for event in events
+                if event.get("attributes", {}).get("event.name") == "codex.turn_ttft"
+            ],
+            "tool_executions": _summarize_tools(events),
+            "artifacts": {
+                "raw_otlp_requests": self.raw_path.name,
+                "events": self.events_path.name,
+            },
+        }
+        self.summary_path.write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+def recover_telemetry_artifacts(work_dir: Path) -> int:
+    """Rebuild derived telemetry files from the incrementally mirrored raw WAL."""
+    raw_path = work_dir / "otel_requests.jsonl"
+    if not raw_path.exists():
+        return 0
+
+    events: list[dict[str, Any]] = []
+    for received_at, payload in _read_otlp_payloads(raw_path):
+        events.extend(_flatten_otlp_logs(payload, received_at))
+
+    events_path = work_dir / "telemetry.jsonl"
+    _write_jsonl_atomic(events_path, events)
+    collector = CodexOtelCollector(work_dir)
+    collector._write_summary(events)
+    return len(events)
+
+
+def _read_otlp_payloads(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
+    current_request_id: str | None = None
+    current_state: dict[str, Any] | None = None
+
+    for record in _iter_jsonl(path):
+        if record.get("record_type") != "otlp_request_chunk":
+            if current_state is not None:
+                decoded = _decode_chunked_payload(current_state)
+                if decoded is not None:
+                    yield decoded
+                current_request_id = None
+                current_state = None
+            legacy_body = record.get("body", {})
+            if isinstance(legacy_body, dict) and isinstance(legacy_body.get("json"), dict):
+                yield str(record.get("received_at", "")), legacy_body["json"]
+            continue
+
+        request_id = record.get("request_id")
+        chunk_index = record.get("chunk_index")
+        chunk_count = record.get("chunk_count")
+        encoded = record.get("payload")
+        if (
+            not isinstance(request_id, str)
+            or not isinstance(chunk_index, int)
+            or not isinstance(chunk_count, int)
+            or chunk_count < 1
+            or not isinstance(encoded, str)
+        ):
+            continue
+
+        if request_id != current_request_id:
+            if current_state is not None:
+                decoded = _decode_chunked_payload(current_state)
+                if decoded is not None:
+                    yield decoded
+            current_request_id = request_id
+            current_state = {
+                "received_at": str(record.get("received_at", "")),
+                "chunk_count": chunk_count,
+                "chunks": {},
+                "payload_sha256": record.get("payload_sha256"),
+            }
+
+        if current_state["chunk_count"] != chunk_count or not 0 <= chunk_index < chunk_count:
+            current_state["invalid"] = True
+            continue
+        try:
+            current_state["chunks"][chunk_index] = base64.b64decode(
+                encoded, validate=True,
+            )
+        except (ValueError, TypeError):
+            current_state["invalid"] = True
+
+    if current_state is not None:
+        decoded = _decode_chunked_payload(current_state)
+        if decoded is not None:
+            yield decoded
+
+
+def _decode_chunked_payload(
+    state: dict[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    chunks = state["chunks"]
+    if state.get("invalid") or len(chunks) != state["chunk_count"]:
+        return None
+    body = b"".join(chunks[index] for index in range(state["chunk_count"]))
+    expected_sha256 = state.get("payload_sha256")
+    if expected_sha256 and hashlib.sha256(body).hexdigest() != expected_sha256:
+        return None
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return state["received_at"], payload
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return list(_iter_jsonl(path))
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8", errors="replace") as file:
+        for line in file:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                yield record
+
+
+def _write_jsonl_atomic(path: Path, records: list[dict[str, Any]]) -> None:
+    tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8") as file:
+            for record in records:
+                file.write(json.dumps(record, ensure_ascii=False) + "\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _flatten_otlp_logs(payload: dict[str, Any], received_at: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for resource_log in payload.get("resourceLogs", []):
+        resource = _attributes(resource_log.get("resource", {}).get("attributes", []))
+        for scope_log in resource_log.get("scopeLogs", []):
+            scope_data = scope_log.get("scope", {})
+            scope = {
+                "name": scope_data.get("name"),
+                "version": scope_data.get("version"),
+                "attributes": _attributes(scope_data.get("attributes", [])),
+            }
+            for record in scope_log.get("logRecords", []):
+                events.append(
+                    {
+                        "received_at": received_at,
+                        "time_unix_nano": record.get("timeUnixNano"),
+                        "observed_time_unix_nano": record.get("observedTimeUnixNano"),
+                        "severity_number": record.get("severityNumber"),
+                        "severity_text": record.get("severityText"),
+                        "body": _any_value(record.get("body")),
+                        "attributes": _attributes(record.get("attributes", [])),
+                        "resource": resource,
+                        "scope": scope,
+                        "trace_id": record.get("traceId"),
+                        "span_id": record.get("spanId"),
+                        "flags": record.get("flags"),
+                    }
+                )
+    return events
+
+
+def _attributes(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {item.get("key", ""): _any_value(item.get("value")) for item in items if item.get("key")}
+
+
+def _any_value(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "boolValue" in value:
+        return value["boolValue"]
+    if "intValue" in value:
+        try:
+            return int(value["intValue"])
+        except (TypeError, ValueError):
+            return value["intValue"]
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    if "bytesValue" in value:
+        return value["bytesValue"]
+    if "arrayValue" in value:
+        return [_any_value(item) for item in value["arrayValue"].get("values", [])]
+    if "kvlistValue" in value:
+        return _attributes(value["kvlistValue"].get("values", []))
+    return value
+
+
+def _summarize_api_calls(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    pending: deque[dict[str, Any]] = deque()
+    calls: list[dict[str, Any]] = []
+
+    for event in events:
+        attributes = event.get("attributes", {})
+        event_name = attributes.get("event.name")
+        if event_name in {"codex.api_request", "codex.websocket_request"}:
+            completed_at = _parse_timestamp(attributes.get("event.timestamp"))
+            transport_duration = _int_or_none(attributes.get("duration_ms"))
+            started_at = None
+            if completed_at is not None and transport_duration is not None:
+                started_at = completed_at.timestamp() * 1000 - transport_duration
+            call = {
+                "sequence": len(calls) + 1,
+                "transport": ("http" if event_name == "codex.api_request" else "websocket"),
+                "started_at": _format_epoch_ms(started_at),
+                "transport_completed_at": attributes.get("event.timestamp"),
+                "response_completed_at": None,
+                "transport_duration_ms": transport_duration,
+                "response_duration_ms": None,
+                "status_code": attributes.get("http.response.status_code"),
+                "attempt": attributes.get("attempt"),
+                "endpoint": attributes.get("endpoint"),
+                "attributes": attributes,
+            }
+            calls.append(call)
+            pending.append(call)
+            continue
+
+        if (
+            event_name == "codex.sse_event"
+            and attributes.get("event.kind") == "response.completed"
+            and pending
+        ):
+            call = pending.popleft()
+            completed_at = _parse_timestamp(attributes.get("event.timestamp"))
+            started_at = _parse_timestamp(call["started_at"])
+            call["response_completed_at"] = attributes.get("event.timestamp")
+            if completed_at is not None and started_at is not None:
+                call["response_duration_ms"] = round(
+                    (completed_at - started_at).total_seconds() * 1000
+                )
+            call["response_completed_event"] = event
+
+    return calls
+
+
+def _summarize_tools(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for event in events:
+        attributes = event.get("attributes", {})
+        if attributes.get("event.name") != "codex.tool_result":
+            continue
+        completed_at = _parse_timestamp(attributes.get("event.timestamp"))
+        duration_ms = _int_or_none(attributes.get("duration_ms"))
+        started_at = None
+        if completed_at is not None and duration_ms is not None:
+            started_at = completed_at.timestamp() * 1000 - duration_ms
+        tools.append(
+            {
+                "sequence": len(tools) + 1,
+                "tool_name": attributes.get("tool_name"),
+                "call_id": attributes.get("call_id"),
+                "started_at": _format_epoch_ms(started_at),
+                "completed_at": attributes.get("event.timestamp"),
+                "duration_ms": duration_ms,
+                "success": attributes.get("success"),
+                "arguments": attributes.get("arguments"),
+                "output": attributes.get("output"),
+                "mcp_server": attributes.get("mcp_server"),
+                "mcp_server_origin": attributes.get("mcp_server_origin"),
+                "event": event,
+            }
+        )
+    return tools
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_epoch_ms(value: float | None) -> str | None:
+    if value is None:
+        return None
+    return (
+        datetime.fromtimestamp(value / 1000, timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/ale_run/agents/openclaw_cli/README.md
+++ b/ale_run/agents/openclaw_cli/README.md
@@ -32,7 +32,7 @@ install time via `npm install` + esbuild (`npm run build`).
 | Auth profiles | `~/.openclaw/agents/main/agent/auth-profiles.json` |
 | Sessions | `~/.openclaw/agents/main/sessions/<sid>.jsonl` |
 
-## Provider — OpenRouter or Direct
+## Provider Routing
 
 Auth is configured via `auth-profiles.json`. Routing is **explicit**, set
 by the `provider` config field (not inferred from which keys are in the
@@ -46,6 +46,16 @@ env):
   `anthropic/...`) uses the `anthropic` provider + `ANTHROPIC_API_KEY`.
   `OPENROUTER_API_KEY` is dropped from the launch env so it can't override
   the chosen direct provider.
+- `provider: zai` — the native Z.AI provider uses `ZAI_API_KEY` or
+  `Z_AI_API_KEY`. Set `base_url` to select the global, CN, or coding endpoint.
+- `provider: custom` — registers an OpenAI-compatible endpoint under
+  `provider_id`. `model_id` is the provider-facing deployment name, while the
+  top-level `model` remains the human-facing experiment label. The key is read
+  from `api_key_env`.
+
+`vision_provider` can route screenshot analysis independently from the
+primary model. For example, a text-only Z.AI model can use
+`vision_provider: direct` with `vision_model: openai/gpt-5.4`.
 
 Missing the required key for the chosen provider is a hard error.
 
@@ -78,8 +88,8 @@ agent:
   harness: openclaw_cli
   model: openai/gpt-5.4
   config:
-    provider: openrouter   # or "direct" (native openai/anthropic)
-    timeout_s: 1800
+    provider: openrouter   # or "direct" / "zai" / "custom"
+    agent_timeout_s: 1800
     thinking: high
     tarball_path: /opt/ale/openclaw-fork.tgz
     tarball_url: https://github.com/cua-verse/openclaw/releases/download/v0.1.0/openclaw-fork.tgz
@@ -90,10 +100,20 @@ agent:
 
 | Field | Meaning |
 |---|---|
-| `provider` | Routing: `openrouter` (default) or `direct` (native openai/anthropic) |
+| `provider` | Primary routing: `openrouter` (default), `direct`, `zai`, or `custom` |
+| `provider_id` | OpenClaw provider id for a custom route |
+| `model_id` | Provider-facing model or deployment id for a custom route |
+| `base_url` | Optional OpenAI-compatible endpoint override |
+| `api_key_env` | Environment variable containing a custom provider key |
+| `provider_api` | OpenClaw transport for a custom provider; defaults to `openai-completions` |
+| `supports_usage_in_streaming` | Request streamed token usage metadata; defaults to `true` |
 | `model` | Model slug. OpenRouter: `openai/gpt-5.4`, `anthropic/claude-sonnet-4-6`. Direct: `gpt-5.4` or `claude-sonnet-4-6` |
-| `thinking` | Reasoning depth: `off\|low\|medium\|high` |
+| `model_params` | Provider-specific model parameters; use `extra_body` for raw request fields |
+| `thinking` | Provider-specific reasoning depth; common values are `off`, `on`, `low`, `medium`, `high`, and `max` |
 | `vision_model` | Per-tool model override for image analysis |
+| `vision_provider` | Optional independent route for `vision_model`; `null` inherits `provider` |
+| `vision_base_url` | Optional endpoint override for the vision route |
+| `vision_api_key` | Optional key override for the vision route |
 | `tools_deny` | Tools removed from the schema |
 | `plugins_allow` | Which plugins load at startup |
 | `heartbeat_every` | `"never"` skips background loop |

--- a/ale_run/agents/openclaw_cli/config.py
+++ b/ale_run/agents/openclaw_cli/config.py
@@ -3,7 +3,7 @@
 OpenClaw is installed from a fork tarball (not public npm).
 CUA bridge is the native OpenClaw plugin (not MCP).
 
-Auth: API keys set via auth-profiles.json (OpenRouter or direct).
+Auth: API keys set via auth-profiles.json.
 """
 from __future__ import annotations
 
@@ -65,7 +65,7 @@ class OpenClawCliConfig:
     # agenthle openclaw_cli_openrouter_gpt-5_4.yaml: openai/gpt-5.4.
     model: str = "openai/gpt-5.4"
 
-    # ---- routing (no secrets — API keys come from shell env) ----
+    # ---- primary-model routing ----
     provider: str = "openrouter"
     """Routing provider, drives auth-profile + model-prefix setup
     explicitly (not a key-presence heuristic):
@@ -78,7 +78,19 @@ class OpenClawCliConfig:
         (``claude-*`` / ``anthropic/...``) uses the ``anthropic`` provider
         + ANTHROPIC_API_KEY. OPENROUTER_API_KEY is dropped from the launch
         env so it cannot override the chosen direct provider.
+      - ``"zai"`` → Z.AI's native provider via ZAI_API_KEY,
+        Z_AI_API_KEY, or GLM_API_KEY; a custom CN/global endpoint can be
+        set with ``base_url``.
+      - ``"custom"`` → a named OpenAI-compatible provider declared through
+        ``provider_id``, ``model_id``, ``base_url``, and ``api_key_env``.
     Missing the required key for the chosen provider is a hard error."""
+
+    provider_id: str | None = None
+    """OpenClaw provider id used when ``provider: custom``."""
+
+    model_id: str | None = None
+    """Provider-facing model/deployment id. The top-level ``model`` remains
+    the human-facing model name recorded in experiment logs."""
 
     base_url: str | None = None
     """Custom OpenAI-compatible base URL for the resolved provider, written
@@ -97,6 +109,23 @@ class OpenClawCliConfig:
     serialized config, needs no env-passthrough whitelist change, and does not
     collide with a real OPENROUTER_API_KEY in the shell env."""
 
+    api_key_env: str | None = None
+    """Environment variable containing the key for ``provider: custom``."""
+
+    provider_api: str = "openai-completions"
+    """OpenClaw transport used by a custom provider."""
+
+    supports_usage_in_streaming: bool = True
+    """Request usage metadata in streamed responses. OpenAI-compatible
+    endpoints normally support this via ``stream_options.include_usage``;
+    disable only for an endpoint that rejects that request field."""
+
+    model_params: dict[str, object] | None = None
+    """Provider-specific parameters written to the primary model's
+    ``agents.defaults.models.<provider/model>.params`` entry. Use
+    ``extra_body`` for request-body fields that the OpenClaw transport does
+    not natively expose."""
+
     # OpenClaw's OWN internal run budget, written into openclaw.json
     # (``timeoutSeconds``) and passed as ``agent --local --timeout <s>``.
     # This is an agent-consumed knob (the CLI enforces it itself), distinct
@@ -104,12 +133,27 @@ class OpenClawCliConfig:
     # openclaw_cli_openrouter_gpt-5_4.yaml: timeout_seconds: 600.
     agent_timeout_s: int = 600
 
-    # agenthle openclaw_cli deployer default (_thinking_level): "high".
+    # Provider-specific accepted values are validated by OpenClaw.
     thinking: str = "high"
     # agenthle openclaw_cli_openrouter_gpt-5_4.yaml sets vision_model to the
     # same id as model; the dataclass default was None but every operational
     # openclaw_cli yaml pins it, so default to the gpt-5.4 operational value.
     vision_model: str | None = "openai/gpt-5.4"
+    """Image model used by both the explicit ``image`` tool and automatic
+    media understanding."""
+
+    vision_provider: str | None = None
+    """Routing mode for ``vision_model``. ``None`` inherits ``provider``.
+    Set ``"direct"`` to route a vision model through its native provider
+    while the primary model uses a gateway or Z.AI endpoint."""
+
+    vision_base_url: str | None = None
+    """Optional endpoint override for the vision route. When
+    ``vision_provider`` is unset, ``None`` inherits ``base_url``."""
+
+    vision_api_key: str | None = None
+    """Optional API key for the vision route. Native-provider environment
+    variables are used when omitted."""
     tools_deny: tuple[str, ...] = _TOOLS_DENY
     # Matches the agenthle openclaw_*_openrouter*.yaml plugins.allow: the
     # `memory-core` plugin provides the harmless `memory_get` file reader

--- a/ale_run/agents/openclaw_cli/deployer.py
+++ b/ale_run/agents/openclaw_cli/deployer.py
@@ -37,6 +37,13 @@ from ale_run.base_interface import (
 )
 
 from .config import CUA_TOOL_NAMES, OpenClawCliConfig
+from .vision import (
+    VisionUsageProxy,
+    persist_transcript_images,
+    read_image_model_usage,
+    run_dir_for_artifacts,
+    stage_transcript_file_images,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +52,6 @@ _TERM_GRACE_S = 2.0
 _AGENT_ID = "main"
 _PLUGIN_PROVIDER_IDS = frozenset({"anthropic", "openai", "openrouter", "zai"})
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
 _STDERR_PREAMBLE_PREFIXES = (
     "[agent/embedded] session file repaired",
     "[agent/embedded] embedded run agent end",
@@ -342,6 +348,65 @@ class OpenClawCliDeployer(BaseAgentDeployer):
             "(expected 'openrouter', 'direct', 'zai', or 'custom')"
         )
 
+    def _start_vision_usage_proxy(
+        self,
+        cfg: OpenClawCliConfig,
+        work_dir: Path,
+    ) -> None:
+        if not cfg.vision_model:
+            return
+        routing_provider = cfg.vision_provider or cfg.provider
+        try:
+            resolved_provider = self._direct_provider_for_model(cfg.vision_model)
+        except RuntimeError:
+            return
+        if routing_provider != "direct" or resolved_provider != "openai":
+            return
+        primary_route_model = cfg.model_id or cfg.model
+        if (
+            cfg.provider == "direct"
+            and self._direct_provider_for_model(primary_route_model) == "openai"
+        ) or (
+            cfg.provider == "custom"
+            and cfg.provider_id == "openai"
+        ):
+            logger.info(
+                "openclaw_cli: image usage capture skipped because the primary "
+                "and vision routes share the OpenAI provider"
+            )
+            return
+
+        upstream_url = cfg.vision_base_url or "https://api.openai.com/v1"
+        try:
+            proxy = VisionUsageProxy(
+                upstream_url=upstream_url,
+                usage_log=work_dir / "vision-usage.jsonl",
+                provider="openai",
+                model=cfg.vision_model.split("/", 1)[-1],
+            )
+        except ValueError:
+            logger.warning(
+                "openclaw_cli: vision usage proxy skipped for unsupported "
+                "upstream URL %s",
+                upstream_url,
+            )
+            return
+        proxy.start()
+        self._vision_usage_proxy = proxy
+        self._vision_usage_proxy_provider = "openai"
+        self._vision_usage_proxy_url = proxy.base_url
+        logger.info(
+            "openclaw_cli: vision usage proxy listening at %s",
+            self._vision_usage_proxy_url,
+        )
+
+    def _stop_vision_usage_proxy(self) -> None:
+        proxy = getattr(self, "_vision_usage_proxy", None)
+        if proxy is None:
+            return
+        proxy.stop()
+        self._vision_usage_proxy = None
+
     def _write_config(self, cfg: OpenClawCliConfig) -> None:
         """Write openclaw.json, auth-profiles.json, exec-approvals, workspace-state."""
         home = os.path.expanduser("~")
@@ -383,6 +448,9 @@ class OpenClawCliDeployer(BaseAgentDeployer):
                 api_key_env=cfg.api_key_env,
                 purpose="vision",
             )
+            proxy_url = getattr(self, "_vision_usage_proxy_url", None)
+            if proxy_url:
+                vision_base_url = proxy_url
 
         # --- openclaw.json ---
         primary_model = self._route_model(primary_route_model, provider)
@@ -518,11 +586,22 @@ class OpenClawCliDeployer(BaseAgentDeployer):
                 if catalog_provider == "zai" or catalog_api:
                     existing["api"] = catalog_api or "openai-completions"
                 provider_catalogs[catalog_provider] = existing
+            if (
+                catalog_provider
+                == getattr(self, "_vision_usage_proxy_provider", None)
+            ):
+                existing["request"] = {"allowPrivateNetwork": True}
             if not any(model["id"] == catalog_id for model in existing["models"]):
                 model_entry = {
                     "id": catalog_id,
                     "name": catalog_name or catalog_id,
                 }
+                if (
+                    catalog_provider
+                    == getattr(self, "_vision_usage_proxy_provider", None)
+                    and catalog_model == cfg.vision_model
+                ):
+                    model_entry["input"] = ["text", "image"]
                 if cfg.provider == "custom" and catalog_provider == provider:
                     model_entry["compat"] = {
                         "maxTokensField": "max_completion_tokens",
@@ -742,11 +821,19 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         else:
             logger.info("openclaw_cli: CUA plugin already installed")
 
-        # 3. Write config files
-        self._write_config(cfg)
+        # 3. Route the direct OpenAI vision model through an ALE-owned
+        # loopback proxy that records response usage only.
+        self._start_vision_usage_proxy(cfg, wd)
 
-        # 4. Pre-warm the bundled-plugin runtime-deps mirror.
-        await self._prewarm_plugin_runtime_mirror(cfg)
+        try:
+            # 4. Write config files
+            self._write_config(cfg)
+
+            # 5. Pre-warm the bundled-plugin runtime-deps mirror.
+            await self._prewarm_plugin_runtime_mirror(cfg)
+        except BaseException:
+            self._stop_vision_usage_proxy()
+            raise
 
     async def _prewarm_plugin_runtime_mirror(self, cfg: OpenClawCliConfig) -> None:
         """Force OpenClaw to build its bundled-plugin runtime-deps mirror now,
@@ -893,8 +980,10 @@ class OpenClawCliDeployer(BaseAgentDeployer):
                     proc.kill()
                 except ProcessLookupError:
                     pass
+            self._stop_vision_usage_proxy()
             raise
 
+        self._stop_vision_usage_proxy()
         duration_s = time.monotonic() - t0
         exit_code = proc.returncode
         status = "completed" if result_envelope is not None or exit_code == 0 else "failed"
@@ -912,6 +1001,7 @@ class OpenClawCliDeployer(BaseAgentDeployer):
             dst = wd / "transcript.jsonl"
             if src.exists():
                 shutil.copy2(str(src), str(dst))
+                stage_transcript_file_images(dst, wd)
                 logger.info("openclaw_cli: copied session trajectory to %s", dst)
 
         return AgentRunResult(
@@ -1020,6 +1110,10 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         # 1. Parse session trajectory JSONL (if available)
         transcript_file = work_dir / "transcript.jsonl"
         if transcript_file.exists():
+            persist_transcript_images(
+                transcript_file,
+                run_dir_for_artifacts(work_dir),
+            )
             raw = transcript_file.read_text(encoding="utf-8", errors="replace")
             for line in raw.splitlines():
                 line = line.strip()
@@ -1046,6 +1140,12 @@ class OpenClawCliDeployer(BaseAgentDeployer):
                     final_metrics = _usage_final_metrics(usage)
                     if final_metrics:
                         builder.override_final_metrics(**final_metrics)
+
+        image_usage = read_image_model_usage(work_dir / "vision-usage.jsonl")
+        if image_usage:
+            builder.trajectory.extra.setdefault("openclaw_cli", {})[
+                "image_model_usage"
+            ] = image_usage
 
         if not transcript_file.exists():
             builder.add_step(
@@ -1149,6 +1249,18 @@ class OpenClawCliDeployer(BaseAgentDeployer):
                                         data=c.get("data"),
                                     ),
                                 ))
+                            elif c.get("type") == "image" and c.get("path"):
+                                parts.append(ContentPart(
+                                    type="image",
+                                    image=ImageSource(
+                                        type="path",
+                                        media_type=c.get(
+                                            "mimeType",
+                                            "image/png",
+                                        ),
+                                        path=c.get("path"),
+                                    ),
+                                ))
                     results.append(ToolResult(
                         tool_call_id=block.get("tool_use_id") or block.get("call_id", ""),
                         content=parts,
@@ -1186,6 +1298,15 @@ class OpenClawCliDeployer(BaseAgentDeployer):
                             type="base64",
                             media_type=block.get("mimeType", "image/png"),
                             data=block.get("data"),
+                        ),
+                    ))
+                elif btype == "image" and block.get("path"):
+                    parts.append(ContentPart(
+                        type="image",
+                        image=ImageSource(
+                            type="path",
+                            media_type=block.get("mimeType", "image/png"),
+                            path=block.get("path"),
                         ),
                     ))
             if not parts:

--- a/ale_run/agents/openclaw_cli/deployer.py
+++ b/ale_run/agents/openclaw_cli/deployer.py
@@ -16,7 +16,6 @@ import asyncio
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -717,14 +716,32 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         pid_file.write_text(str(proc.pid), encoding="ascii")
         logger.info("openclaw_cli: spawned pid=%s", proc.pid)
 
-        # The episode wall budget is orchestration-owned: the executor wraps
-        # launch() in asyncio.wait_for(timeout=timeout_s) (derived from the
-        # task), so we just wait for the child here. (OpenClaw also enforces
-        # its own internal --timeout=agent_timeout_s.) If the orchestration
-        # budget fires we are cancelled mid-await; reap the child before
-        # propagating so it cannot outlive the run.
+        result_envelope: dict | None = None
+        last_stderr_size = -1
         try:
             while proc.poll() is None:
+                try:
+                    stderr_size = stderr_log.stat().st_size
+                except OSError:
+                    stderr_size = -1
+                if stderr_size > 0 and stderr_size != last_stderr_size:
+                    last_stderr_size = stderr_size
+                    candidate = _parse_stderr_json(_read_text_tolerant(stderr_log))
+                    if (
+                        isinstance(candidate, dict)
+                        and isinstance(candidate.get("payloads"), list)
+                        and isinstance(candidate.get("meta"), dict)
+                        and isinstance(
+                            candidate["meta"].get("durationMs"),
+                            (int, float),
+                        )
+                    ):
+                        result_envelope = candidate
+                        logger.info(
+                            "openclaw_cli: result envelope complete while pid=%s remains alive",
+                            proc.pid,
+                        )
+                        break
                 await asyncio.sleep(_POLL_INTERVAL_S)
         except asyncio.CancelledError:
             try:
@@ -744,13 +761,16 @@ class OpenClawCliDeployer(BaseAgentDeployer):
 
         duration_s = time.monotonic() - t0
         exit_code = proc.returncode
-        status = "completed" if exit_code == 0 else "failed"
+        status = "completed" if result_envelope is not None or exit_code == 0 else "failed"
         error: str | None = None
         if status == "failed":
             error = _diagnose_failure(stderr_log, exit_code)
 
         # Copy session trajectory to work_dir for gathering
-        session_id = self._extract_session_id(stderr_log)
+        if result_envelope is not None:
+            session_id = result_envelope.get("meta", {}).get("agentMeta", {}).get("sessionId")
+        else:
+            session_id = self._extract_session_id(stderr_log)
         if session_id:
             src = Path(home) / ".openclaw" / "agents" / _AGENT_ID / "sessions" / f"{session_id}.jsonl"
             dst = wd / "transcript.jsonl"
@@ -1072,7 +1092,8 @@ def _parse_stderr_json(stderr: str) -> dict | None:
         if line.strip() == "{":
             payload = "\n".join(lines[i:])
             try:
-                return json.loads(payload)
+                value, _ = json.JSONDecoder().raw_decode(payload.lstrip())
+                return value if isinstance(value, dict) else None
             except json.JSONDecodeError:
                 break
 

--- a/ale_run/agents/openclaw_cli/deployer.py
+++ b/ale_run/agents/openclaw_cli/deployer.py
@@ -903,6 +903,9 @@ class OpenClawCliDeployer(BaseAgentDeployer):
                 usage = agent_meta.get("usage", {})
                 if usage:
                     builder.trajectory.extra["openclaw_cli"]["usage"] = usage
+                    final_metrics = _usage_final_metrics(usage)
+                    if final_metrics:
+                        builder.override_final_metrics(**final_metrics)
 
         if not transcript_file.exists():
             builder.add_step(
@@ -1122,6 +1125,26 @@ def _parse_stderr_json(stderr: str) -> dict | None:
                     except json.JSONDecodeError:
                         return None
     return None
+
+
+def _usage_final_metrics(usage: object) -> dict[str, int]:
+    """Map an authoritative OpenClaw aggregate usage object to ALE totals."""
+    if not isinstance(usage, dict):
+        return {}
+    field_map = {
+        "input": "total_input_tokens",
+        "output": "total_output_tokens",
+        "cacheRead": "total_cache_read_tokens",
+        "cacheWrite": "total_cache_creation_tokens",
+    }
+    totals = {
+        target: int(value)
+        for source, target in field_map.items()
+        if isinstance((value := usage.get(source)), (int, float))
+        and not isinstance(value, bool)
+        and value >= 0
+    }
+    return totals if any(totals.values()) else {}
 
 
 _DIAG_SIGNAL_PATTERNS = (

--- a/ale_run/agents/openclaw_cli/deployer.py
+++ b/ale_run/agents/openclaw_cli/deployer.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -42,6 +43,8 @@ logger = logging.getLogger(__name__)
 _POLL_INTERVAL_S = 2.0
 _TERM_GRACE_S = 2.0
 _AGENT_ID = "main"
+_PLUGIN_PROVIDER_IDS = frozenset({"anthropic", "openai", "openrouter", "zai"})
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 _STDERR_PREAMBLE_PREFIXES = (
     "[agent/embedded] session file repaired",
@@ -249,13 +252,24 @@ class OpenClawCliDeployer(BaseAgentDeployer):
             f"(claude-*) model, or prefix it with 'openai/' or 'anthropic/'."
         )
 
-    def _resolve_routing(self, cfg: OpenClawCliConfig) -> tuple[str, str]:
-        """Return ``(provider, api_key)`` for the configured routing.
+    def _resolve_route(
+        self,
+        *,
+        model: str,
+        routing_provider: str,
+        api_key_override: str | None,
+        provider_id: str | None = None,
+        api_key_env: str | None = None,
+        purpose: str,
+    ) -> tuple[str, str]:
+        """Return ``(provider, api_key)`` for one configured model route.
 
         Explicit, provider-driven (not key-presence inference):
           - ``openrouter`` → OPENROUTER_API_KEY.
           - ``direct`` → openai/anthropic native provider chosen by the
             model's vendor, keyed by OPENAI_API_KEY / ANTHROPIC_API_KEY.
+          - ``zai`` → ZAI_API_KEY, Z_AI_API_KEY, or GLM_API_KEY.
+          - ``custom`` → caller-supplied provider id and key env var.
         Missing the required key for the chosen provider is a hard error.
         """
         env = self.executor.env or {}
@@ -263,37 +277,69 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         def _key(name: str) -> str:
             return env.get(name) or os.environ.get(name, "")
 
-        if cfg.provider == "openrouter":
-            # A literal cfg.api_key (e.g. api_key: ${env:ARK_API_KEY}) travels
+        if routing_provider == "openrouter":
+            # A literal override (e.g. api_key: ${env:ARK_API_KEY}) travels
             # with the serialized config and takes precedence, so it does not
             # require — or collide with — a real OPENROUTER_API_KEY env var.
-            api_key = cfg.api_key or _key("OPENROUTER_API_KEY")
+            api_key = api_key_override or _key("OPENROUTER_API_KEY")
             if not api_key:
                 raise RuntimeError(
-                    "openclaw_cli: provider=openrouter but neither config "
-                    "api_key nor OPENROUTER_API_KEY is set. Set one before "
-                    "launch()."
+                    f"openclaw_cli: {purpose} provider=openrouter but neither "
+                    "its config api_key nor OPENROUTER_API_KEY is set."
                 )
             return "openrouter", api_key
 
-        if cfg.provider == "direct":
-            provider = self._direct_provider_for_model(cfg.model)
+        if routing_provider == "direct":
+            provider = self._direct_provider_for_model(model)
             key_var = "OPENAI_API_KEY" if provider == "openai" else "ANTHROPIC_API_KEY"
-            # A literal cfg.api_key (e.g. api_key: ${env:ARK_API_KEY}) takes
+            # A literal override (e.g. api_key: ${env:ARK_API_KEY}) takes
             # precedence — lets an OpenAI-compatible gateway (model prefixed
             # ``openai/...`` + base_url) authenticate without the native env var.
-            api_key = cfg.api_key or _key(key_var)
+            api_key = api_key_override or _key(key_var)
             if not api_key:
                 raise RuntimeError(
-                    f"openclaw_cli: provider=direct resolved to {provider!r} "
-                    f"for model {cfg.model!r} but neither config api_key nor "
-                    f"{key_var} is set. Set one before launch()."
+                    f"openclaw_cli: {purpose} provider=direct resolved to "
+                    f"{provider!r} for model {model!r} but neither its config "
+                    f"api_key nor {key_var} is set."
                 )
             return provider, api_key
 
+        if routing_provider == "zai":
+            api_key = (
+                api_key_override
+                or _key("ZAI_API_KEY")
+                or _key("Z_AI_API_KEY")
+                or _key("GLM_API_KEY")
+            )
+            if not api_key:
+                raise RuntimeError(
+                    f"openclaw_cli: {purpose} provider=zai but neither its "
+                    "config api_key, ZAI_API_KEY, Z_AI_API_KEY, nor "
+                    "GLM_API_KEY is set."
+                )
+            return "zai", api_key
+
+        if routing_provider == "custom":
+            if not provider_id:
+                raise RuntimeError(
+                    f"openclaw_cli: {purpose} provider=custom requires provider_id."
+                )
+            if not api_key_env or not _ENV_NAME_RE.fullmatch(api_key_env):
+                raise RuntimeError(
+                    f"openclaw_cli: {purpose} provider=custom requires a valid "
+                    "api_key_env environment variable name."
+                )
+            api_key = api_key_override or _key(api_key_env)
+            if not api_key:
+                raise RuntimeError(
+                    f"openclaw_cli: {purpose} provider=custom but neither its "
+                    f"config api_key nor {api_key_env} is set."
+                )
+            return provider_id, api_key
+
         raise RuntimeError(
-            f"openclaw_cli: unknown provider {cfg.provider!r} "
-            "(expected 'openrouter' or 'direct')"
+            f"openclaw_cli: unknown {purpose} provider {routing_provider!r} "
+            "(expected 'openrouter', 'direct', 'zai', or 'custom')"
         )
 
     def _write_config(self, cfg: OpenClawCliConfig) -> None:
@@ -307,20 +353,59 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         # routes the request through it: "openrouter/<model>" for the
         # OpenRouter gateway, or the native "openai/..." / "anthropic/..."
         # provider for a direct run.
-        provider, api_key = self._resolve_routing(cfg)
+        primary_route_model = cfg.model_id or cfg.model
+        provider, api_key = self._resolve_route(
+            model=primary_route_model,
+            routing_provider=cfg.provider,
+            api_key_override=cfg.api_key,
+            provider_id=cfg.provider_id,
+            api_key_env=cfg.api_key_env,
+            purpose="primary",
+        )
+        vision_provider: str | None = None
+        vision_api_key: str | None = None
+        vision_base_url: str | None = None
+        if cfg.vision_model:
+            vision_routing_provider = cfg.vision_provider or cfg.provider
+            vision_base_url = (
+                cfg.vision_base_url
+                if cfg.vision_provider is not None
+                else cfg.vision_base_url or cfg.base_url
+            )
+            vision_key_override = cfg.vision_api_key
+            if cfg.vision_provider is None and vision_key_override is None:
+                vision_key_override = cfg.api_key
+            vision_provider, vision_api_key = self._resolve_route(
+                model=cfg.vision_model,
+                routing_provider=vision_routing_provider,
+                api_key_override=vision_key_override,
+                provider_id=cfg.provider_id,
+                api_key_env=cfg.api_key_env,
+                purpose="vision",
+            )
 
         # --- openclaw.json ---
-        primary_model = self._route_model(cfg.model, provider)
+        primary_model = self._route_model(primary_route_model, provider)
         # The resolved provider's plugin must be enabled for its auth
         # profile to load (e.g. "anthropic" is not in the default allow set).
         plugins_allow = list(cfg.plugins_allow)
-        if provider not in plugins_allow:
-            plugins_allow.append(provider)
+        for required_provider in (provider, vision_provider):
+            if (
+                required_provider in _PLUGIN_PROVIDER_IDS
+                and required_provider not in plugins_allow
+            ):
+                plugins_allow.append(required_provider)
         tools_also_allow = list(CUA_TOOL_NAMES)
         agent_defaults: dict = {
             "model": {"primary": primary_model},
             "timeoutSeconds": int(cfg.agent_timeout_s),
-            "models": {primary_model: {}},
+            "models": {
+                primary_model: (
+                    {"params": cfg.model_params}
+                    if cfg.model_params is not None
+                    else {}
+                ),
+            },
         }
         # Only add heartbeat config when a valid duration is specified;
         # "never" is not a valid duration string for the openclaw CLI
@@ -365,20 +450,22 @@ class OpenClawCliDeployer(BaseAgentDeployer):
             },
         }
         if cfg.vision_model:
+            vision_model = self._route_model(cfg.vision_model, vision_provider)
+            agent_defaults["imageModel"] = {"primary": vision_model}
+            agent_defaults["models"].setdefault(vision_model, {})
             # openclaw schema (v2026.4.26): tools.media.image.models is an
             # ARRAY of {provider, model} entries (ordered preference list),
-            # not a map. For openrouter routing the model id stays vendor-
-            # prefixed ("openai/gpt-5.4"); for direct routing we split the
-            # vendor head off and route through it.
+            # not a map. OpenRouter keeps vendor-prefixed model ids while
+            # native providers receive their bare model id.
             vm = cfg.vision_model
-            if provider == "openrouter":
+            if vision_provider == "openrouter":
                 vision_entry = {"provider": "openrouter", "model": vm}
             else:
                 head, _, tail = vm.partition("/")
-                if tail:
-                    vision_entry = {"provider": head, "model": tail}
-                else:
-                    vision_entry = {"provider": provider, "model": vm}
+                vision_entry = {
+                    "provider": vision_provider,
+                    "model": tail if tail and head == vision_provider else vm,
+                }
             oc_config["tools"]["media"] = {
                 "image": {"models": [vision_entry]},
             }
@@ -389,23 +476,61 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         # also requires a non-empty ``models`` array declaring each usable model
         # id (bare, no provider prefix); openclaw surfaces them as
         # ``<provider>/<id>``. We register the primary (and vision) model ids.
-        if cfg.base_url:
-            def _bare(m: str) -> str:
-                head, sep, tail = m.partition("/")
-                return tail if sep and head == provider else m
-            catalog_ids: list[str] = [_bare(cfg.model)]
-            if cfg.vision_model:
-                vid = _bare(cfg.vision_model)
-                if vid not in catalog_ids:
-                    catalog_ids.append(vid)
-            oc_config["models"] = {
-                "providers": {
-                    provider: {
-                        "baseUrl": cfg.base_url,
-                        "models": [{"id": mid, "name": mid} for mid in catalog_ids],
-                    },
-                },
-            }
+        provider_catalogs: dict[str, dict] = {}
+        route_catalog_specs = [
+            (
+                provider,
+                cfg.base_url,
+                primary_route_model,
+                cfg.model,
+                cfg.provider_api if cfg.provider == "custom" else None,
+            ),
+            (
+                vision_provider,
+                vision_base_url,
+                cfg.vision_model,
+                cfg.vision_model,
+                None,
+            ),
+        ]
+        for (
+            catalog_provider,
+            catalog_base_url,
+            catalog_model,
+            catalog_name,
+            catalog_api,
+        ) in route_catalog_specs:
+            if not catalog_provider or not catalog_base_url or not catalog_model:
+                continue
+            head, sep, tail = catalog_model.partition("/")
+            catalog_id = tail if sep and head == catalog_provider else catalog_model
+            existing = provider_catalogs.get(catalog_provider)
+            if existing and existing["baseUrl"] != catalog_base_url:
+                raise RuntimeError(
+                    "openclaw_cli: primary and vision routes resolve to provider "
+                    f"{catalog_provider!r} with different base URLs"
+                )
+            if existing is None:
+                existing = {
+                    "baseUrl": catalog_base_url,
+                    "models": [],
+                }
+                if catalog_provider == "zai" or catalog_api:
+                    existing["api"] = catalog_api or "openai-completions"
+                provider_catalogs[catalog_provider] = existing
+            if not any(model["id"] == catalog_id for model in existing["models"]):
+                model_entry = {
+                    "id": catalog_id,
+                    "name": catalog_name or catalog_id,
+                }
+                if cfg.provider == "custom" and catalog_provider == provider:
+                    model_entry["compat"] = {
+                        "maxTokensField": "max_completion_tokens",
+                        "supportsUsageInStreaming": cfg.supports_usage_in_streaming,
+                    }
+                existing["models"].append(model_entry)
+        if provider_catalogs:
+            oc_config["models"] = {"providers": provider_catalogs}
         (oc_home / "openclaw.json").write_text(
             json.dumps(oc_config, indent=2), encoding="utf-8",
         )
@@ -429,16 +554,27 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         agent_dir = oc_home / "agents" / _AGENT_ID / "agent"
         agent_dir.mkdir(parents=True, exist_ok=True)
 
+        auth_keys = {provider: api_key}
+        if vision_provider and vision_api_key:
+            existing_key = auth_keys.get(vision_provider)
+            if existing_key is not None and existing_key != vision_api_key:
+                raise RuntimeError(
+                    "openclaw_cli: primary and vision routes resolve to provider "
+                    f"{vision_provider!r} with different API keys"
+                )
+            auth_keys[vision_provider] = vision_api_key
         auth = {
             "profiles": {
-                f"{provider}:default": {
-                    "provider": provider,
+                f"{auth_provider}:default": {
+                    "provider": auth_provider,
                     "type": "api_key",
-                    "key": api_key,
-                },
+                    "key": auth_key,
+                }
+                for auth_provider, auth_key in auth_keys.items()
             },
             "lastGood": {
-                provider: f"{provider}:default",
+                auth_provider: f"{auth_provider}:default"
+                for auth_provider in auth_keys
             },
         }
         (agent_dir / "auth-profiles.json").write_text(
@@ -840,7 +976,11 @@ class OpenClawCliDeployer(BaseAgentDeployer):
         # For a direct run, drop the OpenRouter key so its presence (always
         # exported by the secrets sidecar) cannot make openclaw fall back to
         # the openrouter provider behind the explicitly-chosen direct one.
-        if cfg.provider == "direct":
+        uses_openrouter = cfg.provider == "openrouter" or (
+            cfg.vision_model is not None
+            and (cfg.vision_provider or cfg.provider) == "openrouter"
+        )
+        if not uses_openrouter:
             env.pop("OPENROUTER_API_KEY", None)
         # Source .env file values
         if env_file.exists():

--- a/ale_run/agents/openclaw_cli/vision.py
+++ b/ale_run/agents/openclaw_cli/vision.py
@@ -1,0 +1,473 @@
+"""OpenClaw-specific vision usage capture and transcript image artifacts."""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import http.client
+import json
+import logging
+import mimetypes
+import re
+import shutil
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+logger = logging.getLogger(__name__)
+
+_DATA_IMAGE_RE = re.compile(
+    r"data:(image/[A-Za-z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+)"
+)
+_HOP_BY_HOP_HEADERS = frozenset({
+    "connection",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+})
+_USAGE_FIELDS = (
+    "requests_with_usage",
+    "input_tokens",
+    "input_write_tokens",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+    "output_tokens",
+)
+
+
+class VisionUsageProxy:
+    """Transparent loopback proxy that records provider response usage."""
+
+    def __init__(
+        self,
+        *,
+        upstream_url: str,
+        usage_log: Path,
+        provider: str,
+        model: str,
+    ) -> None:
+        parsed = urlsplit(upstream_url)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise ValueError(f"unsupported vision upstream URL: {upstream_url}")
+        self._parsed = parsed
+        self._usage_log = usage_log
+        self._provider = provider
+        self._model = model
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._write_lock = threading.Lock()
+
+    @property
+    def base_url(self) -> str:
+        if self._server is None:
+            raise RuntimeError("vision usage proxy is not running")
+        base_path = self._parsed.path.rstrip("/")
+        return f"http://127.0.0.1:{self._server.server_port}{base_path}"
+
+    def start(self) -> None:
+        self._usage_log.unlink(missing_ok=True)
+        proxy = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+            def do_GET(self) -> None:
+                self._forward()
+
+            def do_POST(self) -> None:
+                self._forward()
+
+            def _forward(self) -> None:
+                content_length = int(self.headers.get("content-length", "0"))
+                body = self.rfile.read(content_length) if content_length else None
+                headers = {
+                    name: value
+                    for name, value in self.headers.items()
+                    if name.lower() not in _HOP_BY_HOP_HEADERS
+                }
+                headers["Accept-Encoding"] = "identity"
+                connection = http.client.HTTPSConnection(
+                    proxy._parsed.hostname,
+                    proxy._parsed.port or 443,
+                    timeout=120,
+                )
+                try:
+                    connection.request(
+                        self.command,
+                        self.path,
+                        body=body,
+                        headers=headers,
+                    )
+                    response = connection.getresponse()
+                    response_body = response.read()
+                    self.send_response(response.status, response.reason)
+                    for name, value in response.getheaders():
+                        lowered = name.lower()
+                        if (
+                            lowered not in _HOP_BY_HOP_HEADERS
+                            and lowered != "content-encoding"
+                        ):
+                            self.send_header(name, value)
+                    self.send_header("Content-Length", str(len(response_body)))
+                    self.end_headers()
+                    self.wfile.write(response_body)
+                    proxy._record_usage(response_body)
+                except Exception as exc:
+                    payload = json.dumps({
+                        "error": {
+                            "message": f"ALE vision proxy failed: {exc}",
+                            "type": "ale_vision_proxy_error",
+                        }
+                    }).encode()
+                    self.send_response(502)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(payload)))
+                    self.end_headers()
+                    self.wfile.write(payload)
+                finally:
+                    connection.close()
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="ale-openclaw-vision-usage",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+        self._server = None
+        self._thread = None
+
+    def _record_usage(self, response_body: bytes) -> None:
+        usage = extract_provider_usage(response_body)
+        if not usage:
+            return
+        record = {
+            "provider": self._provider,
+            "model": self._model,
+            **usage,
+        }
+        with self._write_lock:
+            with self._usage_log.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _first_nonnegative_int(mapping: dict, *keys: str) -> int:
+    for key in keys:
+        value = mapping.get(key)
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value >= 0
+        ):
+            return int(value)
+    return 0
+
+
+def extract_provider_usage(body: bytes) -> dict[str, int] | None:
+    """Extract aggregate usage from JSON or SSE provider responses."""
+    text = body.decode("utf-8", errors="replace")
+    payloads: list[object] = []
+    try:
+        payloads.append(json.loads(text))
+    except json.JSONDecodeError:
+        for line in text.splitlines():
+            if not line.startswith("data:"):
+                continue
+            data = line[5:].strip()
+            if not data or data == "[DONE]":
+                continue
+            try:
+                payloads.append(json.loads(data))
+            except json.JSONDecodeError:
+                continue
+
+    candidates: list[dict] = []
+
+    def _walk(value: object) -> None:
+        if isinstance(value, dict):
+            usage = value.get("usage")
+            if isinstance(usage, dict):
+                candidates.append(usage)
+            for child in value.values():
+                _walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                _walk(child)
+
+    for payload in payloads:
+        _walk(payload)
+    if not candidates:
+        return None
+
+    usage = candidates[-1]
+    input_tokens = _first_nonnegative_int(
+        usage,
+        "input_tokens",
+        "prompt_tokens",
+        "input",
+    )
+    output_tokens = _first_nonnegative_int(
+        usage,
+        "output_tokens",
+        "completion_tokens",
+        "output",
+    )
+    details = (
+        usage.get("input_tokens_details")
+        or usage.get("prompt_tokens_details")
+        or {}
+    )
+    cache_read = (
+        _first_nonnegative_int(details, "cached_tokens")
+        if isinstance(details, dict)
+        else 0
+    )
+    if not cache_read:
+        cache_read = _first_nonnegative_int(
+            usage,
+            "cacheRead",
+            "cache_read_tokens",
+        )
+    cache_creation = _first_nonnegative_int(
+        usage,
+        "cacheWrite",
+        "cache_creation_tokens",
+    )
+    if not any((input_tokens, output_tokens, cache_read, cache_creation)):
+        return None
+    return {
+        "requests_with_usage": 1,
+        "input_tokens": input_tokens,
+        "input_write_tokens": max(0, input_tokens - cache_read),
+        "cache_read_tokens": cache_read,
+        "cache_creation_tokens": cache_creation,
+        "output_tokens": output_tokens,
+    }
+
+
+def read_image_model_usage(path: Path) -> dict | None:
+    if not path.is_file():
+        return None
+    totals = {key: 0 for key in _USAGE_FIELDS}
+    provider = None
+    model = None
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        provider = record.get("provider") or provider
+        model = record.get("model") or model
+        for key in totals:
+            totals[key] += _first_nonnegative_int(record, key)
+    if not any(totals.values()):
+        return None
+    return {
+        "provider": provider,
+        "model": model,
+        **totals,
+    }
+
+
+def run_dir_for_artifacts(work_dir: Path) -> Path:
+    if work_dir.parent.name == "origin_log":
+        return work_dir.parent.parent
+    return work_dir
+
+
+def stage_transcript_file_images(
+    transcript_file: Path,
+    work_dir: Path,
+) -> None:
+    """Copy image-tool file inputs into the gathered artifact directory."""
+    workspace = Path.home() / ".openclaw" / "workspace"
+    path_map: dict[str, str] = {}
+    changed = False
+
+    def _stage(value: object) -> object:
+        nonlocal changed
+        if isinstance(value, dict):
+            return {key: _stage(child) for key, child in value.items()}
+        if isinstance(value, list):
+            return [_stage(child) for child in value]
+        if not isinstance(value, str):
+            return value
+        if (
+            value.startswith(("data:image/", "http://", "https://"))
+            or value.startswith("screenshots/")
+        ):
+            return value
+        cached = path_map.get(value)
+        if cached:
+            return cached
+        source_path = Path(value)
+        candidates = (
+            [source_path]
+            if source_path.is_absolute()
+            else [workspace / source_path, work_dir / source_path]
+        )
+        source = next(
+            (candidate for candidate in candidates if candidate.is_file()),
+            None,
+        )
+        if source is None:
+            return value
+        digest = hashlib.sha256(source.read_bytes()).hexdigest()[:16]
+        suffix = source.suffix.lower() or ".png"
+        relative = f"screenshots/openclaw-input-{digest}{suffix}"
+        destination = work_dir / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if not destination.exists():
+            shutil.copy2(source, destination)
+        path_map[value] = relative
+        changed = True
+        return relative
+
+    output: list[str] = []
+    for line in transcript_file.read_text(
+        encoding="utf-8",
+        errors="replace",
+    ).splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            output.append(line)
+            continue
+        message = event.get("message") if isinstance(event, dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, list):
+            for block in content:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") in ("toolCall", "tool_use")
+                    and block.get("name") == "image"
+                ):
+                    key = "arguments" if "arguments" in block else "input"
+                    block[key] = _stage(block.get(key))
+        if isinstance(message, dict) and message.get("toolName") == "image":
+            message["details"] = _stage(message.get("details"))
+        output.append(json.dumps(event, ensure_ascii=False, separators=(",", ":")))
+    if changed:
+        transcript_file.write_text("\n".join(output) + "\n", encoding="utf-8")
+
+
+def persist_transcript_images(
+    transcript_file: Path,
+    run_dir: Path,
+) -> int:
+    """Persist transcript image payloads and replace them with path refs."""
+    screenshots_dir = run_dir / "screenshots"
+    staged_dir = transcript_file.parent / "screenshots"
+    screenshots_dir.mkdir(parents=True, exist_ok=True)
+    written = 0
+    if staged_dir.is_dir() and staged_dir != screenshots_dir:
+        for source in staged_dir.iterdir():
+            if not source.is_file():
+                continue
+            destination = screenshots_dir / source.name
+            if not destination.exists():
+                shutil.move(str(source), str(destination))
+                written += 1
+            else:
+                source.unlink()
+        try:
+            staged_dir.rmdir()
+        except OSError as exc:
+            logger.warning(
+                "openclaw_cli: failed to remove staged screenshot directory "
+                "%s: %s",
+                staged_dir,
+                exc,
+            )
+
+    known = {
+        hashlib.sha256(path.read_bytes()).hexdigest(): f"screenshots/{path.name}"
+        for path in screenshots_dir.iterdir()
+        if path.is_file()
+    }
+
+    def _store(media_type: str, encoded: str) -> str:
+        nonlocal written
+        payload = encoded.strip()
+        payload += "=" * (-len(payload) % 4)
+        try:
+            raw = base64.b64decode(payload)
+        except (binascii.Error, ValueError):
+            return ""
+        digest = hashlib.sha256(raw).hexdigest()
+        if digest in known:
+            return known[digest]
+        extension = mimetypes.guess_extension(media_type) or ".png"
+        relative = f"screenshots/openclaw-inline-{digest[:16]}{extension}"
+        (run_dir / relative).write_bytes(raw)
+        known[digest] = relative
+        written += 1
+        return relative
+
+    def _rewrite(value: object) -> object:
+        if isinstance(value, dict):
+            if (
+                value.get("type") == "image"
+                and isinstance(value.get("data"), str)
+            ):
+                media_type = str(value.get("mimeType") or "image/png")
+                relative = _store(media_type, value["data"])
+                if relative:
+                    value = dict(value)
+                    value.pop("data", None)
+                    value["path"] = relative
+            return {key: _rewrite(child) for key, child in value.items()}
+        if isinstance(value, list):
+            return [_rewrite(child) for child in value]
+        if not isinstance(value, str):
+            return value
+
+        def _replace(match: re.Match[str]) -> str:
+            return _store(match.group(1), match.group(2)) or match.group(0)
+
+        return _DATA_IMAGE_RE.sub(_replace, value)
+
+    changed = False
+    output: list[str] = []
+    for line in transcript_file.read_text(
+        encoding="utf-8",
+        errors="replace",
+    ).splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            output.append(line)
+            continue
+        rewritten = _rewrite(event)
+        serialized = json.dumps(
+            rewritten,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        changed = changed or serialized != line
+        output.append(serialized)
+    if changed:
+        transcript_file.write_text("\n".join(output) + "\n", encoding="utf-8")
+    return written

--- a/configs/agents/codex.yaml
+++ b/configs/agents/codex.yaml
@@ -38,6 +38,10 @@ config:
   # Bypass all interactive approval prompts (headless exec).
   yolo: true
 
+  # Capture complete Codex OpenTelemetry logs, including prompts, API timing,
+  # tool arguments, tool output, and per-tool duration.
+  otel_enabled: true
+
   # model_reasoning_effort → Responses-API reasoning.effort. off|low|medium|high.
   reasoning_effort: high
 

--- a/configs/agents/openclaw_cli.yaml
+++ b/configs/agents/openclaw_cli.yaml
@@ -17,7 +17,8 @@ model: openai/gpt-5.4
 
 config:
   # Routing: "openrouter" (default), "direct" (provider picked by model vendor),
-  # or "zai".
+  # "zai" (validated with GLM-5.2), or "custom" (validated with an Azure
+  # OpenAI-compatible endpoint).
   provider: openrouter
 
   # Custom OpenAI-compatible base URL → written to openclaw.json

--- a/configs/agents/openclaw_cli.yaml
+++ b/configs/agents/openclaw_cli.yaml
@@ -3,6 +3,7 @@
 # Auth: API keys via auth-profiles.json.
 #   provider=openrouter → OPENROUTER_API_KEY (model prefixed openrouter/<model>);
 #   provider=direct → OPENAI_API_KEY (gpt-*) or ANTHROPIC_API_KEY (claude-*).
+#   provider=zai → ZAI_API_KEY / Z_AI_API_KEY (model prefixed zai/<model>).
 #
 # Consolidated preset; `model:` is an example, every `config:` key is the
 # dataclass default (ale_run/agents/openclaw_cli/config.py).
@@ -15,7 +16,8 @@ harness: openclaw_cli
 model: openai/gpt-5.4
 
 config:
-  # Routing: "openrouter" (default) or "direct" (provider picked by model vendor).
+  # Routing: "openrouter" (default), "direct" (provider picked by model vendor),
+  # or "zai".
   provider: openrouter
 
   # Custom OpenAI-compatible base URL → written to openclaw.json
@@ -32,15 +34,29 @@ config:
   # provider's env var. When set, used directly in auth-profiles.json.
   api_key: null
 
+  # Provider-specific primary-model parameters. `extra_body` is merged into
+  # the OpenAI-compatible request body.
+  model_params: null
+
+  # Request token usage in streamed responses. Disable only for an endpoint
+  # that rejects stream_options.include_usage.
+  supports_usage_in_streaming: true
+
   # OpenClaw's OWN internal run budget (openclaw.json timeoutSeconds +
   # `agent --local --timeout <s>`). Distinct from the orchestration episode budget.
   agent_timeout_s: 600
 
-  # Thinking level: off | low | medium | high.
+  # Thinking level. Common values: off | on | minimal | low | medium | high |
+  # xhigh | max. OpenClaw validates provider-specific support at launch.
   thinking: high
 
   # Vision/screenshot model. null = none; default pins it to the same id as model.
   vision_model: openai/gpt-5.4
+
+  # Separate vision routing. null inherits the primary route.
+  vision_provider: null
+  vision_base_url: null
+  vision_api_key: null
 
   # Heartbeat cadence. "never" = no heartbeat messages.
   heartbeat_every: never

--- a/tests/ale_run/test_codex_telemetry.py
+++ b/tests/ale_run/test_codex_telemetry.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+
+from ale_run.agents.codex.deployer import CodexDeployer
+from ale_run.agents.codex.telemetry import (
+    CodexOtelCollector,
+    recover_telemetry_artifacts,
+)
+
+
+def _record(name: str, timestamp: str, **attributes: object) -> dict:
+    items = [
+        {"key": "event.name", "value": {"stringValue": name}},
+        {"key": "event.timestamp", "value": {"stringValue": timestamp}},
+    ]
+    for key, value in attributes.items():
+        if isinstance(value, bool):
+            encoded = {"boolValue": value}
+        elif isinstance(value, int):
+            encoded = {"intValue": str(value)}
+        else:
+            encoded = {"stringValue": str(value)}
+        items.append({"key": key, "value": encoded})
+    return {
+        "observedTimeUnixNano": "123",
+        "severityNumber": 9,
+        "severityText": "INFO",
+        "attributes": items,
+    }
+
+
+def test_collector_persists_and_summarizes_otel_logs(tmp_path: Path) -> None:
+    collector = CodexOtelCollector(tmp_path)
+    collector.start()
+    payload = {
+        "resourceLogs": [
+            {
+                "resource": {
+                    "attributes": [
+                        {
+                            "key": "service.name",
+                            "value": {"stringValue": "codex_exec"},
+                        }
+                    ]
+                },
+                "scopeLogs": [
+                    {
+                        "scope": {"name": "codex_otel.log_only"},
+                        "logRecords": [
+                            _record(
+                                "codex.api_request",
+                                "2026-07-02T10:00:00.500Z",
+                                duration_ms=500,
+                                endpoint="/responses",
+                                attempt=0,
+                            ),
+                            _record(
+                                "codex.sse_event",
+                                "2026-07-02T10:00:02.000Z",
+                                **{"event.kind": "response.completed"},
+                            ),
+                            _record(
+                                "codex.tool_result",
+                                "2026-07-02T10:00:03.000Z",
+                                tool_name="exec_command",
+                                call_id="call_123",
+                                duration_ms=250,
+                                success=True,
+                                arguments='{"cmd":"echo test"}',
+                                output="test",
+                            ),
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    request = urllib.request.Request(
+        collector.endpoint,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        assert response.status == 200
+    collector.stop()
+
+    raw_records = [
+        json.loads(line) for line in collector.raw_path.read_text().splitlines()
+    ]
+    assert raw_records[0]["record_type"] == "otlp_request_chunk"
+    assert raw_records[0]["chunk_count"] == 1
+
+    events = [json.loads(line) for line in collector.events_path.read_text().splitlines()]
+    assert len(events) == 3
+    assert events[2]["attributes"]["arguments"] == '{"cmd":"echo test"}'
+    assert events[2]["attributes"]["output"] == "test"
+
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["event_count"] == 3
+    assert summary["api_calls"][0]["transport_duration_ms"] == 500
+    assert summary["api_calls"][0]["response_duration_ms"] == 2000
+    assert summary["tool_executions"][0]["duration_ms"] == 250
+    assert summary["tool_executions"][0]["arguments"] == '{"cmd":"echo test"}'
+    assert summary["tool_executions"][0]["output"] == "test"
+
+
+def test_large_raw_request_is_chunked_and_recovers_derived_files(tmp_path: Path) -> None:
+    large_output = "x" * (2 * 1024 * 1024)
+    payload = {
+        "resourceLogs": [
+            {
+                "scopeLogs": [
+                    {
+                        "logRecords": [
+                            _record(
+                                "codex.tool_result",
+                                "2026-07-02T10:00:03.000Z",
+                                tool_name="exec_command",
+                                call_id="call_large",
+                                duration_ms=250,
+                                success=True,
+                                output=large_output,
+                            )
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    collector = CodexOtelCollector(tmp_path)
+    collector.start()
+    request = urllib.request.Request(
+        collector.endpoint,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        assert response.status == 200
+    collector.stop()
+
+    raw_lines = collector.raw_path.read_bytes().splitlines()
+    assert len(raw_lines) > 1
+    assert max(map(len, raw_lines)) < 1024 * 1024
+
+    collector.events_path.unlink()
+    collector.summary_path.unlink()
+    assert recover_telemetry_artifacts(tmp_path) == 1
+
+    recovered = json.loads(collector.events_path.read_text().strip())
+    assert recovered["attributes"]["output"] == large_output
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["event_count"] == 1
+    assert summary["tool_executions"][0]["output"] == large_output
+
+
+def test_codex_incrementally_mirrors_raw_telemetry_wal() -> None:
+    assert "otel_requests.jsonl" in CodexDeployer.hot_artifacts
+    assert "telemetry.jsonl" not in CodexDeployer.hot_artifacts
+
+
+def test_recovery_ignores_incomplete_trailing_request(tmp_path: Path) -> None:
+    collector = CodexOtelCollector(tmp_path)
+    complete_payload = {
+        "resourceLogs": [
+            {
+                "scopeLogs": [
+                    {
+                        "logRecords": [
+                            _record(
+                                "codex.turn_ttft",
+                                "2026-07-02T10:00:00.000Z",
+                                duration_ms=123,
+                            )
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    collector._store_request({}, json.dumps(complete_payload).encode())
+    collector._store_request({}, b'{"resourceLogs":"' + b"x" * (2 * 1024 * 1024))
+
+    raw_lines = collector.raw_path.read_text().splitlines()
+    collector.raw_path.write_text("\n".join(raw_lines[:-1]) + "\n")
+
+    assert recover_telemetry_artifacts(tmp_path) == 1
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["event_count"] == 1
+    assert summary["events_by_name"] == {"codex.turn_ttft": 1}

--- a/tests/ale_run/test_openclaw_cli.py
+++ b/tests/ale_run/test_openclaw_cli.py
@@ -172,3 +172,72 @@ def test_write_config_supports_custom_primary_and_direct_openai_vision(
             "key": "openai-test-key",
         },
     }
+
+
+def test_write_config_routes_direct_openai_vision_through_usage_proxy(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = OpenClawCliConfig(
+        model="glm-5.2",
+        provider="zai",
+        base_url="https://open.bigmodel.cn/api/paas/v4",
+        vision_model="openai/gpt-5.4",
+        vision_provider="direct",
+    )
+    executor = SimpleNamespace(
+        config=cfg,
+        env={
+            "GLM_API_KEY": "zai-test-key",
+            "OPENAI_API_KEY": "openai-test-key",
+        },
+        cua_bridge_url=lambda: "http://127.0.0.1:5000",
+    )
+    deployer = OpenClawCliDeployer(executor)
+    deployer._vision_usage_proxy_provider = "openai"
+    deployer._vision_usage_proxy_url = "http://127.0.0.1:43210/v1"
+
+    deployer._write_config(cfg)
+
+    openclaw_config = json.loads(
+        (tmp_path / ".openclaw" / "openclaw.json").read_text()
+    )
+    assert openclaw_config["models"]["providers"]["openai"] == {
+        "baseUrl": "http://127.0.0.1:43210/v1",
+        "models": [
+            {
+                "id": "gpt-5.4",
+                "name": "openai/gpt-5.4",
+                "input": ["text", "image"],
+            }
+        ],
+        "request": {"allowPrivateNetwork": True},
+    }
+
+
+def test_direct_openai_primary_does_not_start_image_usage_proxy(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    cfg = OpenClawCliConfig(
+        model="openai/gpt-5.4",
+        provider="direct",
+        vision_model="openai/gpt-5.4",
+        vision_provider="direct",
+    )
+    executor = SimpleNamespace(config=cfg)
+    deployer = OpenClawCliDeployer(executor)
+
+    class UnexpectedProxy:
+        def __init__(self, **kwargs) -> None:
+            raise AssertionError(f"proxy should not start: {kwargs}")
+
+    monkeypatch.setattr(
+        "ale_run.agents.openclaw_cli.deployer.VisionUsageProxy",
+        UnexpectedProxy,
+    )
+
+    deployer._start_vision_usage_proxy(cfg, tmp_path)
+
+    assert not hasattr(deployer, "_vision_usage_proxy")

--- a/tests/ale_run/test_openclaw_cli.py
+++ b/tests/ale_run/test_openclaw_cli.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from ale_run.agents.openclaw_cli import OpenClawCliConfig, OpenClawCliDeployer
+
+
+def test_write_config_supports_zai_primary_and_direct_openai_vision(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = OpenClawCliConfig(
+        model="glm-5.2",
+        provider="zai",
+        base_url="https://open.bigmodel.cn/api/paas/v4",
+        model_params={
+            "temperature": 1.0,
+            "extra_body": {
+                "thinking": {"type": "enabled"},
+                "reasoning_effort": "max",
+            },
+        },
+        thinking="max",
+        vision_model="openai/gpt-5.4",
+        vision_provider="direct",
+    )
+    executor = SimpleNamespace(
+        config=cfg,
+        env={
+            "GLM_API_KEY": "zai-test-key",
+            "OPENAI_API_KEY": "openai-test-key",
+        },
+        cua_bridge_url=lambda: "http://127.0.0.1:5000",
+    )
+    deployer = OpenClawCliDeployer(executor)
+
+    deployer._write_config(cfg)
+
+    openclaw_config = json.loads(
+        (tmp_path / ".openclaw" / "openclaw.json").read_text()
+    )
+    defaults = openclaw_config["agents"]["defaults"]
+    assert defaults["model"]["primary"] == "zai/glm-5.2"
+    assert defaults["imageModel"]["primary"] == "openai/gpt-5.4"
+    assert defaults["models"]["zai/glm-5.2"]["params"] == cfg.model_params
+    assert defaults["models"]["openai/gpt-5.4"] == {}
+    assert openclaw_config["tools"]["media"]["image"]["models"] == [
+        {"provider": "openai", "model": "gpt-5.4"}
+    ]
+    assert {"cua", "zai", "openai"} <= set(
+        openclaw_config["plugins"]["allow"]
+    )
+    assert openclaw_config["models"]["providers"] == {
+        "zai": {
+            "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
+            "api": "openai-completions",
+            "models": [{"id": "glm-5.2", "name": "glm-5.2"}],
+        }
+    }
+
+    auth = json.loads(
+        (
+            tmp_path
+            / ".openclaw"
+            / "agents"
+            / "main"
+            / "agent"
+            / "auth-profiles.json"
+        ).read_text()
+    )
+    assert auth["profiles"] == {
+        "zai:default": {
+            "provider": "zai",
+            "type": "api_key",
+            "key": "zai-test-key",
+        },
+        "openai:default": {
+            "provider": "openai",
+            "type": "api_key",
+            "key": "openai-test-key",
+        },
+    }
+    assert auth["lastGood"] == {
+        "zai": "zai:default",
+        "openai": "openai:default",
+    }
+
+
+def test_write_config_supports_custom_primary_and_direct_openai_vision(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = OpenClawCliConfig(
+        model="Azure-Code",
+        provider="custom",
+        provider_id="azure-code",
+        model_id="rc6-for-vlm-team",
+        base_url="https://example.openai.azure.com/openai/v1",
+        api_key_env="AZURE_CODE_API_KEY",
+        provider_api="openai-completions",
+        model_params={"temperature": 1.0},
+        thinking="off",
+        vision_model="openai/gpt-5.4",
+        vision_provider="direct",
+        plugins_allow=("cua", "memory-core"),
+    )
+    executor = SimpleNamespace(
+        config=cfg,
+        env={
+            "AZURE_CODE_API_KEY": "azure-test-key",
+            "OPENAI_API_KEY": "openai-test-key",
+        },
+        cua_bridge_url=lambda: "http://127.0.0.1:5000",
+    )
+    deployer = OpenClawCliDeployer(executor)
+
+    deployer._write_config(cfg)
+
+    openclaw_config = json.loads(
+        (tmp_path / ".openclaw" / "openclaw.json").read_text()
+    )
+    defaults = openclaw_config["agents"]["defaults"]
+    assert defaults["model"]["primary"] == "azure-code/rc6-for-vlm-team"
+    assert defaults["imageModel"]["primary"] == "openai/gpt-5.4"
+    assert defaults["models"]["azure-code/rc6-for-vlm-team"]["params"] == {
+        "temperature": 1.0,
+    }
+    assert openclaw_config["tools"]["media"]["image"]["models"] == [
+        {"provider": "openai", "model": "gpt-5.4"},
+    ]
+    assert "openai" in openclaw_config["plugins"]["allow"]
+    assert "azure-code" not in openclaw_config["plugins"]["allow"]
+    assert openclaw_config["models"]["providers"] == {
+        "azure-code": {
+            "baseUrl": "https://example.openai.azure.com/openai/v1",
+            "api": "openai-completions",
+            "models": [
+                {
+                    "id": "rc6-for-vlm-team",
+                    "name": "Azure-Code",
+                    "compat": {
+                        "maxTokensField": "max_completion_tokens",
+                        "supportsUsageInStreaming": True,
+                    },
+                },
+            ],
+        },
+    }
+
+    auth = json.loads(
+        (
+            tmp_path
+            / ".openclaw"
+            / "agents"
+            / "main"
+            / "agent"
+            / "auth-profiles.json"
+        ).read_text()
+    )
+    assert auth["profiles"] == {
+        "azure-code:default": {
+            "provider": "azure-code",
+            "type": "api_key",
+            "key": "azure-test-key",
+        },
+        "openai:default": {
+            "provider": "openai",
+            "type": "api_key",
+            "key": "openai-test-key",
+        },
+    }

--- a/tests/ale_run/test_openclaw_cli_completion.py
+++ b/tests/ale_run/test_openclaw_cli_completion.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from ale_run.agents.openclaw_cli import OpenClawCliConfig, OpenClawCliDeployer
+from ale_run.agents.openclaw_cli import deployer as deployer_module
+
+
+class _LingeringOpenClawProcess:
+    pid = 4242
+    returncode = None
+
+    def __init__(self, *, stderr, envelope: dict) -> None:
+        stderr.write(json.dumps(envelope).encode())
+        stderr.flush()
+
+    def poll(self) -> None:
+        return None
+
+
+def test_launch_finishes_when_result_envelope_is_complete(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(deployer_module, "_POLL_INTERVAL_S", 0)
+
+    config = OpenClawCliConfig()
+    executor = SimpleNamespace(config=config, work_dir=str(tmp_path), env={})
+    deployer = OpenClawCliDeployer(executor)
+    monkeypatch.setattr(deployer, "_complete_workspace_bootstrap", lambda: None)
+    monkeypatch.setattr(deployer, "_launch_prefix", lambda: ["openclaw"])
+    monkeypatch.setattr(deployer, "_build_env", lambda *_: {})
+
+    envelope = {
+        "payloads": [{"text": "done", "mediaUrl": None}],
+        "meta": {
+            "durationMs": 1234,
+            "agentMeta": {"sessionId": "session-1"},
+            "stopReason": "stop",
+        },
+    }
+    process = None
+
+    def fake_popen(*_, stderr, **__) -> _LingeringOpenClawProcess:
+        nonlocal process
+        process = _LingeringOpenClawProcess(
+            stderr=stderr,
+            envelope=envelope,
+        )
+        return process
+
+    monkeypatch.setattr(deployer_module.subprocess, "Popen", fake_popen)
+
+    result = asyncio.run(deployer.launch("finish the task"))
+
+    assert process is not None
+    assert process.poll() is None
+    assert result.status == "completed"
+    assert result.exit_code is None
+
+
+def test_parse_stderr_json_accepts_diagnostics_after_envelope() -> None:
+    stderr = "\n".join(
+        [
+            "[agent/embedded] run complete",
+            json.dumps(
+                {
+                    "payloads": [],
+                    "meta": {"durationMs": 25},
+                },
+                indent=2,
+            ),
+            "[plugin] lingering background handle",
+        ]
+    )
+
+    assert deployer_module._parse_stderr_json(stderr) == {
+        "payloads": [],
+        "meta": {"durationMs": 25},
+    }

--- a/tests/ale_run/test_openclaw_cli_completion.py
+++ b/tests/ale_run/test_openclaw_cli_completion.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+from http.client import HTTPConnection
 from types import SimpleNamespace
 
 from ale_run.agents.openclaw_cli import OpenClawCliConfig, OpenClawCliDeployer
 from ale_run.agents.openclaw_cli import deployer as deployer_module
+from ale_run.agents.openclaw_cli import vision as vision_module
 from ale_run.base_interface.agent_deployer import AgentRunResult
 from ale_run.base_interface.trajectory import StepMetrics, TrajectoryBuilder
 
@@ -198,3 +201,302 @@ def test_empty_envelope_usage_does_not_erase_step_totals(tmp_path) -> None:
     assert final_metrics is not None
     assert final_metrics.total_input_tokens == 10
     assert final_metrics.total_output_tokens == 5
+
+
+def test_extract_provider_usage_supports_responses_json_and_sse() -> None:
+    responses_usage = vision_module.extract_provider_usage(
+        json.dumps(
+            {
+                "usage": {
+                    "input_tokens": 120,
+                    "input_tokens_details": {"cached_tokens": 80},
+                    "output_tokens": 17,
+                }
+            }
+        ).encode()
+    )
+    assert responses_usage == {
+        "requests_with_usage": 1,
+        "input_tokens": 120,
+        "input_write_tokens": 40,
+        "cache_read_tokens": 80,
+        "cache_creation_tokens": 0,
+        "output_tokens": 17,
+    }
+
+    streaming_usage = vision_module.extract_provider_usage(
+        b'data: {"choices":[],"usage":{"prompt_tokens":31,'
+        b'"prompt_tokens_details":{"cached_tokens":11},'
+        b'"completion_tokens":7}}\n\ndata: [DONE]\n'
+    )
+    assert streaming_usage == {
+        "requests_with_usage": 1,
+        "input_tokens": 31,
+        "input_write_tokens": 20,
+        "cache_read_tokens": 11,
+        "cache_creation_tokens": 0,
+        "output_tokens": 7,
+    }
+
+
+def test_vision_usage_proxy_forwards_response_and_records_usage(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    response_body = json.dumps(
+        {
+            "id": "response-1",
+            "usage": {
+                "input_tokens": 45,
+                "input_tokens_details": {"cached_tokens": 5},
+                "output_tokens": 6,
+            },
+        }
+    ).encode()
+    requests = []
+
+    class FakeResponse:
+        status = 200
+        reason = "OK"
+
+        def read(self) -> bytes:
+            return response_body
+
+        def getheaders(self) -> list[tuple[str, str]]:
+            return [("Content-Type", "application/json")]
+
+    class FakeHttpsConnection:
+        def __init__(self, host, port, timeout) -> None:
+            assert host == "api.openai.com"
+            assert port == 443
+            assert timeout == 120
+
+        def request(self, method, path, body, headers) -> None:
+            requests.append((method, path, body, headers))
+
+        def getresponse(self) -> FakeResponse:
+            return FakeResponse()
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setattr(
+        vision_module.http.client,
+        "HTTPSConnection",
+        FakeHttpsConnection,
+    )
+    usage_log = tmp_path / "vision-usage.jsonl"
+    proxy = vision_module.VisionUsageProxy(
+        upstream_url="https://api.openai.com/v1",
+        usage_log=usage_log,
+        provider="openai",
+        model="gpt-5.4",
+    )
+    proxy.start()
+    try:
+        connection = HTTPConnection(
+            "127.0.0.1",
+            int(proxy.base_url.rsplit(":", 1)[1].split("/", 1)[0]),
+            timeout=5,
+        )
+        connection.request(
+            "POST",
+            "/v1/responses",
+            body=b'{"model":"gpt-5.4"}',
+            headers={
+                "Authorization": "Bearer test-key",
+                "Content-Type": "application/json",
+            },
+        )
+        response = connection.getresponse()
+        assert response.read() == response_body
+        connection.close()
+    finally:
+        proxy.stop()
+
+    assert requests[0][0:3] == (
+        "POST",
+        "/v1/responses",
+        b'{"model":"gpt-5.4"}',
+    )
+    assert requests[0][3]["Authorization"] == "Bearer test-key"
+    assert requests[0][3]["Accept-Encoding"] == "identity"
+    assert json.loads(usage_log.read_text()) == {
+        "provider": "openai",
+        "model": "gpt-5.4",
+        "requests_with_usage": 1,
+        "input_tokens": 45,
+        "input_write_tokens": 40,
+        "cache_read_tokens": 5,
+        "cache_creation_tokens": 0,
+        "output_tokens": 6,
+    }
+
+
+def test_parse_keeps_image_usage_in_openclaw_metadata_only(tmp_path) -> None:
+    run_dir = tmp_path / "run"
+    work_dir = run_dir / "origin_log" / "openclaw-cli"
+    work_dir.mkdir(parents=True)
+    image_bytes = b"\x89PNG\r\n\x1a\nsmall-test-image"
+    encoded = base64.b64encode(image_bytes).decode()
+    data_url = f"data:image/png;base64,{encoded}"
+    events = [
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "image-call",
+                        "name": "image",
+                        "arguments": {"image": data_url},
+                    }
+                ],
+                "usage": {
+                    "input": 100,
+                    "output": 20,
+                    "cacheRead": 40,
+                    "cacheWrite": 3,
+                },
+            },
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "image-call",
+                "content": [
+                    {"type": "text", "text": "visible"},
+                    {
+                        "type": "image",
+                        "mimeType": "image/png",
+                        "data": encoded,
+                    },
+                ],
+            },
+        },
+    ]
+    (work_dir / "transcript.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n"
+    )
+    (work_dir / "vision-usage.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "provider": "openai",
+                        "model": "gpt-5.4",
+                        "requests_with_usage": 1,
+                        "input_tokens": 60,
+                        "input_write_tokens": 50,
+                        "cache_read_tokens": 10,
+                        "cache_creation_tokens": 0,
+                        "output_tokens": 5,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "provider": "openai",
+                        "model": "gpt-5.4",
+                        "requests_with_usage": 1,
+                        "input_tokens": 40,
+                        "input_write_tokens": 40,
+                        "cache_read_tokens": 0,
+                        "cache_creation_tokens": 0,
+                        "output_tokens": 4,
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    builder = TrajectoryBuilder(
+        agent_name="openclaw-cli",
+        model="primary-model",
+        task_path="demo/seecheck",
+        variant_index=0,
+    )
+
+    OpenClawCliDeployer.parse_artifacts(
+        work_dir=work_dir,
+        config=OpenClawCliConfig(),
+        run_result=AgentRunResult(
+            status="completed",
+            pid=1,
+            exit_code=0,
+            transcript_path=str(work_dir / "transcript.jsonl"),
+            stderr_path=str(work_dir / "stderr.log"),
+            duration_s=1,
+        ),
+        builder=builder,
+    )
+    trajectory = builder.finalize(reward=1)
+
+    assert trajectory.extra["openclaw_cli"]["image_model_usage"] == {
+        "provider": "openai",
+        "model": "gpt-5.4",
+        "requests_with_usage": 2,
+        "input_tokens": 100,
+        "input_write_tokens": 90,
+        "cache_read_tokens": 10,
+        "cache_creation_tokens": 0,
+        "output_tokens": 9,
+    }
+    assert trajectory.final_metrics is not None
+    assert trajectory.final_metrics.total_input_tokens == 100
+    assert trajectory.final_metrics.total_output_tokens == 20
+    assert "model_usage" not in trajectory.final_metrics.model_dump()
+
+    raw_transcript = (work_dir / "transcript.jsonl").read_text()
+    assert "base64," not in raw_transcript
+    assert encoded not in raw_transcript
+    screenshots = list((run_dir / "screenshots").iterdir())
+    assert len(screenshots) == 1
+    assert screenshots[0].read_bytes() == image_bytes
+    assert trajectory.steps[0].tool_calls[0].arguments["image"].startswith(
+        "screenshots/"
+    )
+    image_part = trajectory.steps[1].observation.results[0].content[1]
+    assert image_part.image is not None
+    assert image_part.image.type == "path"
+    assert image_part.image.path == trajectory.steps[0].tool_calls[0].arguments[
+        "image"
+    ]
+
+
+def test_stage_transcript_file_images_for_gather(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    workspace = tmp_path / ".openclaw" / "workspace"
+    workspace.mkdir(parents=True)
+    source = workspace / "screen.png"
+    source.write_bytes(b"image-file")
+    work_dir = tmp_path / "artifacts"
+    work_dir.mkdir()
+    transcript = work_dir / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "toolCall",
+                            "id": "image-call",
+                            "name": "image",
+                            "arguments": {"image": "screen.png"},
+                        }
+                    ],
+                },
+            }
+        )
+        + "\n"
+    )
+
+    vision_module.stage_transcript_file_images(transcript, work_dir)
+
+    event = json.loads(transcript.read_text())
+    relative = event["message"]["content"][0]["arguments"]["image"]
+    assert relative.startswith("screenshots/openclaw-input-")
+    assert (work_dir / relative).read_bytes() == b"image-file"

--- a/tests/ale_run/test_openclaw_cli_completion.py
+++ b/tests/ale_run/test_openclaw_cli_completion.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 
 from ale_run.agents.openclaw_cli import OpenClawCliConfig, OpenClawCliDeployer
 from ale_run.agents.openclaw_cli import deployer as deployer_module
+from ale_run.base_interface.agent_deployer import AgentRunResult
+from ale_run.base_interface.trajectory import StepMetrics, TrajectoryBuilder
 
 
 class _LingeringOpenClawProcess:
@@ -81,3 +83,118 @@ def test_parse_stderr_json_accepts_diagnostics_after_envelope() -> None:
         "payloads": [],
         "meta": {"durationMs": 25},
     }
+
+
+def test_envelope_usage_overrides_partial_transcript_totals(tmp_path) -> None:
+    (tmp_path / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "done"}],
+                    "usage": {
+                        "input": 10,
+                        "output": 5,
+                        "cacheRead": 20,
+                        "cacheWrite": 2,
+                    },
+                },
+            }
+        )
+    )
+    (tmp_path / "stderr.log").write_text(
+        json.dumps(
+            {
+                "payloads": [{"text": "done"}],
+                "meta": {
+                    "durationMs": 25,
+                    "agentMeta": {
+                        "usage": {
+                            "input": 100,
+                            "output": 50,
+                            "cacheRead": 200,
+                            "cacheWrite": 20,
+                        }
+                    },
+                },
+            }
+        )
+    )
+    builder = TrajectoryBuilder(
+        agent_name="openclaw-cli",
+        model="test-model",
+        task_path="demo/seecheck",
+        variant_index=0,
+    )
+
+    OpenClawCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=OpenClawCliConfig(),
+        run_result=AgentRunResult(
+            status="completed",
+            pid=1,
+            exit_code=0,
+            transcript_path=str(tmp_path / "transcript.jsonl"),
+            stderr_path=str(tmp_path / "stderr.log"),
+            duration_s=1,
+        ),
+        builder=builder,
+    )
+    final_metrics = builder.finalize(reward=1).final_metrics
+
+    assert final_metrics is not None
+    assert final_metrics.total_input_tokens == 100
+    assert final_metrics.total_output_tokens == 50
+    assert final_metrics.total_cache_read_tokens == 200
+    assert final_metrics.total_cache_creation_tokens == 20
+
+
+def test_empty_envelope_usage_does_not_erase_step_totals(tmp_path) -> None:
+    (tmp_path / "stderr.log").write_text(
+        json.dumps(
+            {
+                "payloads": [],
+                "meta": {
+                    "durationMs": 25,
+                    "agentMeta": {
+                        "usage": {
+                            "input": 0,
+                            "output": 0,
+                            "cacheRead": 0,
+                            "cacheWrite": 0,
+                        }
+                    },
+                },
+            }
+        )
+    )
+    builder = TrajectoryBuilder(
+        agent_name="openclaw-cli",
+        model="test-model",
+        task_path="demo/seecheck",
+        variant_index=0,
+    )
+    builder.add_step(
+        source="agent",
+        metrics=StepMetrics(input_tokens=10, output_tokens=5),
+    )
+
+    OpenClawCliDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=OpenClawCliConfig(),
+        run_result=AgentRunResult(
+            status="completed",
+            pid=1,
+            exit_code=0,
+            transcript_path=str(tmp_path / "transcript.jsonl"),
+            stderr_path=str(tmp_path / "stderr.log"),
+            duration_s=1,
+        ),
+        builder=builder,
+    )
+    final_metrics = builder.finalize(reward=1).final_metrics
+
+    assert final_metrics is not None
+    assert final_metrics.total_input_tokens == 10
+    assert final_metrics.total_output_tokens == 5


### PR DESCRIPTION
## Context

This PR groups two agent-harness improvements that were developed and validated together during full ALE benchmark runs.

### OpenClaw

Custom OpenAI-compatible endpoints could finish without complete usage accounting, and some completed OpenClaw turns remained alive until the experiment walltime. OpenClaw can also route image analysis through a separate model, which requires separate accounting and artifact handling.

### Codex

Codex transcripts describe agent actions but do not provide enough operational detail to analyze model latency and tool latency. Codex already emits structured OpenTelemetry events, but ALE did not enable or persist them. Long-running sandbox tasks also need telemetry to be copied incrementally rather than relying only on the final directory download.

## Changes

### OpenClaw integration

- Add explicit custom OpenAI-compatible routing with configurable endpoint, provider-facing model ID, API key, and streaming-usage support.
- Enable streamed usage metadata by default for custom routes; this was validated with the Azure-Code endpoint.
- Add native Z.AI routing, validated with GLM-5.2, including independent direct routing for the vision model.
- Populate ALE's existing shared usage fields from OpenClaw's aggregate result envelope without renaming the shared schema.
- Treat a complete result envelope as task completion even if the CLI process remains alive.
- Record image-model usage separately under OpenClaw-specific trajectory metadata.
- Preserve image-tool inputs under `screenshots/` and replace embedded transcript Base64 payloads with artifact references.

### Codex telemetry

- Enable Codex's built-in OpenTelemetry log exporter through a run-local OTLP/HTTP receiver; no Codex upstream source changes are required.
- Persist raw OTLP batches, flattened events, and a summary containing API/WebSocket duration, response completion timing, time to first token, tool duration, tool arguments/results, and Codex conversation/thread correlation metadata.
- Add raw Codex telemetry to ALE's existing incremental sandbox artifact pull, so long-running tasks do not depend solely on the final directory gather.
- Store large OTLP batches as bounded JSONL records with sequence metadata and SHA-256 validation.
- Rebuild `telemetry.jsonl` and `telemetry_summary.json` from the raw records during finalization. An incomplete final batch is ignored without invalidating earlier complete telemetry.
- Add `otel_enabled` to the public Codex configuration, enabled by default.

## Scope

- No OpenClaw or Codex upstream source modifications.
- No shared trajectory field renames.
- No private agent presets, experiment configurations, task lists, result data, or credentials.
- OpenAI request-ID capture remains out of scope; `conversation.id` is the Codex thread identifier, not an API request identifier.

## Validation

### Automated

- `28 passed` across OpenClaw integration, Codex telemetry, incremental-tail reconciliation, SSE streaming, and ranged-download tests.
- Ruff passes for the changed OpenClaw and Codex code and tests.
- `git diff --check origin/main...HEAD` passes.

### Codex end-to-end smoke

Ran `demo/seecheck` on a fresh Google Cloud Ubuntu sandbox using Direct OpenAI, GPT-5.4, and the Codex harness:

- Run completed with score `1.0`.
- The host had already received 647,888 bytes of raw telemetry before `agent_finished` and before the final directory gather, confirming live incremental transfer.
- All 8 OTLP batches passed SHA-256 validation and JSON parsing.
- Final artifacts contained 213 events, 4 model API/WebSocket calls, and 2 tool executions.
- Rebuilding from only the raw telemetry produced an event file identical to the original derived file.
- Truncating the final batch recovered all earlier complete batches without corrupting the telemetry set.
- The test VM was deleted successfully after the run.