### PR TITLE
Fix CRF free-text evaluation

### DIFF
--- a/tasks/health_medicine/crf_sdtm_mapping_1/scripts/score_crf_sdtm_mapping.py
+++ b/tasks/health_medicine/crf_sdtm_mapping_1/scripts/score_crf_sdtm_mapping.py
@@ -24,6 +24,11 @@ OUTPUT_COLUMNS = [
     "notes",
 ]
 
+FREE_TEXT_COLUMNS = {"mapping_rule", "notes"}
+EXACT_MATCH_COLUMNS = [
+    column for column in OUTPUT_COLUMNS if column not in FREE_TEXT_COLUMNS
+]
+
 KEY_COLUMNS = [
     "crf_form",
     "crf_field_label",
@@ -69,6 +74,16 @@ def normalize_cell(value: object) -> str:
 
 def _format_key(row: dict[str, str]) -> tuple[str, str, str]:
     return tuple(normalize_cell(row[column]) for column in KEY_COLUMNS)
+
+
+def _mentions_target_variable(mapping_rule: str, target_variable: str) -> bool:
+    return bool(
+        re.search(
+            rf"(?<![A-Za-z0-9_]){re.escape(target_variable)}(?![A-Za-z0-9_])",
+            mapping_rule,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _parse_csv(text: str, *, label: str) -> tuple[list[str], list[dict[str, str]], list[str]]:
@@ -130,6 +145,18 @@ def _index_rows(
                 f"{label}: row {row_index} maps supplemental dataset {suppqual} with goes_to_suppqual={supp_flag!r}"
             )
 
+        mapping_rule = row["mapping_rule"]
+        notes = row["notes"]
+        target_variable = row["sdtm_variable"]
+        if not mapping_rule:
+            errors.append(f"{label}: row {row_index} has an empty mapping_rule")
+        elif target_variable and not _mentions_target_variable(mapping_rule, target_variable):
+            errors.append(
+                f"{label}: row {row_index} mapping_rule must name target variable {target_variable!r}"
+            )
+        if not notes:
+            errors.append(f"{label}: row {row_index} has empty notes")
+
         key = _format_key(row)
         if not all(key):
             errors.append(f"{label}: row {row_index} has an empty composite-key cell: {key!r}")
@@ -175,7 +202,7 @@ def score_mapping_csv(agent_csv: str, reference_csv: str, *, variant: str) -> Sc
     for key in sorted(reference_keys & agent_keys):
         expected = reference_index[key]
         observed = agent_index[key]
-        for column in OUTPUT_COLUMNS:
+        for column in EXACT_MATCH_COLUMNS:
             if observed[column] != expected[column]:
                 mismatches.append(
                     {

--- a/tasks/health_medicine/crf_sdtm_mapping_1/scripts/test_score_crf_sdtm_mapping.py
+++ b/tasks/health_medicine/crf_sdtm_mapping_1/scripts/test_score_crf_sdtm_mapping.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import csv
+import io
+import unittest
+
+from score_crf_sdtm_mapping import OUTPUT_COLUMNS, score_mapping_csv
+
+
+REFERENCE_ROW = {
+    "crf_form": "CONCOMITANT MEDICATIONS - BASELINE (CONMED BSL)",
+    "crf_field_label": "What is the medication identifier?",
+    "crf_item_or_placeholder": "Sponsor-Defined Identifier",
+    "sdtm_dataset": "CM",
+    "sdtm_variable": "CMSPID",
+    "role": "Identifier",
+    "origin": "CRF",
+    "mapping_rule": "Map the sponsor-defined medication identifier to CMSPID.",
+    "controlled_terms_or_expected_values": "",
+    "goes_to_suppqual": "NO",
+    "notes": "aCRF page 15 annotates this field to CMSPID.",
+}
+
+
+def render_csv(row: dict[str, str]) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=OUTPUT_COLUMNS, lineterminator="\n")
+    writer.writeheader()
+    writer.writerow(row)
+    return output.getvalue()
+
+
+class ScoreMappingCsvTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.reference = render_csv(REFERENCE_ROW)
+
+    def score(self, **updates: str):
+        row = {**REFERENCE_ROW, **updates}
+        return score_mapping_csv(render_csv(row), self.reference, variant="base")
+
+    def test_reference_passes(self) -> None:
+        self.assertEqual(self.score().score, 1.0)
+
+    def test_equivalent_free_text_passes(self) -> None:
+        result = self.score(
+            mapping_rule="Populate CMSPID directly from the sponsor identifier.",
+            notes="The annotated CRF identifies the corresponding source field.",
+        )
+        self.assertEqual(result.score, 1.0)
+
+    def test_structured_column_mismatch_fails(self) -> None:
+        result = self.score(role="Topic")
+        self.assertEqual(result.score, 0.0)
+        self.assertEqual(result.mismatches[0]["column"], "role")
+
+    def test_empty_mapping_rule_fails(self) -> None:
+        result = self.score(mapping_rule="")
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("empty mapping_rule", result.errors[0])
+
+    def test_mapping_rule_must_name_target_variable(self) -> None:
+        result = self.score(mapping_rule="Map the sponsor identifier to the target field.")
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("must name target variable", result.errors[0])
+
+    def test_empty_notes_fail(self) -> None:
+        result = self.score(notes="")
+        self.assertEqual(result.score, 0.0)
+        self.assertIn("empty notes", result.errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tasks/health_medicine/crf_sdtm_mapping_1/task_card.json
+++ b/tasks/health_medicine/crf_sdtm_mapping_1/task_card.json
@@ -63,7 +63,7 @@
       "description": "Required output for the DS variant."
     }
   ],
-  "evaluation": "Binary CSV evaluation. The submitted file must have the exact required columns in order, use only the variant's allowed primary and supplemental datasets, keep `goes_to_suppqual` consistent with the dataset, and include every expected normalized mapping row with no extras. Correct fixture outputs score 1.0; incomplete or wrong-key fixture outputs score 0.0.",
+  "evaluation": "Binary CSV evaluation. The submitted file must have the exact required columns in order, use only the variant's allowed primary and supplemental datasets, keep `goes_to_suppqual` consistent with the dataset, and include every expected normalized mapping row with no extras. The nine structured columns are compared exactly after whitespace normalization. `mapping_rule` and `notes` must be non-empty, and `mapping_rule` must name the row's target SDTM variable, but semantically equivalent wording is accepted. Correct fixture outputs score 1.0; incomplete, wrong-key, or structurally incorrect outputs score 0.0.",
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free-ubuntu",


### PR DESCRIPTION
Summary:
- compare only the nine structured CRF mapping columns against the reference
- accept semantically equivalent mapping_rule and notes wording
- require both free-text fields to be non-empty and mapping_rule to name the target variable
- document the evaluator contract and add regression tests

Validation:
- 6 focused unit tests pass
- base, VS, and DS references score 1.0
- positive fixture scores 1.0
- negative fixture remains 0.0
- Python, JSON, and diff checks pass