### PR TITLE
feat(claude_code): persist detailed run telemetry via OpenTelemetry

### DIFF
--- a/ale_run/agents/claude_code/config.py
+++ b/ale_run/agents/claude_code/config.py
@@ -95,6 +95,15 @@ class ClaudeCodeConfig:
     disabled_tools: tuple[str, ...] = _DISABLED_TOOLS
     dangerously_skip_permissions: bool = True
 
+    otel_enabled: bool = True
+    """Capture Claude Code's built-in OpenTelemetry stream for every run. The
+    deployer starts a run-local OTLP/HTTP receiver and points the CLI at it
+    (``CLAUDE_CODE_ENABLE_TELEMETRY=1`` + ``OTEL_*`` env vars), storing raw OTLP
+    batches, flattened per-event logs (API request timing/tokens/cost/request-id,
+    tool arguments/duration, prompts), cumulative metrics, and a summary in
+    ``work_dir``. No upstream Claude Code changes are required. Set ``false`` to
+    run the CLI with telemetry off."""
+
     max_thinking_tokens: int | None = 31999
     """Extended-thinking token budget, passed to the CLI via the
     ``MAX_THINKING_TOKENS`` env var (Claude Code's documented knob —

--- a/ale_run/agents/claude_code/deployer.py
+++ b/ale_run/agents/claude_code/deployer.py
@@ -42,6 +42,7 @@ from ale_run.base_interface import (
 )
 
 from .config import ClaudeCodeConfig
+from .telemetry import ClaudeCodeOtelCollector, recover_telemetry_artifacts
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +109,15 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
 
     default_executor: ClassVar[str] = "sandbox"
     supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
-    hot_artifacts: ClassVar[tuple[str, ...]] = ("transcript.jsonl", "stderr.log")
+    # otel_requests.jsonl is the raw OTLP write-ahead log: mirror it incrementally
+    # off the sandbox so long tasks do not depend solely on the final gather.
+    # The derived telemetry.jsonl / telemetry_summary.json are rebuilt from it in
+    # parse_artifacts, so they are deliberately NOT hot.
+    hot_artifacts: ClassVar[tuple[str, ...]] = (
+        "transcript.jsonl",
+        "stderr.log",
+        "otel_requests.jsonl",
+    )
 
     @property
     def version(self) -> str | None:
@@ -253,6 +262,7 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
         stderr_log = wd / "stderr.log"
         pid_file = wd / "claude.pid"
         mcp_config = wd / "mcp_config.json"
+        collector = ClaudeCodeOtelCollector(wd) if cfg.otel_enabled else None
 
         # Reset prior-run files so the puller's "rotation detected" logic
         # sees a clean slate.
@@ -270,52 +280,65 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
             cfg=cfg,
             mcp_config=str(mcp_config),
         )
-        env = self._build_env(cfg)
+        # Start the run-local OTLP receiver BEFORE composing env, so its
+        # endpoint can be injected into the CLI's telemetry env vars.
+        otel_endpoint: str | None = None
+        if collector is not None:
+            collector.start()
+            otel_endpoint = collector.endpoint
+            logger.info("claude_code: OTel collector listening at %s", otel_endpoint)
+        env = self._build_env(cfg, otel_endpoint=otel_endpoint)
 
         t0 = time.monotonic()
-        # Open output files; subprocess inherits the descriptors and the
-        # parent's references can close after spawn (the child keeps them).
-        with open(prompt_file, "rb") as pin, \
-             open(transcript_file, "wb") as tout, \
-             open(stderr_log, "wb") as terr:
-            proc = await asyncio.to_thread(
-                subprocess.Popen,
-                argv,
-                stdin=pin,
-                stdout=tout,
-                stderr=terr,
-                env=env,
-                cwd=str(wd),
-                # Detach: child outlives any incidental signal sent to us.
-                start_new_session=True if hasattr(os, "setsid") else False,
-            )
-        pid_file.write_text(str(proc.pid), encoding="ascii")
-        logger.info("claude_code: spawned pid=%s argv0=%s", proc.pid, argv[0])
-
-        # Wait for the child to finish.
-        # The episode wall budget is orchestration-owned: the executor
-        # wraps launch() in asyncio.wait_for(timeout=timeout_s) (derived
-        # from the task), so we just wait for the child here. If that
-        # budget fires we are cancelled mid-await; reap the child before
-        # propagating so it cannot outlive the run.
         try:
-            while proc.poll() is None:
-                await asyncio.sleep(_POLL_INTERVAL_S)
-        except asyncio.CancelledError:
-            try:
-                proc.terminate()
-            except ProcessLookupError:
-                pass
-            try:
-                await asyncio.wait_for(
-                    asyncio.to_thread(proc.wait), timeout=_TERM_GRACE_S,
+            # Open output files; subprocess inherits the descriptors and the
+            # parent's references can close after spawn (the child keeps them).
+            with open(prompt_file, "rb") as pin, \
+                 open(transcript_file, "wb") as tout, \
+                 open(stderr_log, "wb") as terr:
+                proc = await asyncio.to_thread(
+                    subprocess.Popen,
+                    argv,
+                    stdin=pin,
+                    stdout=tout,
+                    stderr=terr,
+                    env=env,
+                    cwd=str(wd),
+                    # Detach: child outlives any incidental signal sent to us.
+                    start_new_session=True if hasattr(os, "setsid") else False,
                 )
-            except (asyncio.TimeoutError, asyncio.CancelledError):
+            pid_file.write_text(str(proc.pid), encoding="ascii")
+            logger.info("claude_code: spawned pid=%s argv0=%s", proc.pid, argv[0])
+
+            # Wait for the child to finish.
+            # The episode wall budget is orchestration-owned: the executor
+            # wraps launch() in asyncio.wait_for(timeout=timeout_s) (derived
+            # from the task), so we just wait for the child here. If that
+            # budget fires we are cancelled mid-await; reap the child before
+            # propagating so it cannot outlive the run.
+            try:
+                while proc.poll() is None:
+                    await asyncio.sleep(_POLL_INTERVAL_S)
+            except asyncio.CancelledError:
                 try:
-                    proc.kill()
+                    proc.terminate()
                 except ProcessLookupError:
                     pass
-            raise
+                try:
+                    await asyncio.wait_for(
+                        asyncio.to_thread(proc.wait), timeout=_TERM_GRACE_S,
+                    )
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
+                raise
+        finally:
+            # Stop the collector so it drains the final batch and writes the
+            # derived telemetry files, whether the run completed or was killed.
+            if collector is not None:
+                collector.stop()
 
         duration_s = time.monotonic() - t0
         exit_code = proc.returncode
@@ -374,7 +397,9 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
             argv += ["--disallowedTools", tool]
         return argv
 
-    def _build_env(self, cfg: ClaudeCodeConfig) -> dict[str, str]:
+    def _build_env(
+        self, cfg: ClaudeCodeConfig, *, otel_endpoint: str | None = None,
+    ) -> dict[str, str]:
         """Compose the env dict subprocess will see.
 
         OpenRouter remap mirrors the previous shell-script logic, just in
@@ -443,6 +468,28 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
                 f"claude_code: unknown provider {cfg.provider!r} "
                 "(expected 'openrouter' or 'direct')"
             )
+
+        # OpenTelemetry: point Claude Code's built-in exporter at the run-local
+        # OTLP/HTTP receiver. Claude Code emits per-event logs (api_request,
+        # tool_result, tool_decision, user_prompt, api_error, ...) and cumulative
+        # metrics; we take both over http/json so the collector can parse JSON
+        # directly. Short export intervals keep the raw WAL near-real-time for the
+        # incremental sandbox pull. Prompt + tool-detail logging is enabled so the
+        # events carry the operational context (prompt text, tool arguments) the
+        # transcript alone omits. No upstream Claude Code changes are required.
+        if otel_endpoint is not None:
+            env.update({
+                "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+                "OTEL_LOGS_EXPORTER": "otlp",
+                "OTEL_METRICS_EXPORTER": "otlp",
+                "OTEL_TRACES_EXPORTER": "none",
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": otel_endpoint,
+                "OTEL_LOGS_EXPORT_INTERVAL": "1000",
+                "OTEL_METRIC_EXPORT_INTERVAL": "10000",
+                "OTEL_LOG_USER_PROMPTS": "1",
+                "OTEL_LOG_TOOL_DETAILS": "1",
+            })
         return env
 
     def _diagnose_failure(
@@ -480,6 +527,15 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
         run_result: AgentRunResult,
         builder: TrajectoryBuilder,
     ) -> None:
+        # Rebuild derived telemetry (telemetry.jsonl / telemetry_metrics.jsonl /
+        # telemetry_summary.json) from the incrementally-mirrored raw OTLP WAL,
+        # so a task whose final directory gather was interrupted still yields
+        # complete telemetry. Best-effort: never let it break artifact parsing.
+        try:
+            recover_telemetry_artifacts(work_dir)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.warning("claude_code: could not recover telemetry artifacts: %s", exc)
+
         transcript_file = work_dir / "transcript.jsonl"
         if not transcript_file.exists():
             builder.add_step(
@@ -537,6 +593,9 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
             "exit_code": run_result.exit_code,
             "transcript_path": str(transcript_file),
             "stderr_path": run_result.stderr_path,
+            "telemetry_path": str(work_dir / "telemetry.jsonl"),
+            "telemetry_metrics_path": str(work_dir / "telemetry_metrics.jsonl"),
+            "telemetry_summary_path": str(work_dir / "telemetry_summary.json"),
         })
 
     @classmethod

--- a/ale_run/agents/claude_code/telemetry.py
+++ b/ale_run/agents/claude_code/telemetry.py
@@ -1,0 +1,696 @@
+"""Per-run OpenTelemetry receiver for Claude Code CLI observability.
+
+Claude Code emits structured OpenTelemetry **logs** (one record per event:
+``api_request``, ``api_error``, ``tool_result``, ``tool_decision``,
+``user_prompt``, ...) and **metrics** (cumulative token/cost/session counters)
+when ``CLAUDE_CODE_ENABLE_TELEMETRY=1``. The events carry operational detail the
+``transcript.jsonl`` does not: per-request model latency (``duration_ms``), the
+upstream Anthropic ``request_id``, ``query_source`` (main vs. auxiliary calls
+such as session-title generation), per-tool duration/success, and prompt text.
+
+This module stands up a run-local OTLP/HTTP receiver, points the CLI at it via
+env vars (see the deployer), and persists complete run telemetry in ``work_dir``:
+
+* ``otel_requests.jsonl`` — a write-ahead log of every raw OTLP batch, chunked
+  and SHA-256 tagged so large tool payloads stay as bounded JSONL records and a
+  truncated final batch never invalidates earlier complete ones. This file is on
+  the deployer's ``hot_artifacts`` list so it is mirrored incrementally off the
+  sandbox during long tasks, not only at the final directory gather.
+* ``telemetry.jsonl`` — flattened log events, one JSON object per record.
+* ``telemetry_metrics.jsonl`` — flattened metric data points.
+* ``telemetry_summary.json`` — API calls (timing/tokens/cost/request_id), API
+  errors, tool executions, tool decisions, user prompts, and metric totals.
+
+The Claude Code exporter is the OpenTelemetry JS SDK, which sends OTLP/HTTP with
+``Transfer-Encoding: chunked`` and **no** ``Content-Length`` — the receiver must
+de-chunk the request body (a ``read(Content-Length)`` reader would capture
+nothing). No Claude Code upstream source changes are required.
+"""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import json
+import os
+import threading
+import uuid
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Iterator
+
+_RAW_CHUNK_BYTES = 512 * 1024
+
+# OTLP/HTTP signal → request path. Claude Code (OTel JS SDK) appends these to
+# OTEL_EXPORTER_OTLP_ENDPOINT.
+_SIGNAL_BY_PATH = {"/v1/logs": "logs", "/v1/metrics": "metrics"}
+
+
+class ClaudeCodeOtelCollector:
+    """Receive Claude Code OTLP/HTTP JSON and persist complete run telemetry."""
+
+    def __init__(self, work_dir: Path):
+        self.work_dir = work_dir
+        self.raw_path = work_dir / "otel_requests.jsonl"
+        self.events_path = work_dir / "telemetry.jsonl"
+        self.metrics_path = work_dir / "telemetry_metrics.jsonl"
+        self.summary_path = work_dir / "telemetry_summary.json"
+        self._lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def endpoint(self) -> str:
+        """Base OTLP endpoint; the CLI appends ``/v1/logs`` and ``/v1/metrics``."""
+        if self._server is None:
+            raise RuntimeError("Claude Code OTel collector has not been started")
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def start(self) -> None:
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        for path in (
+            self.raw_path,
+            self.events_path,
+            self.metrics_path,
+            self.summary_path,
+        ):
+            path.unlink(missing_ok=True)
+
+        collector = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                signal = _SIGNAL_BY_PATH.get(self.path)
+                if signal is None:
+                    self.send_error(404)
+                    return
+
+                body = self._read_body()
+                if self.headers.get("Content-Encoding", "").lower() == "gzip":
+                    try:
+                        body = gzip.decompress(body)
+                    except (OSError, EOFError):
+                        pass
+
+                collector._store_request(signal, dict(self.headers), body)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def _read_body(self) -> bytes:
+                # The OTel JS exporter streams the body with
+                # Transfer-Encoding: chunked and no Content-Length, so a plain
+                # read(Content-Length) reads zero bytes. Handle both framings.
+                if "chunked" in self.headers.get("Transfer-Encoding", "").lower():
+                    return _read_chunked_body(self.rfile)
+                length = int(self.headers.get("Content-Length", "0"))
+                return self.rfile.read(length)
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="claude-code-otel-collector",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+        self._write_derived()
+
+    def _store_request(self, signal: str, headers: dict[str, str], body: bytes) -> None:
+        received_at = datetime.now(timezone.utc).isoformat()
+        try:
+            payload = json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+
+        events: list[dict[str, Any]] = []
+        metrics: list[dict[str, Any]] = []
+        if isinstance(payload, dict):
+            if signal == "logs":
+                events = _flatten_otlp_logs(payload, received_at)
+            elif signal == "metrics":
+                metrics = _flatten_otlp_metrics(payload, received_at)
+
+        request_id = uuid.uuid4().hex
+        chunks = [
+            body[offset : offset + _RAW_CHUNK_BYTES]
+            for offset in range(0, len(body), _RAW_CHUNK_BYTES)
+        ] or [b""]
+        payload_sha256 = hashlib.sha256(body).hexdigest()
+
+        with self._lock:
+            with self.raw_path.open("a", encoding="utf-8") as file:
+                for index, chunk in enumerate(chunks):
+                    record: dict[str, Any] = {
+                        "record_type": "otlp_request_chunk",
+                        "signal": signal,
+                        "request_id": request_id,
+                        "received_at": received_at,
+                        "chunk_index": index,
+                        "chunk_count": len(chunks),
+                        "payload_encoding": "base64",
+                        "payload": base64.b64encode(chunk).decode("ascii"),
+                    }
+                    if index == 0:
+                        record["headers"] = headers
+                        record["payload_bytes"] = len(body)
+                        record["payload_sha256"] = payload_sha256
+                    file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                file.flush()
+                os.fsync(file.fileno())
+            if events:
+                with self.events_path.open("a", encoding="utf-8") as file:
+                    for event in events:
+                        file.write(json.dumps(event, ensure_ascii=False) + "\n")
+            if metrics:
+                with self.metrics_path.open("a", encoding="utf-8") as file:
+                    for point in metrics:
+                        file.write(json.dumps(point, ensure_ascii=False) + "\n")
+
+    def _write_derived(
+        self,
+        events: list[dict[str, Any]] | None = None,
+        metrics: list[dict[str, Any]] | None = None,
+    ) -> None:
+        if events is None:
+            events = _read_jsonl(self.events_path)
+        if metrics is None:
+            metrics = _read_jsonl(self.metrics_path)
+        events.sort(key=_event_sort_key)
+
+        names = Counter(
+            event.get("attributes", {}).get("event.name", "unknown") for event in events
+        )
+        summary = {
+            "event_count": len(events),
+            "events_by_name": dict(sorted(names.items())),
+            "api_calls": _summarize_api_calls(events),
+            "api_errors": _summarize_api_errors(events),
+            "tool_executions": _summarize_tools(events),
+            "tool_decisions": _summarize_tool_decisions(events),
+            "user_prompts": _summarize_prompts(events),
+            "metric_totals": _summarize_metrics(metrics),
+            "artifacts": {
+                "raw_otlp_requests": self.raw_path.name,
+                "events": self.events_path.name,
+                "metrics": self.metrics_path.name,
+            },
+        }
+        self.summary_path.write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+def recover_telemetry_artifacts(work_dir: Path) -> int:
+    """Rebuild derived telemetry files from the incrementally mirrored raw WAL.
+
+    Returns the number of recovered log events. Used at finalization so a task
+    whose final directory gather was interrupted still yields complete telemetry
+    from the incrementally-pulled ``otel_requests.jsonl``.
+    """
+    raw_path = work_dir / "otel_requests.jsonl"
+    if not raw_path.exists():
+        return 0
+
+    events: list[dict[str, Any]] = []
+    metrics: list[dict[str, Any]] = []
+    for signal, received_at, payload in _read_otlp_payloads(raw_path):
+        if signal == "metrics":
+            metrics.extend(_flatten_otlp_metrics(payload, received_at))
+        else:
+            events.extend(_flatten_otlp_logs(payload, received_at))
+
+    events.sort(key=_event_sort_key)
+    _write_jsonl_atomic(work_dir / "telemetry.jsonl", events)
+    _write_jsonl_atomic(work_dir / "telemetry_metrics.jsonl", metrics)
+    collector = ClaudeCodeOtelCollector(work_dir)
+    collector._write_derived(events, metrics)
+    return len(events)
+
+
+def _read_chunked_body(rfile: Any) -> bytes:
+    """Decode an HTTP/1.1 ``Transfer-Encoding: chunked`` request body."""
+    body = bytearray()
+    while True:
+        size_line = rfile.readline()
+        if not size_line:
+            break
+        try:
+            size = int(size_line.split(b";", 1)[0].strip(), 16)
+        except ValueError:
+            break
+        if size == 0:
+            rfile.readline()  # consume trailing CRLF after the last chunk
+            break
+        body += rfile.read(size)
+        rfile.readline()  # consume the CRLF terminating this chunk
+    return bytes(body)
+
+
+def _read_otlp_payloads(path: Path) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    """Yield ``(signal, received_at, payload)`` for each complete WAL request."""
+    current_request_id: str | None = None
+    current_state: dict[str, Any] | None = None
+
+    for record in _iter_jsonl(path):
+        if record.get("record_type") != "otlp_request_chunk":
+            if current_state is not None:
+                decoded = _decode_chunked_payload(current_state)
+                if decoded is not None:
+                    yield decoded
+                current_request_id = None
+                current_state = None
+            continue
+
+        request_id = record.get("request_id")
+        chunk_index = record.get("chunk_index")
+        chunk_count = record.get("chunk_count")
+        encoded = record.get("payload")
+        if (
+            not isinstance(request_id, str)
+            or not isinstance(chunk_index, int)
+            or not isinstance(chunk_count, int)
+            or chunk_count < 1
+            or not isinstance(encoded, str)
+        ):
+            continue
+
+        if request_id != current_request_id:
+            if current_state is not None:
+                decoded = _decode_chunked_payload(current_state)
+                if decoded is not None:
+                    yield decoded
+            current_request_id = request_id
+            current_state = {
+                "signal": record.get("signal", "logs"),
+                "received_at": str(record.get("received_at", "")),
+                "chunk_count": chunk_count,
+                "chunks": {},
+                "payload_sha256": record.get("payload_sha256"),
+            }
+
+        if current_state["chunk_count"] != chunk_count or not 0 <= chunk_index < chunk_count:
+            current_state["invalid"] = True
+            continue
+        try:
+            current_state["chunks"][chunk_index] = base64.b64decode(
+                encoded, validate=True,
+            )
+        except (ValueError, TypeError):
+            current_state["invalid"] = True
+
+    if current_state is not None:
+        decoded = _decode_chunked_payload(current_state)
+        if decoded is not None:
+            yield decoded
+
+
+def _decode_chunked_payload(
+    state: dict[str, Any],
+) -> tuple[str, str, dict[str, Any]] | None:
+    chunks = state["chunks"]
+    if state.get("invalid") or len(chunks) != state["chunk_count"]:
+        return None
+    body = b"".join(chunks[index] for index in range(state["chunk_count"]))
+    expected_sha256 = state.get("payload_sha256")
+    if expected_sha256 and hashlib.sha256(body).hexdigest() != expected_sha256:
+        return None
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return str(state.get("signal", "logs")), state["received_at"], payload
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return list(_iter_jsonl(path))
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8", errors="replace") as file:
+        for line in file:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                yield record
+
+
+def _write_jsonl_atomic(path: Path, records: list[dict[str, Any]]) -> None:
+    tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8") as file:
+            for record in records:
+                file.write(json.dumps(record, ensure_ascii=False) + "\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _flatten_otlp_logs(payload: dict[str, Any], received_at: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for resource_log in payload.get("resourceLogs", []):
+        resource = _attributes(resource_log.get("resource", {}).get("attributes", []))
+        for scope_log in resource_log.get("scopeLogs", []):
+            scope_data = scope_log.get("scope", {})
+            scope = {
+                "name": scope_data.get("name"),
+                "version": scope_data.get("version"),
+                "attributes": _attributes(scope_data.get("attributes", [])),
+            }
+            for record in scope_log.get("logRecords", []):
+                events.append(
+                    {
+                        "received_at": received_at,
+                        "time_unix_nano": record.get("timeUnixNano"),
+                        "observed_time_unix_nano": record.get("observedTimeUnixNano"),
+                        "severity_number": record.get("severityNumber"),
+                        "severity_text": record.get("severityText"),
+                        "body": _any_value(record.get("body")),
+                        "attributes": _attributes(record.get("attributes", [])),
+                        "resource": resource,
+                        "scope": scope,
+                        "trace_id": record.get("traceId"),
+                        "span_id": record.get("spanId"),
+                        "flags": record.get("flags"),
+                    }
+                )
+    return events
+
+
+def _flatten_otlp_metrics(payload: dict[str, Any], received_at: str) -> list[dict[str, Any]]:
+    points: list[dict[str, Any]] = []
+    for resource_metric in payload.get("resourceMetrics", []):
+        resource = _attributes(
+            resource_metric.get("resource", {}).get("attributes", [])
+        )
+        for scope_metric in resource_metric.get("scopeMetrics", []):
+            scope_name = scope_metric.get("scope", {}).get("name")
+            for metric in scope_metric.get("metrics", []):
+                name = metric.get("name")
+                unit = metric.get("unit")
+                for kind in ("sum", "gauge", "histogram"):
+                    container = metric.get(kind)
+                    if not isinstance(container, dict):
+                        continue
+                    for data_point in container.get("dataPoints", []):
+                        points.append(
+                            {
+                                "received_at": received_at,
+                                "metric": name,
+                                "kind": kind,
+                                "unit": unit,
+                                "value": _data_point_value(data_point),
+                                "attributes": _attributes(
+                                    data_point.get("attributes", [])
+                                ),
+                                "time_unix_nano": data_point.get("timeUnixNano"),
+                                "start_time_unix_nano": data_point.get(
+                                    "startTimeUnixNano"
+                                ),
+                                "scope": scope_name,
+                                "resource": resource,
+                            }
+                        )
+    return points
+
+
+def _data_point_value(data_point: dict[str, Any]) -> Any:
+    if "asInt" in data_point:
+        try:
+            return int(data_point["asInt"])
+        except (TypeError, ValueError):
+            return data_point["asInt"]
+    if "asDouble" in data_point:
+        return data_point["asDouble"]
+    # Histogram data points carry sum/count rather than a scalar value.
+    if "sum" in data_point or "count" in data_point:
+        return {"sum": data_point.get("sum"), "count": data_point.get("count")}
+    return None
+
+
+def _attributes(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {item.get("key", ""): _any_value(item.get("value")) for item in items if item.get("key")}
+
+
+def _any_value(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "boolValue" in value:
+        return value["boolValue"]
+    if "intValue" in value:
+        try:
+            return int(value["intValue"])
+        except (TypeError, ValueError):
+            return value["intValue"]
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    if "bytesValue" in value:
+        return value["bytesValue"]
+    if "arrayValue" in value:
+        return [_any_value(item) for item in value["arrayValue"].get("values", [])]
+    if "kvlistValue" in value:
+        return _attributes(value["kvlistValue"].get("values", []))
+    return value
+
+
+def _event_sort_key(event: dict[str, Any]) -> tuple[int, int, str]:
+    """Order events by Claude Code's monotonic ``event.sequence`` then time."""
+    attributes = event.get("attributes", {})
+    sequence = attributes.get("event.sequence")
+    has_sequence = 0 if isinstance(sequence, int) else 1
+    return (
+        has_sequence,
+        sequence if isinstance(sequence, int) else 0,
+        attributes.get("event.timestamp")
+        or event.get("time_unix_nano")
+        or event.get("observed_time_unix_nano")
+        or "",
+    )
+
+
+def _summarize_api_calls(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    for event in events:
+        attributes = event.get("attributes", {})
+        if attributes.get("event.name") != "api_request":
+            continue
+        completed_at = attributes.get("event.timestamp")
+        duration_ms = _int_or_none(attributes.get("duration_ms"))
+        started_at = None
+        parsed = _parse_timestamp(completed_at)
+        if parsed is not None and duration_ms is not None:
+            started_at = parsed.timestamp() * 1000 - duration_ms
+        calls.append(
+            {
+                "sequence": len(calls) + 1,
+                "started_at": _format_epoch_ms(started_at),
+                "completed_at": completed_at,
+                "duration_ms": duration_ms,
+                "model": attributes.get("model"),
+                "request_id": attributes.get("request_id"),
+                "query_source": attributes.get("query_source"),
+                "input_tokens": _int_or_none(attributes.get("input_tokens")),
+                "output_tokens": _int_or_none(attributes.get("output_tokens")),
+                "cache_read_tokens": _int_or_none(attributes.get("cache_read_tokens")),
+                "cache_creation_tokens": _int_or_none(
+                    attributes.get("cache_creation_tokens")
+                ),
+                "cost_usd": attributes.get("cost_usd"),
+                "effort": attributes.get("effort"),
+                "prompt_id": attributes.get("prompt.id"),
+                "event": event,
+            }
+        )
+    return calls
+
+
+def _summarize_api_errors(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    errors: list[dict[str, Any]] = []
+    for event in events:
+        attributes = event.get("attributes", {})
+        if attributes.get("event.name") != "api_error":
+            continue
+        errors.append(
+            {
+                "sequence": len(errors) + 1,
+                "timestamp": attributes.get("event.timestamp"),
+                "model": attributes.get("model"),
+                "error": attributes.get("error") or attributes.get("error_type"),
+                "status_code": attributes.get("status_code"),
+                "attempt": _int_or_none(attributes.get("attempt")),
+                "duration_ms": _int_or_none(attributes.get("duration_ms")),
+                "request_id": attributes.get("request_id"),
+                "event": event,
+            }
+        )
+    return errors
+
+
+def _summarize_tools(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for event in events:
+        attributes = event.get("attributes", {})
+        if attributes.get("event.name") != "tool_result":
+            continue
+        completed_at = attributes.get("event.timestamp")
+        duration_ms = _int_or_none(attributes.get("duration_ms"))
+        started_at = None
+        parsed = _parse_timestamp(completed_at)
+        if parsed is not None and duration_ms is not None:
+            started_at = parsed.timestamp() * 1000 - duration_ms
+        tools.append(
+            {
+                "sequence": len(tools) + 1,
+                "tool_name": attributes.get("tool_name"),
+                "tool_use_id": attributes.get("tool_use_id"),
+                "started_at": _format_epoch_ms(started_at),
+                "completed_at": completed_at,
+                "duration_ms": duration_ms,
+                "success": attributes.get("success"),
+                "error_type": attributes.get("error_type"),
+                # Tool arguments (present with OTEL_LOG_TOOL_DETAILS=1). The CLI
+                # emits them under `tool_input`; `tool_parameters` is accepted as a
+                # fallback for other/older builds.
+                "tool_input": attributes.get("tool_input")
+                or attributes.get("tool_parameters"),
+                "tool_input_size_bytes": _int_or_none(
+                    attributes.get("tool_input_size_bytes")
+                ),
+                "tool_result_size_bytes": _int_or_none(
+                    attributes.get("tool_result_size_bytes")
+                ),
+                "event": event,
+            }
+        )
+    return tools
+
+
+def _summarize_tool_decisions(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    decisions: list[dict[str, Any]] = []
+    for event in events:
+        attributes = event.get("attributes", {})
+        if attributes.get("event.name") != "tool_decision":
+            continue
+        decisions.append(
+            {
+                "sequence": len(decisions) + 1,
+                "timestamp": attributes.get("event.timestamp"),
+                "tool_name": attributes.get("tool_name"),
+                "decision": attributes.get("decision"),
+                "source": attributes.get("source"),
+                "tool_use_id": attributes.get("tool_use_id"),
+            }
+        )
+    return decisions
+
+
+def _summarize_prompts(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    prompts: list[dict[str, Any]] = []
+    for event in events:
+        attributes = event.get("attributes", {})
+        if attributes.get("event.name") != "user_prompt":
+            continue
+        prompts.append(
+            {
+                "sequence": len(prompts) + 1,
+                "timestamp": attributes.get("event.timestamp"),
+                "prompt_id": attributes.get("prompt.id"),
+                "prompt_length": _int_or_none(attributes.get("prompt_length")),
+                "command_name": attributes.get("command_name"),
+                "prompt": attributes.get("prompt"),
+            }
+        )
+    return prompts
+
+
+def _summarize_metrics(metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    """Reduce metric data points to the latest cumulative value per series.
+
+    Claude Code metrics are monotonic cumulative sums, re-sent every export
+    interval, so the final value for each (metric, attribute) series is the
+    run total. Keyed on the sorted attribute tuple.
+    """
+    latest: dict[tuple[str, tuple[tuple[str, Any], ...]], Any] = {}
+    order: list[tuple[str, tuple[tuple[str, Any], ...]]] = []
+    for point in metrics:
+        name = point.get("metric")
+        if not name:
+            continue
+        attr_key = tuple(sorted(point.get("attributes", {}).items()))
+        key = (name, attr_key)
+        if key not in latest:
+            order.append(key)
+        latest[key] = point.get("value")
+
+    tokens_by_type: dict[str, int] = defaultdict(int)
+    cost_total = 0.0
+    series: list[dict[str, Any]] = []
+    for name, attr_key in order:
+        value = latest[(name, attr_key)]
+        attributes = dict(attr_key)
+        series.append({"metric": name, "attributes": attributes, "value": value})
+        if name == "claude_code.token.usage" and isinstance(value, (int, float)):
+            tokens_by_type[str(attributes.get("type", "unknown"))] += int(value)
+        elif name == "claude_code.cost.usage" and isinstance(value, (int, float)):
+            cost_total += float(value)
+
+    return {
+        "series": series,
+        "tokens_by_type": dict(tokens_by_type),
+        "total_cost_usd": round(cost_total, 6) if cost_total else cost_total,
+    }
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_epoch_ms(value: float | None) -> str | None:
+    if value is None:
+        return None
+    return (
+        datetime.fromtimestamp(value / 1000, timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/configs/agents/claude_code.yaml
+++ b/configs/agents/claude_code.yaml
@@ -37,6 +37,13 @@ config:
   # Bypass all tool-permission prompts (required for headless runs).
   dangerously_skip_permissions: true
 
+  # Capture Claude Code's built-in OpenTelemetry stream: the deployer starts a
+  # run-local OTLP/HTTP receiver and stores raw OTLP batches, flattened per-event
+  # logs (API request timing/tokens/cost/request-id, tool arguments + duration,
+  # prompts), cumulative metrics, and a summary in the run dir. No upstream CLI
+  # changes. false = run with telemetry off.
+  otel_enabled: true
+
   # ── Reasoning depth: TWO knobs, which one is live depends on the model ──
   # (verified by capturing the CLI's actual request body, 2.1.170)
 

--- a/tests/ale_run/test_claude_code_telemetry.py
+++ b/tests/ale_run/test_claude_code_telemetry.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import socket
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
+from ale_run.agents.claude_code.deployer import ClaudeCodeDeployer
+from ale_run.agents.claude_code.telemetry import (
+    ClaudeCodeOtelCollector,
+    recover_telemetry_artifacts,
+)
+
+
+def _record(name: str, timestamp: str, sequence: int, **attributes: object) -> dict:
+    """Build a Claude Code OTLP logRecord (body = prefixed name, attrs = short)."""
+    items = [
+        {"key": "event.name", "value": {"stringValue": name}},
+        {"key": "event.timestamp", "value": {"stringValue": timestamp}},
+        {"key": "event.sequence", "value": {"intValue": sequence}},
+    ]
+    for key, value in attributes.items():
+        if isinstance(value, bool):
+            encoded = {"boolValue": value}
+        elif isinstance(value, int):
+            encoded = {"intValue": value}
+        elif isinstance(value, float):
+            encoded = {"doubleValue": value}
+        else:
+            encoded = {"stringValue": str(value)}
+        items.append({"key": key, "value": encoded})
+    return {
+        "timeUnixNano": "1783556555442000000",
+        "observedTimeUnixNano": "1783556555442000000",
+        "body": {"stringValue": f"claude_code.{name}"},
+        "attributes": items,
+    }
+
+
+def _logs_payload(*records: dict) -> dict:
+    return {
+        "resourceLogs": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "claude-code"}}
+                    ]
+                },
+                "scopeLogs": [
+                    {
+                        "scope": {"name": "com.anthropic.claude_code.events"},
+                        "logRecords": list(records),
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _metrics_payload() -> dict:
+    def _sum(name: str, points: list[tuple[float, dict]]) -> dict:
+        return {
+            "name": name,
+            "sum": {
+                "dataPoints": [
+                    {
+                        "asDouble": value,
+                        "attributes": [
+                            {"key": k, "value": {"stringValue": v}}
+                            for k, v in attrs.items()
+                        ],
+                    }
+                    for value, attrs in points
+                ]
+            },
+        }
+
+    return {
+        "resourceMetrics": [
+            {
+                "scopeMetrics": [
+                    {
+                        "scope": {"name": "com.anthropic.claude_code"},
+                        "metrics": [
+                            _sum(
+                                "claude_code.token.usage",
+                                [
+                                    (525.0, {"type": "input", "model": "m"}),
+                                    (10.0, {"type": "output", "model": "m"}),
+                                ],
+                            ),
+                            _sum(
+                                "claude_code.cost.usage",
+                                [(0.0125, {"model": "m"})],
+                            ),
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def _post_json(url: str, payload: dict) -> None:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        assert response.status == 200
+
+
+def _post_chunked(url: str, payload: dict) -> None:
+    """POST with Transfer-Encoding: chunked and no Content-Length.
+
+    This is exactly how Claude Code's OpenTelemetry JS exporter frames requests;
+    a Content-Length-only reader captures zero bytes.
+    """
+    parsed = urlparse(url)
+    body = json.dumps(payload).encode()
+    frame = b"%x\r\n%s\r\n0\r\n\r\n" % (len(body), body)
+    request = (
+        f"POST {parsed.path} HTTP/1.1\r\n"
+        f"Host: {parsed.hostname}:{parsed.port}\r\n"
+        "Content-Type: application/json\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "Connection: close\r\n\r\n"
+    ).encode() + frame
+    with socket.create_connection((parsed.hostname, parsed.port), timeout=5) as sock:
+        sock.sendall(request)
+        response = b""
+        while True:
+            data = sock.recv(4096)
+            if not data:
+                break
+            response += data
+    assert b"200" in response.split(b"\r\n", 1)[0]
+
+
+def test_collector_persists_and_summarizes_logs_and_metrics(tmp_path: Path) -> None:
+    collector = ClaudeCodeOtelCollector(tmp_path)
+    collector.start()
+    logs = _logs_payload(
+        _record("user_prompt", "2026-07-02T10:00:00.000Z", 0,
+                prompt_length=37, prompt="do the thing", **{"prompt.id": "p1"}),
+        _record("api_request", "2026-07-02T10:00:02.000Z", 1,
+                model="claude-sonnet-4-6", duration_ms=1415,
+                input_tokens=3, output_tokens=5, cache_read_tokens=16885,
+                cost_usd=0.0364, request_id="req_abc", query_source="sdk"),
+        _record("tool_result", "2026-07-02T10:00:03.000Z", 2,
+                tool_name="Bash", tool_use_id="toolu_1", duration_ms=250,
+                success=True, tool_input='{"command":"echo hi"}'),
+        _record("tool_decision", "2026-07-02T10:00:03.100Z", 3,
+                tool_name="Bash", decision="accept", source="config"),
+    )
+    _post_json(collector.endpoint + "/v1/logs", logs)
+    _post_json(collector.endpoint + "/v1/metrics", _metrics_payload())
+    collector.stop()
+
+    raw_records = [
+        json.loads(line) for line in collector.raw_path.read_text().splitlines()
+    ]
+    assert raw_records[0]["record_type"] == "otlp_request_chunk"
+    assert {r["signal"] for r in raw_records} == {"logs", "metrics"}
+
+    events = [json.loads(line) for line in collector.events_path.read_text().splitlines()]
+    assert len(events) == 4
+
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["event_count"] == 4
+    assert summary["events_by_name"] == {
+        "api_request": 1, "tool_decision": 1, "tool_result": 1, "user_prompt": 1,
+    }
+
+    call = summary["api_calls"][0]
+    assert call["model"] == "claude-sonnet-4-6"
+    assert call["duration_ms"] == 1415
+    assert call["request_id"] == "req_abc"
+    assert call["query_source"] == "sdk"
+    assert call["input_tokens"] == 3
+
+    assert summary["tool_executions"][0]["tool_name"] == "Bash"
+    assert summary["tool_executions"][0]["duration_ms"] == 250
+    assert summary["tool_executions"][0]["tool_input"] == '{"command":"echo hi"}'
+    assert summary["tool_decisions"][0]["decision"] == "accept"
+    assert summary["user_prompts"][0]["prompt"] == "do the thing"
+
+    assert summary["metric_totals"]["tokens_by_type"] == {"input": 525, "output": 10}
+    assert summary["metric_totals"]["total_cost_usd"] == 0.0125
+
+
+def test_collector_reads_chunked_transfer_encoding(tmp_path: Path) -> None:
+    # Claude Code's exporter sends chunked bodies with no Content-Length; the
+    # receiver must de-chunk or it captures nothing.
+    collector = ClaudeCodeOtelCollector(tmp_path)
+    collector.start()
+    payload = _logs_payload(
+        _record("api_request", "2026-07-02T10:00:02.000Z", 0,
+                model="m", duration_ms=100, request_id="req_chunk")
+    )
+    _post_chunked(collector.endpoint + "/v1/logs", payload)
+    collector.stop()
+
+    events = [json.loads(line) for line in collector.events_path.read_text().splitlines()]
+    assert len(events) == 1
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["api_calls"][0]["request_id"] == "req_chunk"
+
+
+def test_large_raw_request_is_chunked_and_recovers_derived_files(tmp_path: Path) -> None:
+    large_output = "x" * (2 * 1024 * 1024)
+    payload = _logs_payload(
+        _record("tool_result", "2026-07-02T10:00:03.000Z", 0,
+                tool_name="Bash", tool_use_id="toolu_large", duration_ms=250,
+                success=True, tool_input=large_output)
+    )
+    collector = ClaudeCodeOtelCollector(tmp_path)
+    collector.start()
+    _post_json(collector.endpoint + "/v1/logs", payload)
+    collector.stop()
+
+    raw_lines = collector.raw_path.read_bytes().splitlines()
+    assert len(raw_lines) > 1
+    assert max(map(len, raw_lines)) < 1024 * 1024
+
+    collector.events_path.unlink()
+    collector.summary_path.unlink()
+    assert recover_telemetry_artifacts(tmp_path) == 1
+
+    recovered = json.loads(collector.events_path.read_text().strip())
+    assert recovered["attributes"]["tool_input"] == large_output
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["event_count"] == 1
+    assert summary["tool_executions"][0]["tool_input"] == large_output
+
+
+def test_claude_code_incrementally_mirrors_raw_telemetry_wal() -> None:
+    assert "otel_requests.jsonl" in ClaudeCodeDeployer.hot_artifacts
+    assert "telemetry.jsonl" not in ClaudeCodeDeployer.hot_artifacts
+
+
+def test_recovery_ignores_incomplete_trailing_request(tmp_path: Path) -> None:
+    collector = ClaudeCodeOtelCollector(tmp_path)
+    complete = _logs_payload(
+        _record("api_request", "2026-07-02T10:00:00.000Z", 0,
+                model="m", duration_ms=123, request_id="req_ok")
+    )
+    collector._store_request("logs", {}, json.dumps(complete).encode())
+    collector._store_request("logs", {}, b'{"resourceLogs":"' + b"x" * (2 * 1024 * 1024))
+
+    raw_lines = collector.raw_path.read_text().splitlines()
+    collector.raw_path.write_text("\n".join(raw_lines[:-1]) + "\n")
+
+    assert recover_telemetry_artifacts(tmp_path) == 1
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["event_count"] == 1
+    assert summary["events_by_name"] == {"api_request": 1}
+
+
+def test_events_sorted_by_sequence(tmp_path: Path) -> None:
+    # Batches can arrive out of order; the derived event log is sorted by the
+    # CLI's monotonic event.sequence.
+    collector = ClaudeCodeOtelCollector(tmp_path)
+    later = _logs_payload(
+        _record("api_request", "2026-07-02T10:00:05.000Z", 5, model="m")
+    )
+    earlier = _logs_payload(
+        _record("user_prompt", "2026-07-02T10:00:00.000Z", 0, prompt_length=1)
+    )
+    collector._store_request("logs", {}, json.dumps(later).encode())
+    collector._store_request("logs", {}, json.dumps(earlier).encode())
+
+    # Finalization rebuilds telemetry.jsonl from the raw WAL, sorted by sequence.
+    assert recover_telemetry_artifacts(tmp_path) == 2
+    events = [json.loads(line) for line in collector.events_path.read_text().splitlines()]
+    assert [e["attributes"]["event.sequence"] for e in events] == [0, 5]


### PR DESCRIPTION
## Context

Claude Code transcripts (`transcript.jsonl`) describe the agent's actions but omit the operational detail needed to analyze model and tool latency, per-call cost, and API reliability. Claude Code already emits structured OpenTelemetry logs and metrics when telemetry is enabled, but ALE did not turn them on or persist them. This mirrors the Codex run-telemetry work from #33, adapted to Claude Code's OTel schema and transport.

## Changes

- Enable Claude Code's built-in OpenTelemetry exporter through a run-local OTLP/HTTP receiver; **no Claude Code upstream source changes are required**.
- Add `ClaudeCodeOtelCollector` (`ale_run/agents/claude_code/telemetry.py`): a per-run OTLP/HTTP receiver on `127.0.0.1` accepting both `/v1/logs` and `/v1/metrics`. It **de-chunks the request body** — Claude Code's OpenTelemetry JS exporter streams with `Transfer-Encoding: chunked` and no `Content-Length`, so a `Content-Length`-only reader (as used for Codex) would capture nothing.
- Persist four files per run — a raw OTLP write-ahead log plus flattened per-event logs, metric data points, and a summary. See **Artifacts & captured fields** below for the exact per-file schema and the attributes captured for each event type (API-call latency/tokens/cost/`request_id`, tool duration/args, decisions, prompts, ...).
- Point the CLI at the receiver via `OTEL_*` env vars (`http/json`, short export intervals for near-real-time capture, prompt + tool-detail logging enabled).
- Add `otel_requests.jsonl` to `hot_artifacts` so the raw WAL is mirrored incrementally off the sandbox during long tasks, not only at the final directory gather.
- Rebuild the derived files from the raw WAL during finalization (`recover_telemetry_artifacts`); an incomplete final batch is ignored without invalidating earlier complete telemetry.
- Add `otel_enabled` (default `true`) to the public Claude Code configuration and preset.

## Artifacts & captured fields

Written per run under `<run_dir>/origin_log/claude-code/`.

### `otel_requests.jsonl` — raw OTLP write-ahead log
One JSON record per chunk of every OTLP batch received (a large batch spans several `chunk_index`/`chunk_count` records). Fields: `record_type`, `signal` (`logs`|`metrics`), `request_id`, `received_at`, `chunk_index`, `chunk_count`, base64 `payload`; the first chunk also carries `headers`, `payload_bytes`, and `payload_sha256`. This is the source of truth — the three files below are rebuilt from it.

### `telemetry.jsonl` — flattened per-event logs
One object per OTLP log record, ordered by Claude Code's monotonic `event.sequence`. Each object has `time_unix_nano`, `observed_time_unix_nano`, `body`, `attributes`, `resource`, `scope`, `trace_id`/`span_id`, `received_at`. The `attributes` map is where the detail lives, by `event.name`:

| `event.name` | Key attributes captured |
| --- | --- |
| `api_request` | `model`, `duration_ms`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `cost_usd`, **`request_id`** (upstream Anthropic ID), `query_source` (`sdk` main vs. auxiliary e.g. `generate_session_title`), `effort`, `prompt.id` |
| `api_error` | `model`, `error`/`error_type`, `status_code`, `attempt`, `duration_ms`, `request_id` |
| `tool_result` | `tool_name`, `tool_use_id`, `duration_ms`, `success`, `error_type`, `tool_input` (full args), `tool_input_size_bytes`, `tool_result_size_bytes` |
| `tool_decision` | `tool_name`, `decision` (accept/reject), `source` (config/hook/user/…), `tool_use_id` |
| `user_prompt` | `prompt` (full text), `prompt_length`, `command_name`, `prompt.id` |
| `mcp_server_connection` | `mcp_server_name`, `status`, `error_type` |

All records also carry the session/identity attributes the CLI emits (`session.id`, `user.id`, ...).

### `telemetry_metrics.jsonl` — flattened metric data points
One object per metric data point: `metric` name, `kind` (sum/gauge/histogram), `unit`, `value`, `attributes`, `time_unix_nano`. Covers `claude_code.token.usage` (by `type`/`model`), `claude_code.cost.usage`, `claude_code.session.count`, `claude_code.active_time.total`, etc.

### `telemetry_summary.json` — human-readable rollup
- `event_count`, `events_by_name`
- `api_calls[]` — per call: `sequence`, `started_at`/`completed_at`, `duration_ms`, `model`, `request_id`, `query_source`, token counts, `cost_usd`, `effort`
- `api_errors[]` — per error: `model`, `error`, `status_code`, `attempt`, `duration_ms`, `request_id`
- `tool_executions[]` — per tool: `tool_name`, `started_at`/`completed_at`, `duration_ms`, `success`, `tool_input`, size fields
- `tool_decisions[]`, `user_prompts[]`
- `metric_totals` — `tokens_by_type`, `total_cost_usd`, and the full metric `series`

The trajectory's `extra.claude_code` also records `telemetry_path`, `telemetry_metrics_path`, and `telemetry_summary_path`.

## Scope

- No Claude Code upstream source modifications.
- No shared trajectory field renames.
- No private agent presets, experiment configs, task lists, result data, or credentials.

## Validation

### Automated
- New `tests/ale_run/test_claude_code_telemetry.py` (6 tests): collector persistence + summary over logs and metrics, **chunked transfer-encoding decode**, large-payload chunking + WAL recovery, incremental hot-artifact wiring, truncated-final-batch recovery, and sequence ordering.
- Full `ale_run` test suite passes (64 tests). Ruff clean on the changed files.

### Wire-format capture
Captured the live OTLP payloads Claude Code 2.1.205 emits (Sonnet 4.6, direct Anthropic) and built the flattener against real data — confirming the exporter uses chunked encoding and that `api_request` events carry `model`, token counts, `cost_usd`, `duration_ms`, `request_id`, and `query_source` (main `sdk` vs. auxiliary calls such as session-title generation).

### End-to-end smoke
Ran on fresh Google Cloud sandboxes using direct Anthropic / Sonnet 4.6 / the Claude Code harness. Telemetry was captured in-sandbox and gathered to the host on **both Linux and Windows**:

- `demo/seecheck` (Linux, score `1.0`): 14 events → 5 API calls, 3 tool executions, 3 tool decisions, 1 prompt; cumulative metric totals present.
- `demo/hello` (Linux, a 67-tool GUI run): 205 events → 68 API calls, 67 tool executions, 67 tool decisions.
- `demo/hello_win` (**Windows** `ale-win10`, score `1.0`): 88 events → 29 API calls, 28 tool executions, 28 tool decisions; the run-local collector and chunked-body decode work identically on Windows (captured e.g. tool input `{"file_path":"E:\\agenthle\\demo\\hello_win\\base\\input\\order.json"}`).

Across all runs each API call captured its model, latency (`duration_ms`), token counts, `cost_usd`, upstream Anthropic `request_id`, and `query_source`; each tool execution captured `tool_name`, `duration_ms`, `success`, and `tool_input`. The raw `otel_requests.jsonl` WAL is on `hot_artifacts`, so it is mirrored incrementally during the run; for every run, rebuilding the derived files from only the WAL reproduced the summary identically.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
