### PR TITLE
feat(tasks): add engineering/humanoid_loco_manipulation 

### DIFF
--- a/tasks/engineering/humanoid_loco_manipulation/main.py
+++ b/tasks/engineering/humanoid_loco_manipulation/main.py
@@ -1,0 +1,208 @@
+"""humanoid_loco_manipulation — synthesize a G1 whole-body trajectory."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import cua_bench as cb
+
+if __name__ not in sys.modules:
+    sys.modules[__name__] = sys.modules.get(__name__, type(sys)(__name__))
+
+from tasks.common_setup import BaseTaskSetup
+from tasks.linux_runtime import LinuxTaskConfig
+from tasks.engineering.humanoid_loco_manipulation.scripts.score_outputs import (
+    evaluate_submission,
+)
+
+
+_setup = BaseTaskSetup()
+
+logger = logging.getLogger(__name__)
+
+VARIANTS = [("base", "Turn+walk to the thermos, grasp it, carry it back to the start, hold it")]
+GRADER_TIMEOUT = 900
+
+
+@dataclass
+class HumanoidLocoManipulationConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = "engineering"
+    TASK_NAME: str = "humanoid_loco_manipulation"
+    VARIANT_NAME: str = ""
+    VARIANT_LABEL: str = ""
+
+    @property
+    def input_task_brief(self) -> str:
+        return f"{self.input_dir}/task_brief.md"
+
+    @property
+    def input_success(self) -> str:
+        return f"{self.input_dir}/SUCCESS.md"
+
+    @property
+    def input_schema(self) -> str:
+        return f"{self.input_dir}/TRAJECTORY_SCHEMA.md"
+
+    @property
+    def input_assets_dir(self) -> str:
+        return f"{self.input_dir}/assets"
+
+    @property
+    def input_policy_dir(self) -> str:
+        return f"{self.input_dir}/policy"
+
+    @property
+    def output_trajectory(self) -> str:
+        return f"{self.remote_output_dir}/trajectory.npz"
+
+    @property
+    def reference_trajectory(self) -> str:
+        return f"{self.reference_dir}/trajectory.npz"
+
+    @property
+    def reference_grader(self) -> str:
+        return f"{self.reference_dir}/grader/run_grader.py"
+
+    @property
+    def task_description(self) -> str:
+        return f"""\
+You are synthesizing a fetch-and-return whole-body trajectory for a Unitree G1
+humanoid (43 DoF, right-hand Dex3 3-finger gripper) in a fixed MuJoCo scene.
+The robot starts facing AWAY from the target thermos.
+
+## Variant
+`{self.VARIANT_NAME}`: {self.VARIANT_LABEL}
+
+## Input Files
+- Task brief: `{self.input_task_brief}`
+- Success criteria and metrics: `{self.input_success}`
+- Trajectory format and deterministic replay/control contract: `{self.input_schema}`
+- Frozen self-contained simulation: `{self.input_assets_dir}`
+  (scene.mjb, robot_params.json incl. spawn_xy, init_state.npy, amo_init_state.npz)
+- RL locomotion policy the robot is driven by: `{self.input_policy_dir}`
+  (amo_policy.py + TorchScript weights)
+
+## What You Must Do
+1. Read the task brief, the trajectory schema, and the success criteria.
+2. Build your own control loop over `{self.input_assets_dir}/scene.mjb` +
+   `{self.input_policy_dir}`. There is no motion planner, no grasp database, and
+   no inverse-kinematics helper. Command base velocities + heading to the AMO
+   locomotion policy to turn and walk to the thermos; command waist/arm/hand
+   targets to grasp and lift it; then turn around and carry it back to the start
+   position (`spawn_xy` in robot_params.json). Solve navigation, grasp-pose
+   selection, and arm kinematics yourself. Note: `amo_policy_target_yaw` is
+   relative to the robot's initial facing.
+3. Save exactly one file in `{self.remote_output_dir}`: `trajectory.npz`, with
+   the four float32 arrays defined in `{self.input_schema}`.
+
+## Output Requirements
+- `trajectory.npz` must contain `action` [T,43], `amo_policy_command` [T,9],
+  `amo_policy_target_yaw` [T,1], and `amo_policy_turning_flag` [T,1], all finite
+  and the same length T.
+- When replayed under the contract in `{self.input_schema}`, the robot must end
+  upright (pelvis > 0.6 m), within 0.6 m of `spawn_xy`, and still holding the
+  thermos in the right hand (object z > 0.6 m AND within 0.15 m of the Dex3
+  fingertip center). Scoring is binary: all three or 0.
+- Do not write final answers outside `{self.remote_output_dir}`.
+"""
+
+    def to_metadata(self) -> dict:
+        metadata = super().to_metadata()
+        metadata.update(
+            {
+                "variant_label": self.VARIANT_LABEL,
+                "input_task_brief": self.input_task_brief,
+                "input_success": self.input_success,
+                "input_schema": self.input_schema,
+                "input_assets_dir": self.input_assets_dir,
+                "input_policy_dir": self.input_policy_dir,
+                "output_trajectory": self.output_trajectory,
+                "reference_trajectory": self.reference_trajectory,
+                "reference_grader": self.reference_grader,
+            }
+        )
+        return metadata
+
+
+@cb.tasks_config(split="train")
+def load():
+    return [
+        cb.Task(
+            description=HumanoidLocoManipulationConfig(
+                VARIANT_NAME=variant_name,
+                VARIANT_LABEL=variant_label,
+            ).task_description,
+            metadata=HumanoidLocoManipulationConfig(
+                VARIANT_NAME=variant_name,
+                VARIANT_LABEL=variant_label,
+            ).to_metadata(),
+            computer={"provider": "computer", "setup_config": {"os_type": "linux"}},
+        )
+        for variant_name, variant_label in VARIANTS
+    ]
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    await _setup(task_cfg, session)
+
+
+async def _run_grader(task_cfg, session: cb.DesktopSession, remote_results: str) -> bool:
+    """Replay the submitted trajectory on the VM (GPU) and write a results JSON."""
+    meta = task_cfg.metadata
+    cmd = (
+        f'python3 "{meta["reference_grader"]}" '
+        f'--trajectory "{meta["output_trajectory"]}" '
+        f'--assets "{meta["input_assets_dir"]}" '
+        f'--policy "{meta["input_policy_dir"]}" '
+        f'--results "{remote_results}"'
+    )
+    await session.run_command(f'rm -f "{remote_results}"', check=False)
+    await session.run_command(cmd, check=False, timeout=GRADER_TIMEOUT)
+    return await session.file_exists(remote_results)
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    meta = task_cfg.metadata
+    tag = meta["variant_name"]
+
+    for key, label in [
+        ("output_trajectory", "output trajectory.npz"),
+        ("reference_trajectory", "hidden reference trajectory.npz"),
+        ("reference_grader", "hidden grader"),
+    ]:
+        if not (await session.file_exists(meta[key]) or await session.directory_exists(meta[key])):
+            logger.error("[%s] Missing %s at %s", tag, label, meta[key])
+            return [0.0]
+
+    remote_results = f"{meta['remote_output_dir']}/.grader_result.json"
+
+    with tempfile.TemporaryDirectory(prefix="humanoid_loco_eval_") as tmp_dir:
+        tmp = Path(tmp_dir)
+        local_output = tmp / "output"
+        local_output.mkdir()
+        local_results = tmp / "results.json"
+
+        try:
+            (local_output / "trajectory.npz").write_bytes(
+                await session.read_bytes(meta["output_trajectory"])
+            )
+            grader_ran = await _run_grader(task_cfg, session, remote_results)
+            if grader_ran:
+                local_results.write_bytes(await session.read_bytes(remote_results))
+            result = evaluate_submission(
+                local_output,
+                results_path=local_results if grader_ran else None,
+            )
+        except Exception as exc:
+            logger.exception("[%s] Evaluation failed: %s", tag, exc)
+            return [0.0]
+
+    logger.info("[%s] evaluation=%s", tag, json.dumps(result, sort_keys=True))
+    return [float(result.get("score", 0.0))]

--- a/tasks/engineering/humanoid_loco_manipulation/scripts/score_outputs.py
+++ b/tasks/engineering/humanoid_loco_manipulation/scripts/score_outputs.py
@@ -1,0 +1,108 @@
+"""Score humanoid loco-manipulation trajectory submissions.
+
+The performance signal is functional: the hidden grader replays the submitted
+`trajectory.npz` in MuJoCo under the bundled AMO locomotion policy and reports
+whether the target object was lifted. This module adds the structure + schema
+gates and turns the grader's result into a scalar score.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+REQUIRED_ARRAYS = {
+    "action": 43,
+    "amo_policy_command": 9,
+    "amo_policy_target_yaw": None,
+    "amo_policy_turning_flag": None,
+}
+
+
+def _structure_gate(output_dir: Path) -> tuple[bool, str]:
+    files = {p.name for p in output_dir.iterdir() if p.is_file()}
+    if "trajectory.npz" not in files:
+        return False, f"missing trajectory.npz (found {sorted(files)})"
+    return True, "ok"
+
+
+def _schema_gate(npz_path: Path) -> tuple[bool, str]:
+    try:
+        npz = np.load(npz_path)
+    except Exception as exc:
+        return False, f"cannot read npz: {type(exc).__name__}: {exc}"
+    errs = []
+    for key, cols in REQUIRED_ARRAYS.items():
+        if key not in npz.files:
+            errs.append(f"missing array '{key}'")
+            continue
+        arr = npz[key]
+        if arr.ndim != 2:
+            errs.append(f"'{key}' must be 2-D [T,C], got {arr.shape}")
+        elif cols is not None and arr.shape[1] != cols:
+            errs.append(f"'{key}' must have {cols} columns, got {arr.shape[1]}")
+        if not np.isfinite(np.asarray(arr, dtype=np.float64)).all():
+            errs.append(f"'{key}' contains NaN/Inf")
+    if not errs:
+        lengths = {k: len(npz[k]) for k in REQUIRED_ARRAYS}
+        if len(set(lengths.values())) != 1:
+            errs.append(f"arrays must share length T, got {lengths}")
+        elif next(iter(lengths.values())) < 1:
+            errs.append("trajectory is empty")
+    return (not errs), ("ok" if not errs else "; ".join(errs))
+
+
+def evaluate_submission(
+    output_dir: Path,
+    *,
+    results_path: Path | None = None,
+) -> dict[str, Any]:
+    output_dir = Path(output_dir).resolve()
+
+    ok, reason = _structure_gate(output_dir)
+    if not ok:
+        return {"score": 0.0, "reason": "structure_gate_failed", "details": reason}
+
+    ok, reason = _schema_gate(output_dir / "trajectory.npz")
+    if not ok:
+        return {"score": 0.0, "reason": "schema_gate_failed", "details": reason}
+
+    if results_path is None or not Path(results_path).exists():
+        return {
+            "score": 0.0,
+            "reason": "no_grader_results",
+            "details": "submission passed structure/schema gates, but the replay grader produced no results",
+        }
+
+    grader = json.loads(Path(results_path).read_text(encoding="utf-8"))
+    score = float(grader.get("score", 0.0))
+    # A fallen robot is a hard failure regardless of transient lift.
+    if not grader.get("robot_upright", True):
+        score = 0.0
+    return {
+        "score": score,
+        "reason": "graded" if score > 0 else "grader_failed",
+        "grader": grader,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--results-path", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    result = evaluate_submission(args.output_dir, results_path=args.results_path)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/engineering/humanoid_loco_manipulation/task_card.json
+++ b/tasks/engineering/humanoid_loco_manipulation/task_card.json
@@ -1,0 +1,82 @@
+{
+  "taskId": "engineering/humanoid_loco_manipulation",
+  "title": "Humanoid Fetch-and-Return Loco-Manipulation",
+  "summary": "In a given simulation environment, generate an executable robot trajectory that controls a Unitree G1 humanoid to navigate to a target object, pick it up, and carry it back to its starting position. The robot starts facing AWAY from the thermos, so it must turn and walk to it, grasp it with the Dex3 hand, then turn around and carry it back to the start, ending with the object held there. Fully self-contained (mujoco/torch/numpy); no motion planner, grasp database, or IK helper is provided.",
+  "category": "engineering",
+  "software": [
+    "MuJoCo (mujoco==3.3.6)",
+    "PyTorch (torch, CUDA)",
+    "NumPy",
+    "transforms3d"
+  ],
+  "taskPrompt": "You are synthesizing a fetch-and-return whole-body trajectory for a Unitree G1 humanoid (43 DoF, right-hand Dex3 3-finger gripper) in a fixed MuJoCo scene. The robot starts facing AWAY from the target thermos.\n\n## Variant\n`base`: turn+walk to the thermos, grasp it, carry it back to the start, hold it\n\n## Input Files\n- Task brief: `/input/task_brief.md`\n- Success criteria and metrics: `/input/SUCCESS.md`\n- Trajectory format and deterministic replay/control contract: `/input/TRAJECTORY_SCHEMA.md`\n- Frozen self-contained simulation: `/input/assets` (scene.mjb, robot_params.json incl. spawn_xy, init_state.npy, amo_init_state.npz)\n- RL locomotion policy the robot is driven by: `/input/policy` (amo_policy.py + TorchScript weights)\n\n## What You Must Do\n1. Read the task brief, the trajectory schema, and the success criteria.\n2. Build your own control loop over `/input/assets/scene.mjb` + `/input/policy` (there is no planner, no grasp database, and no inverse-kinematics helper). Command base velocities + heading to the AMO locomotion policy to turn and walk to the thermos; command waist/arm/hand targets to grasp and lift it; then turn around and carry it back to the start position (`spawn_xy`). Solve navigation, grasp-pose selection, and arm kinematics yourself. Note: `amo_policy_target_yaw` is relative to the robot's initial facing.\n3. Save exactly one file in `/output`: `trajectory.npz`, containing the four float32 arrays defined in `/input/TRAJECTORY_SCHEMA.md`.\n\n## Output Requirements\n- `trajectory.npz` must contain `action` [T,43], `amo_policy_command` [T,9], `amo_policy_target_yaw` [T,1], and `amo_policy_turning_flag` [T,1], all finite and the same length T.\n- When replayed under the contract in `/input/TRAJECTORY_SCHEMA.md`, the robot must end upright (pelvis > 0.6 m), within 0.6 m of `spawn_xy`, holding the thermos aloft (object z > 0.6 m) AND still grasped in the right hand (within 0.15 m of the Dex3 fingertip center).\n- Do not write final answers outside `/output`.",
+  "agentMustDo": [
+    "Read /input/task_brief.md, /input/TRAJECTORY_SCHEMA.md, and /input/SUCCESS.md.",
+    "Drive the bundled MuJoCo sim + AMO RL locomotion policy from the fixed initial state (robot facing away from the object); turn and walk to the thermos without falling.",
+    "Solve grasping yourself: choose a grasp on the thermos, derive the arm joint angles (your own IK), and close the Dex3 fingers. No grasp poses or IK helper are provided.",
+    "Turn around and carry the object back to within 0.6 m of the start (spawn_xy), keeping it grasped in the right hand and aloft.",
+    "Record the run to /output/trajectory.npz with all four required arrays; verify success in your own loop (upright, returned, object held). No self-test harness is provided."
+  ],
+  "inputFiles": [
+    {
+      "name": "task_brief.md",
+      "format": "md",
+      "path": "input/task_brief.md",
+      "description": "Agent-facing task contract: goal, what is given (self-contained sim + AMO policy) vs what must be solved."
+    },
+    {
+      "name": "SUCCESS.md",
+      "format": "md",
+      "path": "input/SUCCESS.md",
+      "description": "Hard gates, the exact grader command, metrics, and acceptance thresholds."
+    },
+    {
+      "name": "TRAJECTORY_SCHEMA.md",
+      "format": "md",
+      "path": "input/TRAJECTORY_SCHEMA.md",
+      "description": "The four-array trajectory.npz schema and the deterministic replay/control contract, so the file can be produced without a harness."
+    },
+    {
+      "name": "assets/",
+      "format": "directory",
+      "path": "input/assets/",
+      "description": "Frozen self-contained MuJoCo model (scene.mjb, meshes embedded), robot params (PD gains/joint order/target body), and the fixed initial physics + policy state."
+    },
+    {
+      "name": "policy/",
+      "format": "directory",
+      "path": "input/policy/",
+      "description": "The AMO RL locomotion/balance policy (amo_policy.py + TorchScript weights) the robot is driven by. The only control aid provided."
+    }
+  ],
+  "referenceFiles": [
+    {
+      "name": "trajectory.npz",
+      "format": "npz",
+      "path": "reference/trajectory.npz",
+      "description": "Hidden gold-standard fetch-and-return trajectory produced by an actual planner run; replays to a full turn->walk->grasp->lift->carry-back->hold (score 1.0). Scoring is functional (the grader replays the agent's own file)."
+    },
+    {
+      "name": "grader/run_grader.py",
+      "format": "py",
+      "path": "reference/grader/run_grader.py",
+      "description": "Hidden replay/scoring engine. Loads assets/scene.mjb + policy, restores the fixed state, replays the submitted trajectory under the AMO policy, and emits lift/upright metrics."
+    }
+  ],
+  "evaluation": "Functional, reference-free, and self-contained (only mujoco/torch/numpy/transforms3d; no `simple` framework). The evaluator enforces the one-file output structure (`trajectory.npz`) and a schema gate (four arrays, correct shapes, finite), then runs the hidden grader `reference/grader/run_grader.py` on the submission against `input/assets` + `input/policy`. The grader restores the frozen MuJoCo integration state + AMO policy state and replays the trajectory on GPU (deterministic; bit-identical across repeated replays). At the end it checks, ALL required: (1) upright -- robot pelvis height > 0.60 m; (2) returned -- robot base within 0.60 m of spawn_xy; (3) held -- thermos off the ground (z > 0.60 m) AND still grasped in the right hand (within 0.15 m of the Dex3 fingertip center). Score is binary: 1.0 iff all three hold, else 0.0. A malformed npz, a crashed replay, a fallen robot, a dropped/left object, or a non-return all score 0.0. The gold reference replays to score 1.0 (return_dist 0.49, object_z 1.14, hand_obj_dist 0.037); an idle/fallen trajectory scores 0.0.",
+  "vm": {
+    "machineType": "g2-standard-8",
+    "snapshot": "gpu-free",
+    "timeout": 3600
+  },
+  "taxonomy": {
+    "domain_id": "1",
+    "domain_code": "engineering",
+    "subdomain_id": "1.11",
+    "subdomain_code": "robotics",
+    "subdomain_name": "Robotics & Autonomous Systems"
+  },
+  "requiredSystemPackages": [
+    "mujoco-gl-libs"
+  ]
+}

--- a/tasks/engineering/robot_dexterous_grasping/main.py
+++ b/tasks/engineering/robot_dexterous_grasping/main.py
@@ -1,0 +1,209 @@
+"""robot_dexterous_grasping — synthesize G1 upper-body grasp+lift trajectories."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import cua_bench as cb
+
+if __name__ not in sys.modules:
+    sys.modules[__name__] = sys.modules.get(__name__, type(sys)(__name__))
+
+from tasks.common_setup import BaseTaskSetup
+from tasks.linux_runtime import LinuxTaskConfig
+from tasks.engineering.robot_dexterous_grasping.scripts.score_outputs import (
+    evaluate_submission,
+)
+
+
+_setup = BaseTaskSetup()
+
+logger = logging.getLogger(__name__)
+
+VARIANTS = [("base", "Grasp and lift each of the three target objects")]
+GRADER_TIMEOUT = 1800
+
+
+@dataclass
+class RobotDexterousGraspingConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = "engineering"
+    TASK_NAME: str = "robot_dexterous_grasping"
+    VARIANT_NAME: str = ""
+    VARIANT_LABEL: str = ""
+
+    @property
+    def input_task_brief(self) -> str:
+        return f"{self.input_dir}/task_brief.md"
+
+    @property
+    def input_success(self) -> str:
+        return f"{self.input_dir}/SUCCESS.md"
+
+    @property
+    def input_schema(self) -> str:
+        return f"{self.input_dir}/TRAJECTORY_SCHEMA.md"
+
+    @property
+    def input_assets_dir(self) -> str:
+        return f"{self.input_dir}/assets"
+
+    @property
+    def input_objects_json(self) -> str:
+        return f"{self.input_assets_dir}/objects.json"
+
+    @property
+    def input_policy_dir(self) -> str:
+        return f"{self.input_dir}/policy"
+
+    @property
+    def reference_grader(self) -> str:
+        return f"{self.reference_dir}/grader/run_grader.py"
+
+    @property
+    def task_description(self) -> str:
+        return f"""\
+You are synthesizing dexterous grasping trajectories for a Unitree G1 humanoid
+(Dex3 3-finger hands) in fixed MuJoCo scenes.
+
+The robot is ALREADY STANDING at the table in front of each object and its
+LOWER BODY DOES NOT MOVE: you do not control the legs or the base, and the robot
+never walks. A bundled RL balance policy holds it standing in place. You control
+ONLY the 31 upper-body joints: waist (3), left arm (7), right arm (7), left Dex3
+hand (7), right Dex3 hand (7). The right hand is the grasping hand.
+
+## Variant
+`{self.VARIANT_NAME}`: {self.VARIANT_LABEL}
+
+## Input Files
+- Task brief: `{self.input_task_brief}`
+- Success criteria and metrics: `{self.input_success}`
+- Trajectory format and deterministic replay/control contract: `{self.input_schema}`
+- Target object ids: `{self.input_objects_json}`
+- Per-object frozen simulation: `{self.input_assets_dir}/obj_<id>/`
+  (scene.mjb, init_state.npy, amo_init_state.npz, robot_params.json incl.
+  upper_body_joint_names / target_body / init_object_z / stand_command)
+- Bundled RL balance policy (holds the robot standing; you never command it):
+  `{self.input_policy_dir}`
+
+## What You Must Do
+1. Read the task brief, the trajectory schema, and the success criteria.
+2. For EACH object id in `{self.input_objects_json}`, build your own control loop
+   over that object's `scene.mjb` + `{self.input_policy_dir}` and synthesize an
+   upper-body motion that reaches to the object, closes the Dex3 fingers on it,
+   and lifts it. There is no grasp database and no inverse-kinematics helper:
+   grasp-pose selection, arm IK, finger closure and motion timing are yours.
+3. Save one file per object in `{self.remote_output_dir}`:
+   `trajectory_<object_id>.npz`, each containing the float32 array `upper_body`
+   of shape [T, 31] defined in `{self.input_schema}`.
+
+## Output Requirements
+- One `trajectory_<object_id>.npz` per object id, each with `upper_body` [T, 31],
+  finite, T >= 1.
+- On replay under the contract in `{self.input_schema}`, EACH object must end
+  grasped in the right hand (within 0.15 m of the Dex3 fingertip centre), lifted
+  >= 0.08 m above its starting height, robot still upright (pelvis > 0.6 m).
+- Scoring is all-or-nothing: all three objects, or 0.
+- Do not write final answers outside `{self.remote_output_dir}`.
+"""
+
+    def to_metadata(self) -> dict:
+        metadata = super().to_metadata()
+        metadata.update(
+            {
+                "variant_label": self.VARIANT_LABEL,
+                "input_task_brief": self.input_task_brief,
+                "input_success": self.input_success,
+                "input_schema": self.input_schema,
+                "input_assets_dir": self.input_assets_dir,
+                "input_objects_json": self.input_objects_json,
+                "input_policy_dir": self.input_policy_dir,
+                "reference_grader": self.reference_grader,
+            }
+        )
+        return metadata
+
+
+@cb.tasks_config(split="train")
+def load():
+    return [
+        cb.Task(
+            description=RobotDexterousGraspingConfig(
+                VARIANT_NAME=variant_name, VARIANT_LABEL=variant_label,
+            ).task_description,
+            metadata=RobotDexterousGraspingConfig(
+                VARIANT_NAME=variant_name, VARIANT_LABEL=variant_label,
+            ).to_metadata(),
+            computer={"provider": "computer", "setup_config": {"os_type": "linux"}},
+        )
+        for variant_name, variant_label in VARIANTS
+    ]
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    await _setup(task_cfg, session)
+
+
+async def _run_grader(task_cfg, session: cb.DesktopSession, remote_results: str) -> bool:
+    """Replay every submitted trajectory on the VM (GPU) and write a results JSON."""
+    meta = task_cfg.metadata
+    cmd = (
+        f'python3 "{meta["reference_grader"]}" '
+        f'--output "{meta["remote_output_dir"]}" '
+        f'--assets "{meta["input_assets_dir"]}" '
+        f'--policy "{meta["input_policy_dir"]}" '
+        f'--results "{remote_results}"'
+    )
+    await session.run_command(f'rm -f "{remote_results}"', check=False)
+    await session.run_command(cmd, check=False, timeout=GRADER_TIMEOUT)
+    return await session.file_exists(remote_results)
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    meta = task_cfg.metadata
+    tag = meta["variant_name"]
+
+    if not (await session.file_exists(meta["reference_grader"])
+            or await session.directory_exists(meta["reference_grader"])):
+        logger.error("[%s] Missing hidden grader: %s", tag, meta["reference_grader"])
+        return [0.0]
+    if not (await session.file_exists(meta["remote_output_dir"])
+            or await session.directory_exists(meta["remote_output_dir"])):
+        logger.error("[%s] Missing output directory: %s", tag, meta["remote_output_dir"])
+        return [0.0]
+
+    remote_results = f"{meta['remote_output_dir']}/.grader_result.json"
+
+    with tempfile.TemporaryDirectory(prefix="dexterous_grasping_eval_") as tmp_dir:
+        tmp = Path(tmp_dir)
+        local_output = tmp / "output"
+        local_output.mkdir()
+        local_results = tmp / "results.json"
+
+        try:
+            object_ids = json.loads(await session.read_text(meta["input_objects_json"]))["object_ids"]
+            for oid in object_ids:
+                remote_traj = f"{meta['remote_output_dir']}/trajectory_{oid}.npz"
+                if await session.file_exists(remote_traj):
+                    (local_output / f"trajectory_{oid}.npz").write_bytes(
+                        await session.read_bytes(remote_traj))
+            grader_ran = await _run_grader(task_cfg, session, remote_results)
+            if grader_ran:
+                local_results.write_bytes(await session.read_bytes(remote_results))
+            result = evaluate_submission(
+                local_output,
+                object_ids=object_ids,
+                results_path=local_results if grader_ran else None,
+            )
+        except Exception as exc:
+            logger.exception("[%s] Evaluation failed: %s", tag, exc)
+            return [0.0]
+
+    logger.info("[%s] evaluation=%s", tag, json.dumps(result, sort_keys=True))
+    return [float(result.get("score", 0.0))]

--- a/tasks/engineering/robot_dexterous_grasping/scripts/score_outputs.py
+++ b/tasks/engineering/robot_dexterous_grasping/scripts/score_outputs.py
@@ -1,0 +1,110 @@
+"""Score robot dexterous grasping submissions.
+
+The performance signal is functional: the hidden grader replays each submitted
+upper-body trajectory in its object's MuJoCo scene (lower body held standing by
+the bundled balance policy) and reports whether the object was grasped and
+lifted. This module adds the structure + schema gates and turns the grader's
+result into a scalar score. Scoring is all-or-nothing over the target objects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+UPPER_BODY_DIM = 31
+
+
+def _structure_gate(output_dir: Path, object_ids) -> tuple[bool, str]:
+    missing = [oid for oid in object_ids
+               if not (output_dir / f"trajectory_{oid}.npz").exists()]
+    if missing:
+        found = sorted(p.name for p in output_dir.iterdir() if p.is_file())
+        return False, f"missing trajectory files for objects {missing} (found {found})"
+    return True, "ok"
+
+
+def _schema_gate(output_dir: Path, object_ids) -> tuple[bool, str]:
+    errs = []
+    for oid in object_ids:
+        p = output_dir / f"trajectory_{oid}.npz"
+        try:
+            npz = np.load(p)
+        except Exception as exc:
+            errs.append(f"{p.name}: cannot read npz ({type(exc).__name__}: {exc})")
+            continue
+        if "upper_body" not in npz.files:
+            errs.append(f"{p.name}: missing array 'upper_body' (found {list(npz.files)})")
+            continue
+        a = npz["upper_body"]
+        if a.ndim != 2:
+            errs.append(f"{p.name}: 'upper_body' must be 2-D [T,{UPPER_BODY_DIM}], got {a.shape}")
+        elif a.shape[1] != UPPER_BODY_DIM:
+            errs.append(f"{p.name}: 'upper_body' must have {UPPER_BODY_DIM} columns, got {a.shape[1]}")
+        elif len(a) < 1:
+            errs.append(f"{p.name}: trajectory is empty")
+        if not np.isfinite(np.asarray(a, dtype=np.float64)).all():
+            errs.append(f"{p.name}: 'upper_body' contains NaN/Inf")
+    return (not errs), ("ok" if not errs else "; ".join(errs))
+
+
+def evaluate_submission(
+    output_dir: Path,
+    *,
+    object_ids,
+    results_path: Path | None = None,
+) -> dict[str, Any]:
+    output_dir = Path(output_dir).resolve()
+
+    ok, reason = _structure_gate(output_dir, object_ids)
+    if not ok:
+        return {"score": 0.0, "reason": "structure_gate_failed", "details": reason}
+
+    ok, reason = _schema_gate(output_dir, object_ids)
+    if not ok:
+        return {"score": 0.0, "reason": "schema_gate_failed", "details": reason}
+
+    if results_path is None or not Path(results_path).exists():
+        return {
+            "score": 0.0,
+            "reason": "no_grader_results",
+            "details": "submission passed structure/schema gates, but the replay grader produced no results",
+        }
+
+    grader = json.loads(Path(results_path).read_text(encoding="utf-8"))
+    n_ok = int(grader.get("objects_succeeded", 0))
+    n = int(grader.get("objects_total", len(object_ids)))
+    score = 1.0 if (n > 0 and n_ok == n) else 0.0   # all-or-nothing
+    return {
+        "score": score,
+        "reason": "graded" if score > 0 else "grader_failed",
+        "objects_succeeded": n_ok,
+        "objects_total": n,
+        "grader": grader,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--object-ids", required=True,
+                        help="comma-separated object ids, e.g. 102,103,105")
+    parser.add_argument("--results-path", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    ids = [s.strip() for s in args.object_ids.split(",") if s.strip()]
+    result = evaluate_submission(args.output_dir, object_ids=ids,
+                                 results_path=args.results_path)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/engineering/robot_dexterous_grasping/task_card.json
+++ b/tasks/engineering/robot_dexterous_grasping/task_card.json
@@ -1,0 +1,47 @@
+{
+  "taskId": "engineering/robot_dexterous_grasping",
+  "title": "Robot Dexterous Grasping",
+  "summary": "In a given simulation environment, generate executable robot trajectories that make a Unitree G1 humanoid grasp and lift three different objects, one trajectory per object. The robot already stands at the table and its LOWER BODY DOES NOT MOVE: the agent controls only the 31 upper-body joints (waist + both arms + both Dex3 hands) and must synthesize the reach, the grasp and the lift itself. Fully self-contained (mujoco/torch/numpy); no grasp poses, no grasp database, and no IK helper are provided. Scoring is all-or-nothing across the three objects.",
+  "category": "engineering",
+  "software": [
+    "MuJoCo (mujoco==3.3.6)",
+    "PyTorch (torch, CUDA)",
+    "NumPy",
+    "transforms3d"
+  ],
+  "taskPrompt": "You are synthesizing dexterous grasping trajectories for a Unitree G1 humanoid (Dex3 3-finger hands) in fixed MuJoCo scenes. The robot is ALREADY STANDING at the table in front of each object and its LOWER BODY DOES NOT MOVE: you do not control the legs or the base and the robot never walks. A bundled RL balance policy holds it standing. You control ONLY the 31 upper-body joints: waist (3), left arm (7), right arm (7), left Dex3 hand (7), right Dex3 hand (7). The right hand is the grasping hand.\n\n## Variant\n`base`: grasp and lift each of the three target objects\n\n## Input Files\n- Task brief: `/input/task_brief.md`\n- Success criteria and metrics: `/input/SUCCESS.md`\n- Trajectory format and deterministic replay/control contract: `/input/TRAJECTORY_SCHEMA.md`\n- Target object ids: `/input/assets/objects.json`\n- Per-object frozen simulation: `/input/assets/obj_<id>/` (scene.mjb, init_state.npy, amo_init_state.npz, robot_params.json incl. upper_body_joint_names / target_body / init_object_z / stand_command)\n- Bundled RL balance policy (holds the robot standing; you never command it): `/input/policy`\n\n## What You Must Do\n1. Read the task brief, the trajectory schema, and the success criteria.\n2. For EACH object id in `/input/assets/objects.json`, build your own control loop over that object's `scene.mjb` + `/input/policy` and synthesize an upper-body motion that reaches to the object, closes the Dex3 fingers on it, and lifts it. There is no grasp database and no inverse-kinematics helper: grasp-pose selection, arm IK, finger closure and motion timing are all yours to solve.\n3. Save one file per object in `/output`: `trajectory_<object_id>.npz`, each containing the float32 array `upper_body` of shape [T, 31] defined in `/input/TRAJECTORY_SCHEMA.md`.\n\n## Output Requirements\n- One `trajectory_<object_id>.npz` per object id, each with `upper_body` [T, 31], finite, T >= 1.\n- On replay under the contract in `/input/TRAJECTORY_SCHEMA.md`, EACH object must end grasped in the right hand (within 0.15 m of the Dex3 fingertip centre), lifted >= 0.08 m above its starting height, with the robot still upright (pelvis > 0.6 m).\n- Scoring is all-or-nothing: all three objects or 0.\n- Do not write final answers outside `/output`.",
+  "agentMustDo": [
+    "Read /input/task_brief.md, /input/TRAJECTORY_SCHEMA.md, and /input/SUCCESS.md.",
+    "For each object id in /input/assets/objects.json, drive that object's bundled MuJoCo scene from its fixed initial state (robot already standing; lower body held by the bundled balance policy).",
+    "Solve grasping yourself for each object: choose where to place the hand, derive the arm joint angles (your own IK), and close the Dex3 fingers. No grasp poses or IK helper are provided.",
+    "Lift each object >= 0.08 m off the table while keeping it in the hand.",
+    "Save one trajectory_<object_id>.npz per object with the 31-column upper_body array; verify success in your own loop (in-hand, lifted, upright). No self-test harness is provided."
+  ],
+  "inputFiles": [
+    {"name": "task_brief.md", "format": "md", "path": "input/task_brief.md", "description": "Agent-facing task contract: goal, the upper-body-only control model, what is given vs what must be solved."},
+    {"name": "SUCCESS.md", "format": "md", "path": "input/SUCCESS.md", "description": "Hard gates, per-object metrics (in_hand, lifted, upright) and the all-or-nothing scoring rule."},
+    {"name": "TRAJECTORY_SCHEMA.md", "format": "md", "path": "input/TRAJECTORY_SCHEMA.md", "description": "The upper_body [T,31] array layout and the deterministic replay/control contract."},
+    {"name": "assets/", "format": "directory", "path": "input/assets/", "description": "objects.json (target ids) plus per-object obj_<id>/ with scene.mjb, init_state.npy, amo_init_state.npz and robot_params.json."},
+    {"name": "policy/", "format": "directory", "path": "input/policy/", "description": "The bundled RL balance policy that holds the robot standing (amo_policy.py + TorchScript weights). The agent never commands it; it is included so the replay is reproducible."}
+  ],
+  "referenceFiles": [
+    {"name": "trajectory_<id>.npz", "format": "npz", "path": "reference/", "description": "Hidden gold-standard upper-body grasp trajectories, one per object, produced by an expert pipeline driven by HUMAN-ANNOTATED grasp poses (automated grasp synthesis was not good enough, which is why this task is hard). Each replays to a successful grasp+lift."},
+    {"name": "grader/run_grader.py", "format": "py", "path": "reference/grader/run_grader.py", "description": "Hidden replay/scoring engine. Replays each object's trajectory with the lower body held by the balance policy and checks in-hand + lifted + upright."}
+  ],
+  "evaluation": "Functional, reference-free, and self-contained (only mujoco/torch/numpy/transforms3d; no external framework). The evaluator enforces the output structure (one trajectory_<object_id>.npz per target object) and a schema gate (array `upper_body`, 2-D, exactly 31 columns, finite), then runs the hidden grader `reference/grader/run_grader.py`. For each object the grader restores that object's frozen MuJoCo integration state and balance-policy state and replays the submitted upper-body trajectory on GPU (deterministic; bit-identical across repeated replays); the lower body is not agent-controlled -- the bundled policy receives a fixed in-place stand command so the robot never walks. An object is solved iff at the end: in_hand (object within 0.15 m of the Dex3 right-hand fingertip centre) AND lifted (>= 0.08 m above its starting height) AND upright (pelvis > 0.60 m). Task score is binary and all-or-nothing: 1.0 iff every object is solved, else 0.0 (the report includes objects_succeeded/objects_total and a per-object breakdown). A malformed npz, a missing file, a crashed replay, a missed grasp or no lift all score 0.0.",
+  "vm": {
+    "machineType": "g2-standard-8",
+    "snapshot": "gpu-free",
+    "timeout": 3600
+  },
+  "taxonomy": {
+    "domain_id": "1",
+    "domain_code": "engineering",
+    "subdomain_id": "1.11",
+    "subdomain_code": "robotics",
+    "subdomain_name": "Robotics & Autonomous Systems"
+  },
+  "requiredSystemPackages": [
+    "mujoco-gl-libs"
+  ]
+}

--- a/tasks/engineering/robot_room_rearrangement/main.py
+++ b/tasks/engineering/robot_room_rearrangement/main.py
@@ -1,0 +1,204 @@
+"""humanoid_object_stowing — synthesize one continuous G1 whole-body tidy-up trajectory."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import cua_bench as cb
+
+if __name__ not in sys.modules:
+    sys.modules[__name__] = sys.modules.get(__name__, type(sys)(__name__))
+
+from tasks.common_setup import BaseTaskSetup
+from tasks.linux_runtime import LinuxTaskConfig
+from tasks.engineering.humanoid_object_stowing.scripts.score_outputs import (
+    evaluate_submission,
+)
+
+
+_setup = BaseTaskSetup()
+
+logger = logging.getLogger(__name__)
+
+VARIANTS = [("base", "Walk to the table object, pick it up, and drop it into the floor bin")]
+GRADER_TIMEOUT = 3600
+
+
+@dataclass
+class HumanoidObjectStowingConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = "engineering"
+    TASK_NAME: str = "humanoid_object_stowing"
+    VARIANT_NAME: str = ""
+    VARIANT_LABEL: str = ""
+
+    @property
+    def input_task_brief(self) -> str:
+        return f"{self.input_dir}/task_brief.md"
+
+    @property
+    def input_success(self) -> str:
+        return f"{self.input_dir}/SUCCESS.md"
+
+    @property
+    def input_schema(self) -> str:
+        return f"{self.input_dir}/TRAJECTORY_SCHEMA.md"
+
+    @property
+    def input_assets_dir(self) -> str:
+        return f"{self.input_dir}/assets"
+
+    @property
+    def input_policy_dir(self) -> str:
+        return f"{self.input_dir}/policy"
+
+    @property
+    def reference_grader(self) -> str:
+        return f"{self.reference_dir}/grader/run_grader.py"
+
+    @property
+    def task_description(self) -> str:
+        return f"""\
+You are synthesizing a single continuous whole-body trajectory for a Unitree G1
+humanoid (Dex3 3-finger hands) in a fixed MuJoCo bedroom scene.
+
+An object sits on a table and a bin stands on the floor nearby. The robot starts
+standing away from the table and must walk to the object, grasp it, carry it to
+the bin and drop it in, ending with the object inside the bin and the robot still
+standing.
+
+This is a WHOLE-BODY task. You control the legs and the upper body: one
+trajectory drives walking, turning, reaching, grasping and releasing. It is ONE
+continuous episode -- not one trajectory per object. A bundled RL balance policy
+converts your locomotion command stream into leg motion; you must still decide
+where to walk, when to turn, how to reach and how to grasp.
+
+## Variant
+`{self.VARIANT_NAME}`: {self.VARIANT_LABEL}
+
+## Input Files
+- Task brief: `{self.input_task_brief}`
+- Success criteria and metrics: `{self.input_success}`
+- Trajectory format and deterministic replay/control contract: `{self.input_schema}`
+- Frozen simulation: `{self.input_assets_dir}/` (scene.mjb, init_state.npy,
+  amo_init_state.npz, robot_params.json incl. joint order, PD gains, torque
+  limits, the bin's axis-aligned bounds and the target object label)
+- Bundled RL balance policy: `{self.input_policy_dir}`
+
+## What You Must Do
+1. Read the task brief, the trajectory schema, and the success criteria.
+2. Build your own control loop over `scene.mjb` + `{self.input_policy_dir}` and
+   synthesize ONE continuous episode that puts the target object in the bin. There
+   is no motion planner, no grasp database and no inverse-kinematics helper:
+   navigation, grasp-pose selection, arm IK, finger closure and motion timing are
+   all yours to solve.
+3. Save `{self.remote_output_dir}/trajectory.npz` containing the four float32
+   arrays defined in `{self.input_schema}`: `action` [T, 43],
+   `amo_policy_command` [T, 9], `amo_policy_target_yaw` [T, 1] and
+   `amo_policy_turning_flag` [T, 1]. All four must share the same T.
+
+## Output Requirements
+- Exactly one `trajectory.npz` with the four arrays above, finite, T >= 1.
+- On replay under the contract in `{self.input_schema}`, the target object must
+  end inside the bin (within its XY bounds and below the rim) and the robot must
+  still be upright (pelvis > 0.60 m).
+- Scoring is binary: 1.0 or 0.0.
+- Do not write final answers outside `{self.remote_output_dir}`.
+"""
+
+    def to_metadata(self) -> dict:
+        metadata = super().to_metadata()
+        metadata.update(
+            {
+                "variant_label": self.VARIANT_LABEL,
+                "input_task_brief": self.input_task_brief,
+                "input_success": self.input_success,
+                "input_schema": self.input_schema,
+                "input_assets_dir": self.input_assets_dir,
+                "input_policy_dir": self.input_policy_dir,
+                "reference_grader": self.reference_grader,
+            }
+        )
+        return metadata
+
+
+@cb.tasks_config(split="train")
+def load():
+    return [
+        cb.Task(
+            description=HumanoidObjectStowingConfig(
+                VARIANT_NAME=variant_name, VARIANT_LABEL=variant_label,
+            ).task_description,
+            metadata=HumanoidObjectStowingConfig(
+                VARIANT_NAME=variant_name, VARIANT_LABEL=variant_label,
+            ).to_metadata(),
+            computer={"provider": "computer", "setup_config": {"os_type": "linux"}},
+        )
+        for variant_name, variant_label in VARIANTS
+    ]
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    await _setup(task_cfg, session)
+
+
+async def _run_grader(task_cfg, session: cb.DesktopSession, remote_results: str) -> bool:
+    """Replay the submitted trajectory on the VM (GPU) and write a results JSON."""
+    meta = task_cfg.metadata
+    cmd = (
+        f'python3 "{meta["reference_grader"]}" '
+        f'--output "{meta["remote_output_dir"]}" '
+        f'--assets "{meta["input_assets_dir"]}" '
+        f'--policy "{meta["input_policy_dir"]}" '
+        f'--results "{remote_results}"'
+    )
+    await session.run_command(f'rm -f "{remote_results}"', check=False)
+    await session.run_command(cmd, check=False, timeout=GRADER_TIMEOUT)
+    return await session.file_exists(remote_results)
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    meta = task_cfg.metadata
+    tag = meta["variant_name"]
+
+    if not (await session.file_exists(meta["reference_grader"])
+            or await session.directory_exists(meta["reference_grader"])):
+        logger.error("[%s] Missing hidden grader: %s", tag, meta["reference_grader"])
+        return [0.0]
+    if not (await session.file_exists(meta["remote_output_dir"])
+            or await session.directory_exists(meta["remote_output_dir"])):
+        logger.error("[%s] Missing output directory: %s", tag, meta["remote_output_dir"])
+        return [0.0]
+
+    remote_results = f"{meta['remote_output_dir']}/.grader_result.json"
+
+    with tempfile.TemporaryDirectory(prefix="humanoid_object_stowing_eval_") as tmp_dir:
+        tmp = Path(tmp_dir)
+        local_output = tmp / "output"
+        local_output.mkdir()
+        local_results = tmp / "results.json"
+
+        try:
+            remote_traj = f"{meta['remote_output_dir']}/trajectory.npz"
+            if await session.file_exists(remote_traj):
+                (local_output / "trajectory.npz").write_bytes(
+                    await session.read_bytes(remote_traj))
+            grader_ran = await _run_grader(task_cfg, session, remote_results)
+            if grader_ran:
+                local_results.write_bytes(await session.read_bytes(remote_results))
+            result = evaluate_submission(
+                local_output,
+                results_path=local_results if grader_ran else None,
+            )
+        except Exception as exc:
+            logger.exception("[%s] Evaluation failed: %s", tag, exc)
+            return [0.0]
+
+    logger.info("[%s] evaluation=%s", tag, json.dumps(result, sort_keys=True))
+    return [float(result.get("score", 0.0))]

--- a/tasks/engineering/robot_room_rearrangement/scripts/score_outputs.py
+++ b/tasks/engineering/robot_room_rearrangement/scripts/score_outputs.py
@@ -1,0 +1,127 @@
+"""Score humanoid object stowing submissions.
+
+The performance signal is functional: the hidden grader replays the submitted
+whole-body trajectory in the frozen MuJoCo scene and reports where each target
+object ended up. This module adds the structure + schema gates and turns the
+grader's result into a scalar score.
+
+Scoring is binary: the target object must end inside the bin and the robot must
+still be upright.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+TRAJECTORY_NAME = "trajectory.npz"
+
+# (array name, required column count). The robot is driven by the same 4-array
+# whole-body schema used by humanoid_loco_manipulation: joint targets plus the
+# balance-policy command stream.
+REQUIRED_ARRAYS = (
+    ("action", 43),
+    ("amo_policy_command", 9),
+    ("amo_policy_target_yaw", 1),
+    ("amo_policy_turning_flag", 1),
+)
+
+
+def _structure_gate(output_dir: Path) -> tuple[bool, str]:
+    p = output_dir / TRAJECTORY_NAME
+    if not p.exists():
+        found = sorted(q.name for q in output_dir.iterdir() if q.is_file())
+        return False, f"missing {TRAJECTORY_NAME} (found {found})"
+    return True, "ok"
+
+
+def _schema_gate(output_dir: Path) -> tuple[bool, str]:
+    p = output_dir / TRAJECTORY_NAME
+    try:
+        npz = np.load(p)
+    except Exception as exc:
+        return False, f"{p.name}: cannot read npz ({type(exc).__name__}: {exc})"
+
+    errs: list[str] = []
+    lengths: set[int] = set()
+    for name, cols in REQUIRED_ARRAYS:
+        if name not in npz.files:
+            errs.append(f"{p.name}: missing array '{name}' (found {list(npz.files)})")
+            continue
+        a = np.asarray(npz[name])
+        if a.ndim != 2:
+            errs.append(f"{p.name}: '{name}' must be 2-D [T,{cols}], got {a.shape}")
+            continue
+        if a.shape[1] != cols:
+            errs.append(f"{p.name}: '{name}' must have {cols} columns, got {a.shape[1]}")
+            continue
+        if len(a) < 1:
+            errs.append(f"{p.name}: '{name}' is empty")
+            continue
+        if not np.isfinite(np.asarray(a, dtype=np.float64)).all():
+            errs.append(f"{p.name}: '{name}' contains NaN/Inf")
+        lengths.add(len(a))
+
+    # All four streams are consumed step-by-step in lockstep; ragged lengths
+    # would silently truncate the episode during replay.
+    if len(lengths) > 1:
+        errs.append(f"{p.name}: arrays disagree on T: {sorted(lengths)}")
+
+    return (not errs), ("ok" if not errs else "; ".join(errs))
+
+
+def evaluate_submission(
+    output_dir: Path,
+    *,
+    results_path: Path | None = None,
+) -> dict[str, Any]:
+    output_dir = Path(output_dir)
+    if not output_dir.is_dir():
+        return {"score": 0.0, "success": False, "error": "output_dir_missing",
+                "details": str(output_dir)}
+
+    ok, msg = _structure_gate(output_dir)
+    if not ok:
+        return {"score": 0.0, "success": False, "error": "structure_gate", "details": msg}
+
+    ok, msg = _schema_gate(output_dir)
+    if not ok:
+        return {"score": 0.0, "success": False, "error": "schema_gate", "details": msg}
+
+    if results_path is None or not Path(results_path).exists():
+        return {"score": 0.0, "success": False, "error": "grader_did_not_run",
+                "details": "the hidden grader produced no results file"}
+
+    try:
+        report = json.loads(Path(results_path).read_text())
+    except Exception as exc:
+        return {"score": 0.0, "success": False, "error": "grader_result_unreadable",
+                "details": f"{type(exc).__name__}: {exc}"}
+
+    success = bool(report.get("success", False))
+    result = {
+        "score": 1.0 if success else 0.0,
+        "success": success,
+        "in_bin_xy": report.get("in_bin_xy"),
+        "below_rim": report.get("below_rim"),
+        "robot_upright": report.get("robot_upright"),
+        "object_final_pos": report.get("object_final_pos"),
+        "replay_steps": report.get("replay_steps"),
+    }
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--output", required=True, type=Path)
+    ap.add_argument("--results", type=Path, default=None)
+    args = ap.parse_args()
+    print(json.dumps(evaluate_submission(args.output, results_path=args.results), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/engineering/robot_room_rearrangement/task_card.json
+++ b/tasks/engineering/robot_room_rearrangement/task_card.json
@@ -1,0 +1,83 @@
+{
+  "taskId": "engineering/humanoid_object_stowing",
+  "title": "Humanoid Object Stowing",
+  "summary": "In a given simulation environment, generate ONE continuous executable whole-body trajectory that makes a Unitree G1 humanoid walk to an object on a table, grasp it, carry it to a bin standing on the floor, and drop it in. The agent controls both the lower body (walking/turning, via a bundled RL balance policy's command stream) and the upper body (reaching, grasping, releasing). Fully self-contained (mujoco/torch/numpy); no motion planner, no grasp database and no IK helper are provided. Scoring is binary.",
+  "category": "engineering",
+  "software": [
+    "MuJoCo (mujoco==3.3.6)",
+    "PyTorch (torch, CUDA)",
+    "NumPy",
+    "transforms3d"
+  ],
+  "taskPrompt": "You are synthesizing a single continuous whole-body trajectory for a Unitree G1 humanoid (Dex3 3-finger hands) in a fixed MuJoCo bedroom scene.\n\nAn object sits on a table and a bin stands on the floor nearby. The robot starts standing away from the table and must walk to the object, grasp it, carry it to the bin and drop it in, ending with the object inside the bin and the robot still standing.\n\nThis is a WHOLE-BODY task. You control the legs and the upper body: one trajectory drives walking, turning, reaching, grasping and releasing. It is ONE continuous episode -- not one trajectory per object. A bundled RL balance policy converts your locomotion command stream into leg motion; you must still decide where to walk, when to turn, how to reach and how to grasp.\n\n## Variant\n`base`: walk to the table object, pick it up, and drop it into the floor bin\n\n## Input Files\n- Task brief: `/input/task_brief.md`\n- Success criteria and metrics: `/input/SUCCESS.md`\n- Trajectory format and deterministic replay/control contract: `/input/TRAJECTORY_SCHEMA.md`\n- Frozen simulation: `/input/assets/` (scene.mjb, init_state.npy, amo_init_state.npz, robot_params.json incl. joint order, PD gains, torque limits, the bin's axis-aligned bounds `bin_aabb_lo`/`bin_aabb_hi`, and `object_label`)\n- Bundled RL balance policy: `/input/policy`\n\n## What You Must Do\n1. Read the task brief, the trajectory schema, and the success criteria.\n2. Build your own control loop over `scene.mjb` + `/input/policy` and synthesize ONE continuous episode that puts the target object in the bin. There is no motion planner, no grasp database and no inverse-kinematics helper: navigation, grasp-pose selection, arm IK, finger closure and motion timing are all yours to solve.\n3. Save `/output/trajectory.npz` containing the four float32 arrays defined in `/input/TRAJECTORY_SCHEMA.md`: `action` [T, 43], `amo_policy_command` [T, 9], `amo_policy_target_yaw` [T, 1] and `amo_policy_turning_flag` [T, 1]. All four must share the same T.\n\n## Output Requirements\n- Exactly one `trajectory.npz` with the four arrays above, finite, T >= 1.\n- On replay under the contract in `/input/TRAJECTORY_SCHEMA.md`, the target object must end inside the bin (within its XY bounds and below the rim) and the robot must still be upright (pelvis > 0.60 m).\n- Scoring is binary: 1.0 or 0.0.\n- Do not write final answers outside `/output`.",
+  "agentMustDo": [
+    "Read /input/task_brief.md, /input/TRAJECTORY_SCHEMA.md, and /input/SUCCESS.md.",
+    "Drive the bundled MuJoCo scene from its fixed initial state, controlling BOTH the locomotion command stream (legs, via the bundled balance policy) and the 31 upper-body joint targets.",
+    "Navigate to the target object within ONE continuous episode -- the robot must walk and turn, not teleport.",
+    "Solve grasping yourself: choose where to stand, where to place the hand, derive the arm joint angles (your own IK), and close the Dex3 fingers. No grasp poses, motion planner or IK helper are provided.",
+    "Carry the object to the floor bin and release it so it lands inside, then keep the robot upright to the end of the episode.",
+    "Save a single trajectory.npz with the four whole-body arrays; verify success in your own loop. No self-test harness is provided."
+  ],
+  "inputFiles": [
+    {
+      "name": "task_brief.md",
+      "format": "md",
+      "path": "input/task_brief.md",
+      "description": "Agent-facing task contract: goal, the whole-body control model, what is given vs what must be solved."
+    },
+    {
+      "name": "SUCCESS.md",
+      "format": "md",
+      "path": "input/SUCCESS.md",
+      "description": "Hard gates, the in-bin / upright metrics and the binary scoring rule."
+    },
+    {
+      "name": "TRAJECTORY_SCHEMA.md",
+      "format": "md",
+      "path": "input/TRAJECTORY_SCHEMA.md",
+      "description": "The four-array whole-body trajectory layout (action [T,43], amo_policy_command [T,9], amo_policy_target_yaw [T,1], amo_policy_turning_flag [T,1]) and the deterministic replay/control contract."
+    },
+    {
+      "name": "assets/",
+      "format": "directory",
+      "path": "input/assets/",
+      "description": "scene.mjb (meshes embedded), init_state.npy, amo_init_state.npz and robot_params.json (joint order, PD gains, torque limits, bin_aabb_lo/hi, object_label)."
+    },
+    {
+      "name": "policy/",
+      "format": "directory",
+      "path": "input/policy/",
+      "description": "The bundled RL balance policy (amo_policy.py + TorchScript weights) that turns the agent's locomotion command stream into leg motion."
+    }
+  ],
+  "referenceFiles": [
+    {
+      "name": "trajectory.npz",
+      "format": "npz",
+      "path": "reference/",
+      "description": "Hidden gold-standard whole-body trajectory produced by an expert pipeline driven by HUMAN-ANNOTATED grasp poses (automated grasp synthesis was not good enough, which is why this task is hard). Replays to the object inside the bin."
+    },
+    {
+      "name": "grader/run_grader.py",
+      "format": "py",
+      "path": "reference/grader/run_grader.py",
+      "description": "Hidden replay/scoring engine. Replays the submitted whole-body trajectory from the frozen state and checks the object's final position against the bin bounds plus robot uprightness."
+    }
+  ],
+  "evaluation": "Functional, reference-free, and self-contained (only mujoco/torch/numpy/transforms3d; no external framework). The evaluator enforces the output structure (exactly one trajectory.npz) and a schema gate (arrays `action` [T,43], `amo_policy_command` [T,9], `amo_policy_target_yaw` [T,1], `amo_policy_turning_flag` [T,1]; all 2-D, finite, non-empty, sharing the same T), then runs the hidden grader `reference/grader/run_grader.py`. The grader restores the frozen MuJoCo integration state and balance-policy state and replays the submitted trajectory on GPU (deterministic; bit-identical across repeated replays on the same GPU). Score is 1.0 iff at the final step the target object lies within the bin's XY bounds (bin_aabb_lo/hi, 0.02 m pad) AND below the rim (z < 0.28 m) AND the robot is upright (pelvis > 0.60 m), else 0.0. A malformed npz, a missing file, ragged array lengths, a crashed replay, a dropped object or a fallen robot all score 0.0.",
+  "vm": {
+    "machineType": "g2-standard-8",
+    "snapshot": "gpu-free",
+    "timeout": 5400
+  },
+  "taxonomy": {
+    "domain_id": "1",
+    "domain_code": "engineering",
+    "subdomain_id": "1.11",
+    "subdomain_code": "robotics",
+    "subdomain_name": "Robotics & Autonomous Systems"
+  },
+  "requiredSystemPackages": [
+    "mujoco-gl-libs"
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a self-contained MuJoCo + AMO-policy benchmark task
`engineering/humanoid_loco_manipulation` (fetch-and-return).

A Unitree G1 humanoid starts **facing away** from a thermos and must synthesize a
whole-body `trajectory.npz` that (1) turns and walks to the object, (2) grasps it
with the Dex3 hand and lifts it, and (3) turns around and carries it **back to its
starting position**, still held. No motion planner, grasp database, or IK helper
is provided — the agent solves navigation, grasp-pose selection, arm IK, and
finger control itself.

## Scoring (functional, binary, deterministic)
The hidden grader replays the submitted trajectory under the bundled AMO policy
and, at the end, requires ALL of: **upright** (pelvis > 0.60 m), **returned**
(base within 0.60 m of `spawn_xy`), and **held** (thermos z > 0.60 m AND within
0.15 m of the Dex3 right-hand fingertip center). `score = 1.0` iff all three, else
`0.0`. Replay is bit-identical across repeated runs on the same GPU.

## Self-contained
Grader imports no `simple` framework and reads no external data — only
`mujoco==3.3.6 / torch / numpy / transforms3d`. Linux + GPU.

## What's in this PR
Task definition only, matching the existing `humanoid_*` tasks:
- `tasks/engineering/humanoid_loco_manipulation/main.py`
- `tasks/engineering/humanoid_loco_manipulation/task_card.json`
- `tasks/engineering/humanoid_loco_manipulation/scripts/score_outputs.py`

## Data (uploaded via the submission form, not committed)
- **Input Materials**: `input/` — `assets/scene.mjb` (composed MuJoCo model,
  meshes embedded) + `policy/` (AMO policy + TorchScript weights) + task docs.
- **Reference Output**: `reference/` — gold `trajectory.npz` + `grader/run_grader.py`.

## Notes for reviewers
- The reference was generated + verified on an RTX 6000 Ada. Please confirm
  `run_grader.py` still scores 1.0 on the eval VM's GPU (cross-GPU FP is not
  guaranteed bit-identical; tightest margins are return 0.11 m, hand-object 0.11 m).
