### PR TITLE
feat(agents): add Kimi Code CLI harness

### DIFF
--- a/ale_run/agents/kimi_code/__init__.py
+++ b/ale_run/agents/kimi_code/__init__.py
@@ -1,0 +1,6 @@
+"""Kimi Code CLI in-sandbox deployer."""
+
+from .config import KimiCodeConfig
+from .deployer import KimiCodeDeployer
+
+__all__ = ["KimiCodeConfig", "KimiCodeDeployer"]

--- a/ale_run/agents/kimi_code/config.py
+++ b/ale_run/agents/kimi_code/config.py
@@ -13,21 +13,18 @@ class KimiCodeConfig:
     name: ClassVar[str] = "kimi-code"
 
     model: str = "kimi-k3"
-
     api_key: str | None = None
-    """Literal API key. ``None`` reads :attr:`api_key_env` from the executor."""
-
     api_key_env: str = "MOONSHOT_API_KEY"
     base_url: str = "https://api.moonshot.ai/v1"
     provider_type: str = "kimi"
 
-    max_context_size: int = 262144
+    max_context_size: int = 1_048_576
     capabilities: tuple[str, ...] = ("image_in", "thinking")
-    thinking_effort: str | None = "high"
+    thinking_effort: str | None = "max"
     max_completion_tokens: int | None = None
 
     disable_telemetry: bool = True
+    otel_enabled: bool = True
     disable_auto_update: bool = True
 
     cli_version: str = "@moonshot-ai/kimi-code@0.27.0"
-    """Pinned npm package spec installed dynamically when missing or stale."""

--- a/ale_run/agents/kimi_code/config.py
+++ b/ale_run/agents/kimi_code/config.py
@@ -1,0 +1,33 @@
+"""Configuration for the native Kimi Code CLI deployer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass
+class KimiCodeConfig:
+    """Per-episode Kimi Code settings."""
+
+    name: ClassVar[str] = "kimi-code"
+
+    model: str = "kimi-k3"
+
+    api_key: str | None = None
+    """Literal API key. ``None`` reads :attr:`api_key_env` from the executor."""
+
+    api_key_env: str = "MOONSHOT_API_KEY"
+    base_url: str = "https://api.moonshot.ai/v1"
+    provider_type: str = "kimi"
+
+    max_context_size: int = 262144
+    capabilities: tuple[str, ...] = ("image_in", "thinking")
+    thinking_effort: str | None = "high"
+    max_completion_tokens: int | None = None
+
+    disable_telemetry: bool = True
+    disable_auto_update: bool = True
+
+    cli_version: str = "@moonshot-ai/kimi-code@0.27.0"
+    """Pinned npm package spec installed dynamically when missing or stale."""

--- a/ale_run/agents/kimi_code/deployer.py
+++ b/ale_run/agents/kimi_code/deployer.py
@@ -1,0 +1,670 @@
+"""Run the official Kimi Code CLI inside an ALE sandbox."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, ClassVar
+
+from ale_run.base_interface import (
+    AgentRunResult,
+    BaseAgentDeployer,
+    ContentPart,
+    ImageSource,
+    Observation,
+    StepMetrics,
+    ToolCall,
+    ToolResult,
+    TrajectoryBuilder,
+)
+
+from .config import KimiCodeConfig
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_S = 2.0
+_TERM_GRACE_S = 2.0
+_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+_MIN_NODE_VERSION = (22, 19, 0)
+_DATA_URL_RE = re.compile(r"^data:([^;,]+);base64,(.+)$", re.DOTALL)
+
+
+def _expected_version(npm_spec: str | None) -> str | None:
+    if not npm_spec:
+        return None
+    match = _VERSION_RE.search(npm_spec.rsplit("@", 1)[-1])
+    return match.group(1) if match else None
+
+
+def _installed_version(kimi_path: str) -> str | None:
+    try:
+        probe = subprocess.run(
+            [kimi_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = _VERSION_RE.search((probe.stdout or "") + (probe.stderr or ""))
+    return match.group(1) if match else None
+
+
+def _node_version(node_path: str) -> tuple[int, int, int] | None:
+    try:
+        probe = subprocess.run(
+            [node_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = _VERSION_RE.search((probe.stdout or "") + (probe.stderr or ""))
+    if not match:
+        return None
+    major, minor, patch = (int(part) for part in match.group(1).split("."))
+    return major, minor, patch
+
+
+def _find_kimi_shim(prefix: str) -> str | None:
+    for candidate in (
+        os.path.join(prefix, "bin", "kimi"),
+        os.path.join(prefix, "kimi.cmd"),
+        os.path.join(prefix, "bin", "kimi.cmd"),
+    ):
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+class KimiCodeDeployer(BaseAgentDeployer):
+    """Sandbox deployer for ``@moonshot-ai/kimi-code``."""
+
+    default_executor: ClassVar[str] = "sandbox"
+    supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
+    hot_artifacts: ClassVar[tuple[str, ...]] = ("transcript.jsonl", "stderr.log")
+
+    @property
+    def version(self) -> str | None:
+        config: KimiCodeConfig = self.config  # type: ignore[assignment]
+        return config.cli_version
+
+    async def install(self) -> None:
+        config: KimiCodeConfig = self.config  # type: ignore[assignment]
+        sandbox = self.executor.sandbox
+
+        from ale_run.agents._bootstrap import ensure_cua_mcp_server, ensure_node_npm
+
+        node_path, npm_path = await ensure_node_npm()
+        installed_node = await asyncio.to_thread(_node_version, node_path)
+        if installed_node is None or installed_node < _MIN_NODE_VERSION:
+            rendered = ".".join(str(part) for part in installed_node or ())
+            raise RuntimeError(
+                "kimi_code: Kimi Code requires Node.js >=22.19.0, "
+                f"found {rendered or 'an unreadable version'} at {node_path}"
+            )
+
+        kimi_path = shutil.which("kimi")
+        expected = _expected_version(config.cli_version)
+        installed = await asyncio.to_thread(_installed_version, kimi_path) if kimi_path else None
+        if not kimi_path or (expected is not None and installed != expected):
+            home = os.path.expanduser("~")
+            prefix = os.path.join(home, ".local")
+            package = config.cli_version or "@moonshot-ai/kimi-code"
+            logger.info(
+                "kimi_code: installing %s via npm (installed=%s expected=%s)",
+                package,
+                installed or "missing",
+                expected or "unpinned",
+            )
+            env = {
+                **os.environ,
+                "npm_config_cache": os.path.join(home, ".npm-ale"),
+            }
+            process = await asyncio.to_thread(
+                subprocess.run,
+                [
+                    npm_path,
+                    "install",
+                    "-g",
+                    "--force",
+                    "--prefix",
+                    prefix,
+                    package,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=900,
+                env=env,
+            )
+            if process.returncode != 0:
+                raise RuntimeError(
+                    f"npm install -g {package} failed (rc={process.returncode}): "
+                    f"{(process.stderr or process.stdout or '')[-800:]}"
+                )
+            for bin_dir in (prefix, os.path.join(prefix, "bin")):
+                os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
+            kimi_path = _find_kimi_shim(prefix) or shutil.which("kimi")
+            if not kimi_path:
+                raise RuntimeError("kimi_code: 'kimi' not found after dynamic npm installation")
+            installed = await asyncio.to_thread(_installed_version, kimi_path)
+            if expected is not None and installed != expected:
+                raise RuntimeError(
+                    f"kimi_code: post-install version {installed!r} does not "
+                    f"match expected {expected!r}"
+                )
+            logger.info("kimi_code: dynamic npm installation completed")
+
+        self._kimi_path = kimi_path
+        logger.info(
+            "kimi_code: CLI ready at %s (version %s, node %s)",
+            kimi_path,
+            installed or "unknown",
+            ".".join(str(part) for part in installed_node),
+        )
+
+        work_dir = Path(self.executor.work_dir)
+        kimi_home = work_dir / "kimi-home"
+        kimi_home.mkdir(parents=True, exist_ok=True)
+
+        await ensure_cua_mcp_server(sandbox)
+        from ale_run.agents._bootstrap import cua_bridge_env
+
+        mcp_config = {
+            "mcpServers": {
+                "cua": {
+                    "command": sandbox.node,
+                    "args": [
+                        self._join(
+                            sandbox.mcp_server_dir,
+                            "src",
+                            "index.js",
+                            is_linux=sandbox.is_linux,
+                        )
+                    ],
+                    "env": cua_bridge_env(self.executor),
+                }
+            }
+        }
+        (kimi_home / "mcp.json").write_text(
+            json.dumps(mcp_config, indent=2),
+            encoding="utf-8",
+        )
+
+    async def launch(self, prompt: str) -> AgentRunResult:
+        config: KimiCodeConfig = self.config  # type: ignore[assignment]
+        work_dir = Path(self.executor.work_dir)
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        prompt_file = work_dir / "prompt.txt"
+        transcript_file = work_dir / "transcript.jsonl"
+        stderr_file = work_dir / "stderr.log"
+        pid_file = work_dir / "kimi.pid"
+        for path in (transcript_file, stderr_file, pid_file):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+        prompt_file.write_text(prompt, encoding="utf-8")
+        argv = [
+            self._kimi_path,
+            "--prompt",
+            prompt,
+            "--output-format",
+            "stream-json",
+        ]
+        env = self._build_env(config, work_dir=work_dir)
+
+        started = time.monotonic()
+        with open(transcript_file, "wb") as stdout, open(stderr_file, "wb") as stderr:
+            process = await asyncio.to_thread(
+                subprocess.Popen,
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout,
+                stderr=stderr,
+                cwd=str(work_dir),
+                env=env,
+                start_new_session=True if hasattr(os, "setsid") else False,
+            )
+        pid_file.write_text(str(process.pid), encoding="ascii")
+        logger.info("kimi_code: spawned pid=%s", process.pid)
+
+        try:
+            while process.poll() is None:
+                await asyncio.sleep(_POLL_INTERVAL_S)
+        except asyncio.CancelledError:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(process.wait),
+                    timeout=_TERM_GRACE_S,
+                )
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+            raise
+
+        duration_s = time.monotonic() - started
+        status = "completed" if process.returncode == 0 else "failed"
+        error = None
+        if status == "failed":
+            error = self._diagnose_failure(
+                transcript_file=transcript_file,
+                stderr_file=stderr_file,
+                exit_code=process.returncode,
+            )
+        return AgentRunResult(
+            status=status,
+            pid=process.pid,
+            exit_code=process.returncode,
+            transcript_path=str(transcript_file),
+            stderr_path=str(stderr_file),
+            duration_s=duration_s,
+            error=error,
+        )
+
+    def _build_env(
+        self,
+        config: KimiCodeConfig,
+        *,
+        work_dir: Path,
+    ) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(self.executor.env or {})
+
+        api_key = config.api_key or env.get(config.api_key_env)
+        if not api_key:
+            raise RuntimeError(
+                f"kimi_code: no API key configured; set config.api_key or {config.api_key_env}"
+            )
+
+        env.update(
+            {
+                "KIMI_CODE_HOME": str(work_dir / "kimi-home"),
+                "KIMI_MODEL_NAME": config.model,
+                "KIMI_MODEL_API_KEY": api_key,
+                "KIMI_MODEL_PROVIDER_TYPE": config.provider_type,
+                "KIMI_MODEL_BASE_URL": config.base_url,
+                "KIMI_MODEL_MAX_CONTEXT_SIZE": str(config.max_context_size),
+                "KIMI_MODEL_CAPABILITIES": ",".join(config.capabilities),
+            }
+        )
+        if config.thinking_effort is None:
+            env.pop("KIMI_MODEL_THINKING_EFFORT", None)
+        else:
+            env["KIMI_MODEL_THINKING_EFFORT"] = config.thinking_effort
+        if config.max_completion_tokens is None:
+            env.pop("KIMI_MODEL_MAX_COMPLETION_TOKENS", None)
+        else:
+            env["KIMI_MODEL_MAX_COMPLETION_TOKENS"] = str(config.max_completion_tokens)
+        if config.disable_telemetry:
+            env["KIMI_DISABLE_TELEMETRY"] = "1"
+        if config.disable_auto_update:
+            env["KIMI_CODE_NO_AUTO_UPDATE"] = "1"
+        return env
+
+    @staticmethod
+    def _join(*parts: str, is_linux: bool) -> str:
+        separator = "/" if is_linux else "\\"
+        head = parts[0].rstrip("/\\")
+        tail = separator.join(part.strip("/\\") for part in parts[1:])
+        return f"{head}{separator}{tail}" if tail else head
+
+    @classmethod
+    def parse_artifacts(
+        cls,
+        *,
+        work_dir: Path,
+        config: KimiCodeConfig,
+        run_result: AgentRunResult,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        wire_files = sorted(
+            (work_dir / "kimi-home" / "sessions").glob("**/agents/main/wire.jsonl"),
+            key=lambda path: path.stat().st_mtime,
+        )
+        if wire_files:
+            wire_file = wire_files[-1]
+            cls._parse_wire(wire_file, builder)
+            source_path = wire_file
+        else:
+            transcript_file = work_dir / "transcript.jsonl"
+            cls._parse_transcript(transcript_file, builder)
+            source_path = transcript_file
+
+        builder.trajectory.extra.setdefault("kimi_code", {}).update(
+            {
+                "exit_code": run_result.exit_code,
+                "transcript_path": str(work_dir / "transcript.jsonl"),
+                "wire_path": str(source_path) if wire_files else None,
+                "stderr_path": run_result.stderr_path,
+            }
+        )
+
+    @classmethod
+    def _parse_wire(cls, wire_file: Path, builder: TrajectoryBuilder) -> None:
+        active: dict[str, Any] | None = None
+        requests: list[dict[str, Any]] = []
+        blobs_dir = wire_file.parent / "blobs"
+        for record in cls._json_lines(wire_file):
+            record_type = record.get("type")
+            if record_type == "llm.request":
+                requests.append(record)
+                continue
+            if record_type != "context.append_loop_event":
+                continue
+            event = record.get("event") or {}
+            event_type = event.get("type")
+            if event_type == "step.begin":
+                if active is not None:
+                    cls._flush_wire_step(active, builder)
+                active = {
+                    "text": [],
+                    "reasoning": [],
+                    "tool_calls": [],
+                    "tool_results": [],
+                    "extra": {},
+                }
+            elif event_type == "content.part":
+                if active is None:
+                    active = {
+                        "text": [],
+                        "reasoning": [],
+                        "tool_calls": [],
+                        "tool_results": [],
+                        "extra": {},
+                    }
+                part = event.get("part") or {}
+                if part.get("type") == "text":
+                    active["text"].append(part.get("text", ""))
+                elif part.get("type") == "think":
+                    active["reasoning"].append(part.get("think", ""))
+            elif event_type == "tool.call":
+                if active is None:
+                    continue
+                arguments = event.get("args")
+                if not isinstance(arguments, dict):
+                    arguments = {"value": arguments}
+                active["tool_calls"].append(
+                    ToolCall(
+                        id=event.get("toolCallId") or event.get("uuid") or "",
+                        name=event.get("name") or "",
+                        arguments=arguments,
+                    )
+                )
+            elif event_type == "tool.result":
+                if active is None:
+                    continue
+                active["tool_results"].append(cls._wire_tool_result(event, blobs_dir=blobs_dir))
+            elif event_type == "step.retrying":
+                builder.add_step(
+                    source="system",
+                    message=event.get("errorMessage") or "Kimi Code retrying",
+                    extra={"kimi_code_retry": event},
+                )
+            elif event_type == "turn.interrupted":
+                builder.add_step(
+                    source="system",
+                    message=event.get("message") or "Kimi Code turn interrupted",
+                    extra={"kimi_code_interrupt": event},
+                )
+            elif event_type == "step.end":
+                if active is None:
+                    continue
+                usage = event.get("usage") or {}
+                active["metrics"] = StepMetrics(
+                    input_tokens=usage.get("inputOther"),
+                    output_tokens=usage.get("output"),
+                    cache_read_tokens=usage.get("inputCacheRead"),
+                    cache_creation_tokens=usage.get("inputCacheCreation"),
+                    duration_ms=(
+                        (event.get("llmFirstTokenLatencyMs") or 0)
+                        + (event.get("llmStreamDurationMs") or 0)
+                    )
+                    or None,
+                )
+                active["extra"] = {
+                    key: value
+                    for key, value in event.items()
+                    if key
+                    not in {
+                        "type",
+                        "uuid",
+                        "turnId",
+                        "step",
+                        "usage",
+                    }
+                }
+                cls._flush_wire_step(active, builder)
+                active = None
+
+        if active is not None:
+            cls._flush_wire_step(active, builder)
+        if requests:
+            builder.trajectory.extra.setdefault("kimi_code", {})["llm_requests"] = requests
+
+    @staticmethod
+    def _flush_wire_step(active: dict[str, Any], builder: TrajectoryBuilder) -> None:
+        text = "".join(active["text"]).strip() or None
+        reasoning = "".join(active["reasoning"]).strip() or None
+        tool_calls = active["tool_calls"]
+        metrics = active.get("metrics")
+        if text is not None or reasoning is not None or tool_calls or metrics is not None:
+            builder.add_step(
+                source="agent",
+                message=text,
+                reasoning=reasoning,
+                tool_calls=tool_calls,
+                metrics=metrics,
+                extra=active.get("extra") or {},
+            )
+        tool_results = active["tool_results"]
+        if tool_results:
+            builder.add_step(
+                source="environment",
+                observation=Observation(results=tool_results),
+            )
+
+    @classmethod
+    def _wire_tool_result(
+        cls,
+        event: dict[str, Any],
+        *,
+        blobs_dir: Path,
+    ) -> ToolResult:
+        result = event.get("result") or {}
+        content = cls._content_parts(result.get("output"), blobs_dir=blobs_dir)
+        for key in ("message", "note"):
+            value = result.get(key)
+            if isinstance(value, str) and value:
+                content.append(ContentPart(type="text", text=value))
+        return ToolResult(
+            tool_call_id=event.get("toolCallId") or event.get("parentUuid") or "",
+            content=content,
+            is_error=bool(result.get("isError")),
+        )
+
+    @classmethod
+    def _content_parts(
+        cls,
+        output: Any,
+        *,
+        blobs_dir: Path | None = None,
+    ) -> list[ContentPart]:
+        if isinstance(output, str):
+            return [ContentPart(type="text", text=output)]
+        if not isinstance(output, list):
+            return [
+                ContentPart(
+                    type="text",
+                    text=json.dumps(output, ensure_ascii=False, default=str),
+                )
+            ]
+
+        content: list[ContentPart] = []
+        for part in output:
+            if not isinstance(part, dict):
+                content.append(ContentPart(type="text", text=str(part)))
+                continue
+            part_type = part.get("type")
+            if part_type == "text":
+                content.append(ContentPart(type="text", text=part.get("text", "")))
+                continue
+            if part_type != "image_url":
+                continue
+            image_url = part.get("imageUrl") or part.get("image_url") or {}
+            url = image_url.get("url") if isinstance(image_url, dict) else None
+            if not isinstance(url, str):
+                continue
+            if url.startswith("blobref:") and blobs_dir is not None:
+                reference = url.removeprefix("blobref:")
+                media_type, separator, digest = reference.partition(";")
+                blob_path = blobs_dir / digest
+                if separator and digest and blob_path.is_file():
+                    content.append(
+                        ContentPart(
+                            type="image",
+                            image=ImageSource(
+                                type="base64",
+                                media_type=media_type or "image/png",
+                                data=base64.b64encode(blob_path.read_bytes()).decode("ascii"),
+                            ),
+                        )
+                    )
+                    continue
+            match = _DATA_URL_RE.match(url)
+            if match:
+                content.append(
+                    ContentPart(
+                        type="image",
+                        image=ImageSource(
+                            type="base64",
+                            media_type=match.group(1),
+                            data=match.group(2),
+                        ),
+                    )
+                )
+            else:
+                content.append(
+                    ContentPart(
+                        type="image",
+                        image=ImageSource(type="url", url=url),
+                    )
+                )
+        return content
+
+    @classmethod
+    def _parse_transcript(
+        cls,
+        transcript_file: Path,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        if not transcript_file.exists():
+            builder.add_step(
+                source="system",
+                message=f"kimi-code: no transcript at {transcript_file}",
+                extra={"reason": "no_transcript"},
+            )
+            return
+        for event in cls._json_lines(transcript_file):
+            role = event.get("role")
+            if role == "assistant":
+                tool_calls: list[ToolCall] = []
+                for raw_call in event.get("tool_calls") or []:
+                    function = raw_call.get("function") or {}
+                    raw_arguments = function.get("arguments") or "{}"
+                    try:
+                        arguments = json.loads(raw_arguments)
+                    except (json.JSONDecodeError, TypeError):
+                        arguments = {"raw": raw_arguments}
+                    tool_calls.append(
+                        ToolCall(
+                            id=raw_call.get("id") or "",
+                            name=function.get("name") or "",
+                            arguments=arguments,
+                        )
+                    )
+                builder.add_step(
+                    source="agent",
+                    message=event.get("content"),
+                    tool_calls=tool_calls,
+                )
+            elif role == "tool":
+                builder.add_step(
+                    source="environment",
+                    observation=Observation(
+                        results=[
+                            ToolResult(
+                                tool_call_id=event.get("tool_call_id") or "",
+                                content=cls._content_parts(event.get("content", "")),
+                            )
+                        ]
+                    ),
+                )
+            elif role == "meta" and event.get("type") == "turn.step.retrying":
+                builder.add_step(
+                    source="system",
+                    message=event.get("error_message") or "Kimi Code retrying",
+                    extra={"kimi_code_retry": event},
+                )
+
+    @staticmethod
+    def _json_lines(path: Path):
+        try:
+            raw = path.read_text(encoding="utf-8", errors="replace")
+        except (FileNotFoundError, OSError):
+            return
+        for line in raw.splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                yield event
+
+    @staticmethod
+    def _diagnose_failure(
+        *,
+        transcript_file: Path,
+        stderr_file: Path,
+        exit_code: int | None,
+    ) -> str:
+        transcript = (
+            transcript_file.read_text(encoding="utf-8", errors="replace")
+            if transcript_file.exists()
+            else ""
+        )
+        stderr = (
+            stderr_file.read_text(encoding="utf-8", errors="replace")
+            if stderr_file.exists()
+            else ""
+        )
+        parts = [
+            f"agent failed (rc={exit_code})",
+            f"stderr={len(stderr)}B transcript={len(transcript)}B",
+        ]
+        if "status_code=429" in transcript or "429" in stderr:
+            parts.append("LLM rate-limited")
+        if stderr.strip():
+            parts.append(f"stderr tail: ...{stderr[-800:]}")
+        if transcript.strip():
+            parts.append(f"transcript tail: ...{transcript[-800:]}")
+        return " | ".join(parts)

--- a/ale_run/agents/kimi_code/deployer.py
+++ b/ale_run/agents/kimi_code/deployer.py
@@ -12,7 +12,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Iterator
 
 from ale_run.base_interface import (
     AgentRunResult,
@@ -27,6 +27,13 @@ from ale_run.base_interface import (
 )
 
 from .config import KimiCodeConfig
+from .telemetry import (
+    OTEL_NPM_PACKAGE_VERSIONS,
+    OTEL_NPM_PACKAGES,
+    KimiCodeOtelCollector,
+    recover_telemetry_artifacts,
+    write_otel_bootstrap,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,37 +51,24 @@ def _expected_version(npm_spec: str | None) -> str | None:
     return match.group(1) if match else None
 
 
-def _installed_version(kimi_path: str) -> str | None:
+def _command_version(path: str, timeout: int = 60) -> str | None:
     try:
-        probe = subprocess.run(
-            [kimi_path, "--version"],
+        result = subprocess.run(
+            [path, "--version"],
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=timeout,
             stdin=subprocess.DEVNULL,
         )
     except (OSError, subprocess.TimeoutExpired):
         return None
-    match = _VERSION_RE.search((probe.stdout or "") + (probe.stderr or ""))
+    match = _VERSION_RE.search((result.stdout or "") + (result.stderr or ""))
     return match.group(1) if match else None
 
 
-def _node_version(node_path: str) -> tuple[int, int, int] | None:
-    try:
-        probe = subprocess.run(
-            [node_path, "--version"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            stdin=subprocess.DEVNULL,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    match = _VERSION_RE.search((probe.stdout or "") + (probe.stderr or ""))
-    if not match:
-        return None
-    major, minor, patch = (int(part) for part in match.group(1).split("."))
-    return major, minor, patch
+def _node_version(path: str) -> tuple[int, int, int] | None:
+    version = _command_version(path, timeout=30)
+    return tuple(map(int, version.split("."))) if version else None
 
 
 def _find_kimi_shim(prefix: str) -> str | None:
@@ -88,12 +82,32 @@ def _find_kimi_shim(prefix: str) -> str | None:
     return None
 
 
+def _npm_global_root(npm_path: str, prefix: str) -> Path:
+    result = subprocess.run(
+        [npm_path, "root", "--global", "--prefix", prefix],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        stdin=subprocess.DEVNULL,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RuntimeError(
+            "kimi_code: could not resolve npm global root: "
+            f"{(result.stderr or result.stdout or '').strip()[-400:]}"
+        )
+    return Path(result.stdout.strip()).resolve()
+
+
 class KimiCodeDeployer(BaseAgentDeployer):
     """Sandbox deployer for ``@moonshot-ai/kimi-code``."""
 
     default_executor: ClassVar[str] = "sandbox"
     supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
-    hot_artifacts: ClassVar[tuple[str, ...]] = ("transcript.jsonl", "stderr.log")
+    hot_artifacts: ClassVar[tuple[str, ...]] = (
+        "transcript.jsonl",
+        "stderr.log",
+        "otel_requests.jsonl",
+    )
 
     @property
     def version(self) -> str | None:
@@ -103,36 +117,35 @@ class KimiCodeDeployer(BaseAgentDeployer):
     async def install(self) -> None:
         config: KimiCodeConfig = self.config  # type: ignore[assignment]
         sandbox = self.executor.sandbox
-
         from ale_run.agents._bootstrap import ensure_cua_mcp_server, ensure_node_npm
 
         node_path, npm_path = await ensure_node_npm()
-        installed_node = await asyncio.to_thread(_node_version, node_path)
-        if installed_node is None or installed_node < _MIN_NODE_VERSION:
-            rendered = ".".join(str(part) for part in installed_node or ())
+        node_version = await asyncio.to_thread(_node_version, node_path)
+        if node_version is None or node_version < _MIN_NODE_VERSION:
+            rendered = ".".join(map(str, node_version or ()))
             raise RuntimeError(
                 "kimi_code: Kimi Code requires Node.js >=22.19.0, "
                 f"found {rendered or 'an unreadable version'} at {node_path}"
             )
 
+        home = os.path.expanduser("~")
+        prefix = os.path.join(home, ".local")
+        npm_env = {**os.environ, "npm_config_cache": os.path.join(home, ".npm-ale")}
+        node_modules = await asyncio.to_thread(_npm_global_root, npm_path, prefix)
         kimi_path = shutil.which("kimi")
         expected = _expected_version(config.cli_version)
-        installed = await asyncio.to_thread(_installed_version, kimi_path) if kimi_path else None
+        installed = await asyncio.to_thread(_command_version, kimi_path) if kimi_path else None
+
+        packages: list[str] = []
         if not kimi_path or (expected is not None and installed != expected):
-            home = os.path.expanduser("~")
-            prefix = os.path.join(home, ".local")
-            package = config.cli_version or "@moonshot-ai/kimi-code"
-            logger.info(
-                "kimi_code: installing %s via npm (installed=%s expected=%s)",
-                package,
-                installed or "missing",
-                expected or "unpinned",
-            )
-            env = {
-                **os.environ,
-                "npm_config_cache": os.path.join(home, ".npm-ale"),
-            }
-            process = await asyncio.to_thread(
+            packages.append(config.cli_version or "@moonshot-ai/kimi-code")
+        if config.otel_enabled and any(
+            self._package_version(node_modules, name) != version
+            for name, version in OTEL_NPM_PACKAGE_VERSIONS.items()
+        ):
+            packages.extend(OTEL_NPM_PACKAGES)
+        if packages:
+            result = await asyncio.to_thread(
                 subprocess.run,
                 [
                     npm_path,
@@ -141,43 +154,41 @@ class KimiCodeDeployer(BaseAgentDeployer):
                     "--force",
                     "--prefix",
                     prefix,
-                    package,
+                    *packages,
                 ],
                 capture_output=True,
                 text=True,
                 timeout=900,
-                env=env,
+                env=npm_env,
             )
-            if process.returncode != 0:
+            if result.returncode != 0:
                 raise RuntimeError(
-                    f"npm install -g {package} failed (rc={process.returncode}): "
-                    f"{(process.stderr or process.stdout or '')[-800:]}"
+                    f"kimi_code: npm install failed for {packages}: "
+                    f"{(result.stderr or result.stdout or '')[-800:]}"
                 )
+
+        if not kimi_path or (expected is not None and installed != expected):
             for bin_dir in (prefix, os.path.join(prefix, "bin")):
                 os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
             kimi_path = _find_kimi_shim(prefix) or shutil.which("kimi")
             if not kimi_path:
-                raise RuntimeError("kimi_code: 'kimi' not found after dynamic npm installation")
-            installed = await asyncio.to_thread(_installed_version, kimi_path)
+                raise RuntimeError("kimi_code: 'kimi' not found after npm installation")
+            installed = await asyncio.to_thread(_command_version, kimi_path)
             if expected is not None and installed != expected:
                 raise RuntimeError(
-                    f"kimi_code: post-install version {installed!r} does not "
-                    f"match expected {expected!r}"
+                    f"kimi_code: installed version {installed!r} != expected {expected!r}"
                 )
-            logger.info("kimi_code: dynamic npm installation completed")
 
         self._kimi_path = kimi_path
-        logger.info(
-            "kimi_code: CLI ready at %s (version %s, node %s)",
-            kimi_path,
-            installed or "unknown",
-            ".".join(str(part) for part in installed_node),
-        )
+        self._otel_bootstrap_path: Path | None = None
+        if config.otel_enabled:
+            node_modules = await asyncio.to_thread(_npm_global_root, npm_path, prefix)
+            self._otel_bootstrap_path = node_modules / "ale-kimi-otel" / "bootstrap.mjs"
+            await asyncio.to_thread(write_otel_bootstrap, self._otel_bootstrap_path)
 
         work_dir = Path(self.executor.work_dir)
         kimi_home = work_dir / "kimi-home"
         kimi_home.mkdir(parents=True, exist_ok=True)
-
         await ensure_cua_mcp_server(sandbox)
         from ale_run.agents._bootstrap import cua_bridge_env
 
@@ -201,76 +212,69 @@ class KimiCodeDeployer(BaseAgentDeployer):
             json.dumps(mcp_config, indent=2),
             encoding="utf-8",
         )
+        logger.info(
+            "kimi_code: CLI ready at %s (version %s, node %s)",
+            kimi_path,
+            installed or "unknown",
+            ".".join(map(str, node_version)),
+        )
 
     async def launch(self, prompt: str) -> AgentRunResult:
         config: KimiCodeConfig = self.config  # type: ignore[assignment]
         work_dir = Path(self.executor.work_dir)
         work_dir.mkdir(parents=True, exist_ok=True)
-
         prompt_file = work_dir / "prompt.txt"
         transcript_file = work_dir / "transcript.jsonl"
         stderr_file = work_dir / "stderr.log"
         pid_file = work_dir / "kimi.pid"
         for path in (transcript_file, stderr_file, pid_file):
-            try:
-                path.unlink()
-            except FileNotFoundError:
-                pass
-
+            path.unlink(missing_ok=True)
         prompt_file.write_text(prompt, encoding="utf-8")
-        argv = [
-            self._kimi_path,
-            "--prompt",
-            prompt,
-            "--output-format",
-            "stream-json",
-        ]
-        env = self._build_env(config, work_dir=work_dir)
 
+        collector = KimiCodeOtelCollector(work_dir) if config.otel_enabled else None
+        process: subprocess.Popen[bytes] | None = None
         started = time.monotonic()
-        with open(transcript_file, "wb") as stdout, open(stderr_file, "wb") as stderr:
-            process = await asyncio.to_thread(
-                subprocess.Popen,
-                argv,
-                stdin=subprocess.DEVNULL,
-                stdout=stdout,
-                stderr=stderr,
-                cwd=str(work_dir),
-                env=env,
-                start_new_session=True if hasattr(os, "setsid") else False,
-            )
-        pid_file.write_text(str(process.pid), encoding="ascii")
-        logger.info("kimi_code: spawned pid=%s", process.pid)
-
         try:
+            if collector is not None:
+                collector.start()
+            env = self._build_env(
+                config,
+                work_dir=work_dir,
+                otel_endpoint=collector.endpoint if collector else None,
+                otel_bootstrap=self._otel_bootstrap_path,
+            )
+            with transcript_file.open("wb") as stdout, stderr_file.open("wb") as stderr:
+                process = await asyncio.to_thread(
+                    subprocess.Popen,
+                    [
+                        self._kimi_path,
+                        "--prompt",
+                        prompt,
+                        "--output-format",
+                        "stream-json",
+                    ],
+                    stdin=subprocess.DEVNULL,
+                    stdout=stdout,
+                    stderr=stderr,
+                    cwd=str(work_dir),
+                    env=env,
+                    start_new_session=hasattr(os, "setsid"),
+                )
+            pid_file.write_text(str(process.pid), encoding="ascii")
             while process.poll() is None:
                 await asyncio.sleep(_POLL_INTERVAL_S)
         except asyncio.CancelledError:
-            try:
-                process.terminate()
-            except ProcessLookupError:
-                pass
-            try:
-                await asyncio.wait_for(
-                    asyncio.to_thread(process.wait),
-                    timeout=_TERM_GRACE_S,
-                )
-            except (asyncio.TimeoutError, asyncio.CancelledError):
-                try:
-                    process.kill()
-                except ProcessLookupError:
-                    pass
+            if process is not None:
+                await self._terminate(process)
             raise
+        finally:
+            if collector is not None:
+                collector.stop()
 
+        if process is None:
+            raise RuntimeError("kimi_code: process was not started")
         duration_s = time.monotonic() - started
         status = "completed" if process.returncode == 0 else "failed"
-        error = None
-        if status == "failed":
-            error = self._diagnose_failure(
-                transcript_file=transcript_file,
-                stderr_file=stderr_file,
-                exit_code=process.returncode,
-            )
         return AgentRunResult(
             status=status,
             pid=process.pid,
@@ -278,7 +282,9 @@ class KimiCodeDeployer(BaseAgentDeployer):
             transcript_path=str(transcript_file),
             stderr_path=str(stderr_file),
             duration_s=duration_s,
-            error=error,
+            error=None
+            if status == "completed"
+            else self._diagnose_failure(transcript_file, stderr_file, process.returncode),
         )
 
     def _build_env(
@@ -286,16 +292,13 @@ class KimiCodeDeployer(BaseAgentDeployer):
         config: KimiCodeConfig,
         *,
         work_dir: Path,
+        otel_endpoint: str | None = None,
+        otel_bootstrap: Path | None = None,
     ) -> dict[str, str]:
-        env = os.environ.copy()
-        env.update(self.executor.env or {})
-
+        env = {**os.environ, **(self.executor.env or {})}
         api_key = config.api_key or env.get(config.api_key_env)
         if not api_key:
-            raise RuntimeError(
-                f"kimi_code: no API key configured; set config.api_key or {config.api_key_env}"
-            )
-
+            raise RuntimeError(f"kimi_code: set config.api_key or environment {config.api_key_env}")
         env.update(
             {
                 "KIMI_CODE_HOME": str(work_dir / "kimi-home"),
@@ -305,28 +308,29 @@ class KimiCodeDeployer(BaseAgentDeployer):
                 "KIMI_MODEL_BASE_URL": config.base_url,
                 "KIMI_MODEL_MAX_CONTEXT_SIZE": str(config.max_context_size),
                 "KIMI_MODEL_CAPABILITIES": ",".join(config.capabilities),
+                "KIMI_MODEL_OUTPUT_FORMAT": "stream-json",
             }
         )
-        if config.thinking_effort is None:
-            env.pop("KIMI_MODEL_THINKING_EFFORT", None)
-        else:
-            env["KIMI_MODEL_THINKING_EFFORT"] = config.thinking_effort
-        if config.max_completion_tokens is None:
-            env.pop("KIMI_MODEL_MAX_COMPLETION_TOKENS", None)
-        else:
-            env["KIMI_MODEL_MAX_COMPLETION_TOKENS"] = str(config.max_completion_tokens)
+        self._set_optional_env(env, "KIMI_MODEL_THINKING_EFFORT", config.thinking_effort)
+        self._set_optional_env(
+            env,
+            "KIMI_MODEL_MAX_COMPLETION_TOKENS",
+            config.max_completion_tokens,
+        )
         if config.disable_telemetry:
             env["KIMI_DISABLE_TELEMETRY"] = "1"
         if config.disable_auto_update:
             env["KIMI_CODE_NO_AUTO_UPDATE"] = "1"
+        if otel_endpoint is not None:
+            if otel_bootstrap is None:
+                raise RuntimeError("kimi_code: OTel enabled without bootstrap")
+            import_option = f"--import={otel_bootstrap.resolve().as_uri()}"
+            env["ALE_KIMI_OTEL_ENDPOINT"] = otel_endpoint
+            env["ALE_KIMI_OTEL_IMPORT_OPTION"] = import_option
+            env["NODE_OPTIONS"] = " ".join(
+                value for value in (env.get("NODE_OPTIONS", "").strip(), import_option) if value
+            )
         return env
-
-    @staticmethod
-    def _join(*parts: str, is_linux: bool) -> str:
-        separator = "/" if is_linux else "\\"
-        head = parts[0].rstrip("/\\")
-        tail = separator.join(part.strip("/\\") for part in parts[1:])
-        return f"{head}{separator}{tail}" if tail else head
 
     @classmethod
     def parse_artifacts(
@@ -337,98 +341,95 @@ class KimiCodeDeployer(BaseAgentDeployer):
         run_result: AgentRunResult,
         builder: TrajectoryBuilder,
     ) -> None:
+        transcript_file = work_dir / "transcript.jsonl"
         wire_files = sorted(
             (work_dir / "kimi-home" / "sessions").glob("**/agents/main/wire.jsonl"),
             key=lambda path: path.stat().st_mtime,
         )
-        if wire_files:
-            wire_file = wire_files[-1]
-            cls._parse_wire(wire_file, builder)
-            source_path = wire_file
-        else:
-            transcript_file = work_dir / "transcript.jsonl"
-            cls._parse_transcript(transcript_file, builder)
-            source_path = transcript_file
+        wire_file = wire_files[-1] if wire_files else None
+        try:
+            recover_telemetry_artifacts(work_dir, wire_file=wire_file)
+        except (OSError, TypeError, ValueError) as exc:
+            logger.warning("kimi_code: telemetry recovery failed: %s", exc)
 
+        if wire_file is not None:
+            cls._parse_wire(
+                wire_file,
+                builder,
+                transcript_results=cls._transcript_tool_results(transcript_file),
+            )
+        else:
+            cls._parse_transcript(transcript_file, builder)
         builder.trajectory.extra.setdefault("kimi_code", {}).update(
             {
                 "exit_code": run_result.exit_code,
-                "transcript_path": str(work_dir / "transcript.jsonl"),
-                "wire_path": str(source_path) if wire_files else None,
+                "transcript_path": str(transcript_file),
+                "wire_path": str(wire_file) if wire_file else None,
                 "stderr_path": run_result.stderr_path,
+                "telemetry_path": str(work_dir / "telemetry.jsonl"),
+                "telemetry_summary_path": str(work_dir / "telemetry_summary.json"),
             }
         )
 
     @classmethod
-    def _parse_wire(cls, wire_file: Path, builder: TrajectoryBuilder) -> None:
+    def _parse_wire(
+        cls,
+        wire_file: Path,
+        builder: TrajectoryBuilder,
+        *,
+        transcript_results: dict[str, list[ContentPart]],
+    ) -> None:
         active: dict[str, Any] | None = None
         requests: list[dict[str, Any]] = []
         blobs_dir = wire_file.parent / "blobs"
         for record in cls._json_lines(wire_file):
-            record_type = record.get("type")
-            if record_type == "llm.request":
+            if record.get("type") == "llm.request":
                 requests.append(record)
                 continue
-            if record_type != "context.append_loop_event":
+            if record.get("type") != "context.append_loop_event":
                 continue
             event = record.get("event") or {}
             event_type = event.get("type")
             if event_type == "step.begin":
                 if active is not None:
-                    cls._flush_wire_step(active, builder)
-                active = {
-                    "text": [],
-                    "reasoning": [],
-                    "tool_calls": [],
-                    "tool_results": [],
-                    "extra": {},
-                }
+                    cls._flush_step(active, builder)
+                active = cls._new_step()
             elif event_type == "content.part":
-                if active is None:
-                    active = {
-                        "text": [],
-                        "reasoning": [],
-                        "tool_calls": [],
-                        "tool_results": [],
-                        "extra": {},
-                    }
+                active = active or cls._new_step()
                 part = event.get("part") or {}
                 if part.get("type") == "text":
                     active["text"].append(part.get("text", ""))
                 elif part.get("type") == "think":
                     active["reasoning"].append(part.get("think", ""))
-            elif event_type == "tool.call":
-                if active is None:
-                    continue
+            elif event_type == "tool.call" and active is not None:
                 arguments = event.get("args")
-                if not isinstance(arguments, dict):
-                    arguments = {"value": arguments}
                 active["tool_calls"].append(
                     ToolCall(
                         id=event.get("toolCallId") or event.get("uuid") or "",
                         name=event.get("name") or "",
-                        arguments=arguments,
+                        arguments=arguments
+                        if isinstance(arguments, dict)
+                        else {"value": arguments},
                     )
                 )
-            elif event_type == "tool.result":
-                if active is None:
-                    continue
-                active["tool_results"].append(cls._wire_tool_result(event, blobs_dir=blobs_dir))
-            elif event_type == "step.retrying":
+            elif event_type == "tool.result" and active is not None:
+                tool_id = event.get("toolCallId") or event.get("parentUuid") or ""
+                active["tool_results"].append(
+                    cls._wire_tool_result(
+                        event,
+                        blobs_dir=blobs_dir,
+                        transcript_content=transcript_results.get(tool_id),
+                    )
+                )
+            elif event_type in {"step.retrying", "turn.interrupted"}:
                 builder.add_step(
                     source="system",
-                    message=event.get("errorMessage") or "Kimi Code retrying",
-                    extra={"kimi_code_retry": event},
+                    message=event.get("errorMessage")
+                    or event.get("message")
+                    or f"Kimi Code {event_type}",
+                    extra={"kimi_code_event": event},
                 )
-            elif event_type == "turn.interrupted":
-                builder.add_step(
-                    source="system",
-                    message=event.get("message") or "Kimi Code turn interrupted",
-                    extra={"kimi_code_interrupt": event},
-                )
-            elif event_type == "step.end":
-                if active is None:
-                    continue
+            elif event_type == "step.end" and active is not None:
                 usage = event.get("usage") or {}
                 active["metrics"] = StepMetrics(
                     input_tokens=usage.get("inputOther"),
@@ -444,160 +445,38 @@ class KimiCodeDeployer(BaseAgentDeployer):
                 active["extra"] = {
                     key: value
                     for key, value in event.items()
-                    if key
-                    not in {
-                        "type",
-                        "uuid",
-                        "turnId",
-                        "step",
-                        "usage",
-                    }
+                    if key not in {"type", "uuid", "turnId", "step", "usage"}
                 }
-                cls._flush_wire_step(active, builder)
+                cls._flush_step(active, builder)
                 active = None
-
         if active is not None:
-            cls._flush_wire_step(active, builder)
+            cls._flush_step(active, builder)
         if requests:
             builder.trajectory.extra.setdefault("kimi_code", {})["llm_requests"] = requests
 
-    @staticmethod
-    def _flush_wire_step(active: dict[str, Any], builder: TrajectoryBuilder) -> None:
-        text = "".join(active["text"]).strip() or None
-        reasoning = "".join(active["reasoning"]).strip() or None
-        tool_calls = active["tool_calls"]
-        metrics = active.get("metrics")
-        if text is not None or reasoning is not None or tool_calls or metrics is not None:
-            builder.add_step(
-                source="agent",
-                message=text,
-                reasoning=reasoning,
-                tool_calls=tool_calls,
-                metrics=metrics,
-                extra=active.get("extra") or {},
-            )
-        tool_results = active["tool_results"]
-        if tool_results:
-            builder.add_step(
-                source="environment",
-                observation=Observation(results=tool_results),
-            )
-
     @classmethod
-    def _wire_tool_result(
-        cls,
-        event: dict[str, Any],
-        *,
-        blobs_dir: Path,
-    ) -> ToolResult:
-        result = event.get("result") or {}
-        content = cls._content_parts(result.get("output"), blobs_dir=blobs_dir)
-        for key in ("message", "note"):
-            value = result.get(key)
-            if isinstance(value, str) and value:
-                content.append(ContentPart(type="text", text=value))
-        return ToolResult(
-            tool_call_id=event.get("toolCallId") or event.get("parentUuid") or "",
-            content=content,
-            is_error=bool(result.get("isError")),
-        )
-
-    @classmethod
-    def _content_parts(
-        cls,
-        output: Any,
-        *,
-        blobs_dir: Path | None = None,
-    ) -> list[ContentPart]:
-        if isinstance(output, str):
-            return [ContentPart(type="text", text=output)]
-        if not isinstance(output, list):
-            return [
-                ContentPart(
-                    type="text",
-                    text=json.dumps(output, ensure_ascii=False, default=str),
-                )
-            ]
-
-        content: list[ContentPart] = []
-        for part in output:
-            if not isinstance(part, dict):
-                content.append(ContentPart(type="text", text=str(part)))
-                continue
-            part_type = part.get("type")
-            if part_type == "text":
-                content.append(ContentPart(type="text", text=part.get("text", "")))
-                continue
-            if part_type != "image_url":
-                continue
-            image_url = part.get("imageUrl") or part.get("image_url") or {}
-            url = image_url.get("url") if isinstance(image_url, dict) else None
-            if not isinstance(url, str):
-                continue
-            if url.startswith("blobref:") and blobs_dir is not None:
-                reference = url.removeprefix("blobref:")
-                media_type, separator, digest = reference.partition(";")
-                blob_path = blobs_dir / digest
-                if separator and digest and blob_path.is_file():
-                    content.append(
-                        ContentPart(
-                            type="image",
-                            image=ImageSource(
-                                type="base64",
-                                media_type=media_type or "image/png",
-                                data=base64.b64encode(blob_path.read_bytes()).decode("ascii"),
-                            ),
-                        )
-                    )
-                    continue
-            match = _DATA_URL_RE.match(url)
-            if match:
-                content.append(
-                    ContentPart(
-                        type="image",
-                        image=ImageSource(
-                            type="base64",
-                            media_type=match.group(1),
-                            data=match.group(2),
-                        ),
-                    )
-                )
-            else:
-                content.append(
-                    ContentPart(
-                        type="image",
-                        image=ImageSource(type="url", url=url),
-                    )
-                )
-        return content
-
-    @classmethod
-    def _parse_transcript(
-        cls,
-        transcript_file: Path,
-        builder: TrajectoryBuilder,
-    ) -> None:
-        if not transcript_file.exists():
+    def _parse_transcript(cls, path: Path, builder: TrajectoryBuilder) -> None:
+        if not path.exists():
             builder.add_step(
                 source="system",
-                message=f"kimi-code: no transcript at {transcript_file}",
+                message=f"kimi-code: no transcript at {path}",
                 extra={"reason": "no_transcript"},
             )
             return
-        for event in cls._json_lines(transcript_file):
+        for event in cls._json_lines(path):
             role = event.get("role")
             if role == "assistant":
                 tool_calls: list[ToolCall] = []
-                for raw_call in event.get("tool_calls") or []:
-                    function = raw_call.get("function") or {}
-                    raw_arguments = function.get("arguments") or "{}"
+                for raw in event.get("tool_calls") or []:
+                    function = raw.get("function") or {}
+                    arguments = function.get("arguments") or "{}"
                     try:
-                        arguments = json.loads(raw_arguments)
+                        arguments = json.loads(arguments)
                     except (json.JSONDecodeError, TypeError):
-                        arguments = {"raw": raw_arguments}
+                        arguments = {"raw": arguments}
                     tool_calls.append(
                         ToolCall(
-                            id=raw_call.get("id") or "",
+                            id=raw.get("id") or "",
                             name=function.get("name") or "",
                             arguments=arguments,
                         )
@@ -626,45 +505,185 @@ class KimiCodeDeployer(BaseAgentDeployer):
                     extra={"kimi_code_retry": event},
                 )
 
-    @staticmethod
-    def _json_lines(path: Path):
-        try:
-            raw = path.read_text(encoding="utf-8", errors="replace")
-        except (FileNotFoundError, OSError):
-            return
-        for line in raw.splitlines():
+    @classmethod
+    def _wire_tool_result(
+        cls,
+        event: dict[str, Any],
+        *,
+        blobs_dir: Path,
+        transcript_content: list[ContentPart] | None,
+    ) -> ToolResult:
+        result = event.get("result") or {}
+        content = cls._content_parts(result.get("output"), blobs_dir=blobs_dir)
+        if transcript_content and any(part.type == "image" for part in transcript_content):
+            content = transcript_content
+        for key in ("message", "note"):
+            if isinstance(result.get(key), str) and result[key]:
+                content.append(ContentPart(type="text", text=result[key]))
+        return ToolResult(
+            tool_call_id=event.get("toolCallId") or event.get("parentUuid") or "",
+            content=content,
+            is_error=bool(result.get("isError")),
+        )
+
+    @classmethod
+    def _content_parts(
+        cls,
+        output: Any,
+        *,
+        blobs_dir: Path | None = None,
+    ) -> list[ContentPart]:
+        if isinstance(output, str):
             try:
-                event = json.loads(line)
+                decoded = json.loads(output)
             except json.JSONDecodeError:
+                return [ContentPart(type="text", text=output)]
+            if isinstance(decoded, (dict, list)):
+                return cls._content_parts(decoded, blobs_dir=blobs_dir)
+            return [ContentPart(type="text", text=output)]
+        if isinstance(output, dict):
+            output = [output]
+        if not isinstance(output, list):
+            return [ContentPart(type="text", text=json.dumps(output, default=str))]
+
+        content: list[ContentPart] = []
+        for part in output:
+            if not isinstance(part, dict):
+                content.append(ContentPart(type="text", text=str(part)))
                 continue
-            if isinstance(event, dict):
-                yield event
+            if part.get("type") == "text":
+                content.append(ContentPart(type="text", text=part.get("text", "")))
+                continue
+            if part.get("type") != "image_url":
+                continue
+            image_url = part.get("imageUrl") or part.get("image_url") or {}
+            url = image_url.get("url") if isinstance(image_url, dict) else None
+            if not isinstance(url, str):
+                continue
+            image = cls._image_source(url, blobs_dir)
+            if image is not None:
+                content.append(ContentPart(type="image", image=image))
+        return content
 
     @staticmethod
-    def _diagnose_failure(
-        *,
-        transcript_file: Path,
-        stderr_file: Path,
-        exit_code: int | None,
-    ) -> str:
-        transcript = (
-            transcript_file.read_text(encoding="utf-8", errors="replace")
-            if transcript_file.exists()
-            else ""
+    def _image_source(url: str, blobs_dir: Path | None) -> ImageSource | None:
+        if url.startswith("blobref:"):
+            if blobs_dir is None:
+                return None
+            media_type, separator, digest = url.removeprefix("blobref:").partition(";")
+            blob = blobs_dir / digest
+            if separator and digest and blob.is_file():
+                return ImageSource(
+                    type="base64",
+                    media_type=media_type or "image/png",
+                    data=base64.b64encode(blob.read_bytes()).decode("ascii"),
+                )
+            return None
+        match = _DATA_URL_RE.match(url)
+        if match:
+            return ImageSource(type="base64", media_type=match.group(1), data=match.group(2))
+        return ImageSource(type="url", url=url)
+
+    @classmethod
+    def _transcript_tool_results(cls, path: Path) -> dict[str, list[ContentPart]]:
+        results: dict[str, list[ContentPart]] = {}
+        for event in cls._json_lines(path):
+            tool_id = event.get("tool_call_id")
+            if event.get("role") == "tool" and isinstance(tool_id, str) and tool_id:
+                results[tool_id] = cls._content_parts(event.get("content", ""))
+        return results
+
+    @staticmethod
+    def _new_step() -> dict[str, Any]:
+        return {
+            "text": [],
+            "reasoning": [],
+            "tool_calls": [],
+            "tool_results": [],
+            "extra": {},
+        }
+
+    @staticmethod
+    def _flush_step(active: dict[str, Any], builder: TrajectoryBuilder) -> None:
+        text = "".join(active["text"]).strip() or None
+        reasoning = "".join(active["reasoning"]).strip() or None
+        if text or reasoning or active["tool_calls"] or active.get("metrics"):
+            builder.add_step(
+                source="agent",
+                message=text,
+                reasoning=reasoning,
+                tool_calls=active["tool_calls"],
+                metrics=active.get("metrics"),
+                extra=active.get("extra") or {},
+            )
+        if active["tool_results"]:
+            builder.add_step(
+                source="environment",
+                observation=Observation(results=active["tool_results"]),
+            )
+
+    @staticmethod
+    def _json_lines(path: Path) -> Iterator[dict[str, Any]]:
+        if not path.exists():
+            return
+        with path.open("r", encoding="utf-8", errors="replace") as file:
+            for line in file:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict):
+                    yield event
+
+    @staticmethod
+    def _join(*parts: str, is_linux: bool) -> str:
+        separator = "/" if is_linux else "\\"
+        return (
+            parts[0].rstrip("/\\")
+            + separator
+            + separator.join(part.strip("/\\") for part in parts[1:])
         )
-        stderr = (
-            stderr_file.read_text(encoding="utf-8", errors="replace")
-            if stderr_file.exists()
-            else ""
-        )
+
+    @staticmethod
+    def _set_optional_env(env: dict[str, str], key: str, value: Any) -> None:
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = str(value)
+
+    @staticmethod
+    def _package_version(root: Path, package: str) -> str | None:
+        try:
+            return json.loads((root / package / "package.json").read_text())["version"]
+        except (FileNotFoundError, OSError, KeyError, json.JSONDecodeError):
+            return None
+
+    @staticmethod
+    async def _terminate(process: subprocess.Popen[bytes]) -> None:
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(asyncio.to_thread(process.wait), timeout=_TERM_GRACE_S)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+
+    @staticmethod
+    def _diagnose_failure(transcript: Path, stderr: Path, exit_code: int | None) -> str:
+        transcript_text = transcript.read_text(errors="replace") if transcript.exists() else ""
+        stderr_text = stderr.read_text(errors="replace") if stderr.exists() else ""
         parts = [
             f"agent failed (rc={exit_code})",
-            f"stderr={len(stderr)}B transcript={len(transcript)}B",
+            f"stderr={len(stderr_text)}B transcript={len(transcript_text)}B",
         ]
-        if "status_code=429" in transcript or "429" in stderr:
+        if "429" in stderr_text or "status_code=429" in transcript_text:
             parts.append("LLM rate-limited")
-        if stderr.strip():
-            parts.append(f"stderr tail: ...{stderr[-800:]}")
-        if transcript.strip():
-            parts.append(f"transcript tail: ...{transcript[-800:]}")
+        if stderr_text.strip():
+            parts.append(f"stderr tail: ...{stderr_text[-800:]}")
+        if transcript_text.strip():
+            parts.append(f"transcript tail: ...{transcript_text[-800:]}")
         return " | ".join(parts)

--- a/ale_run/agents/kimi_code/pyproject.toml
+++ b/ale_run/agents/kimi_code/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "ale-kimi-code"
+version = "0.1.0"
+description = "Kimi Code CLI in-sandbox deployer for ALE."
+requires-python = ">=3.12,<3.14"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = []
+sources = {}
+bypass-selection = true

--- a/ale_run/agents/kimi_code/telemetry.py
+++ b/ale_run/agents/kimi_code/telemetry.py
@@ -1,0 +1,457 @@
+"""Run-local OpenTelemetry capture and recovery for Kimi Code."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import json
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Iterator
+
+_RAW_CHUNK_BYTES = 512 * 1024
+_TRACE_PATH = "/v1/traces"
+
+OTEL_NPM_PACKAGE_VERSIONS = {
+    "@opentelemetry/sdk-node": "0.220.0",
+    "@opentelemetry/sdk-trace-base": "2.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.220.0",
+    "@opentelemetry/instrumentation-undici": "0.30.0",
+}
+OTEL_NPM_PACKAGES = tuple(
+    f"{name}@{version}" for name, version in OTEL_NPM_PACKAGE_VERSIONS.items()
+)
+
+OTEL_BOOTSTRAP_SOURCE = """\
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
+
+const endpoint = process.env.ALE_KIMI_OTEL_ENDPOINT;
+if (endpoint) {
+  const importOption = process.env.ALE_KIMI_OTEL_IMPORT_OPTION;
+  delete process.env.ALE_KIMI_OTEL_ENDPOINT;
+  delete process.env.ALE_KIMI_OTEL_IMPORT_OPTION;
+  if (importOption && process.env.NODE_OPTIONS) {
+    process.env.NODE_OPTIONS = process.env.NODE_OPTIONS.replace(importOption, "").trim();
+  }
+  const sdk = new NodeSDK({
+    serviceName: "kimi-code",
+    spanProcessors: [new SimpleSpanProcessor(
+      new OTLPTraceExporter({ url: `${endpoint}/v1/traces` })
+    )],
+    instrumentations: [new UndiciInstrumentation()],
+  });
+  sdk.start();
+  let stopping = false;
+  process.once("beforeExit", async () => {
+    if (stopping) return;
+    stopping = true;
+    try { await sdk.shutdown(); } catch {}
+  });
+}
+"""
+
+
+class KimiCodeOtelCollector:
+    """Receive OTLP/HTTP traces and persist a recoverable bounded-record WAL."""
+
+    def __init__(self, work_dir: Path):
+        self.work_dir = work_dir
+        self.raw_path = work_dir / "otel_requests.jsonl"
+        self.events_path = work_dir / "telemetry.jsonl"
+        self.summary_path = work_dir / "telemetry_summary.json"
+        self._lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def endpoint(self) -> str:
+        if self._server is None:
+            raise RuntimeError("Kimi Code OTel collector is not running")
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def start(self) -> None:
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        for path in (self.raw_path, self.events_path, self.summary_path):
+            path.unlink(missing_ok=True)
+        collector = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                if self.path != _TRACE_PATH:
+                    self.send_error(404)
+                    return
+                body = self._read_body()
+                if self.headers.get("Content-Encoding", "").lower() == "gzip":
+                    try:
+                        body = gzip.decompress(body)
+                    except (OSError, EOFError):
+                        pass
+                collector._store_request(dict(self.headers), body)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def _read_body(self) -> bytes:
+                if "chunked" in self.headers.get("Transfer-Encoding", "").lower():
+                    return _read_chunked_body(self.rfile)
+                return self.rfile.read(int(self.headers.get("Content-Length", "0")))
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="kimi-code-otel-collector",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+        recover_telemetry_artifacts(self.work_dir)
+
+    def _store_request(self, headers: dict[str, str], body: bytes) -> None:
+        request_id = uuid.uuid4().hex
+        chunks = [
+            body[offset : offset + _RAW_CHUNK_BYTES]
+            for offset in range(0, len(body), _RAW_CHUNK_BYTES)
+        ] or [b""]
+        with self._lock, self.raw_path.open("a", encoding="utf-8") as file:
+            for index, chunk in enumerate(chunks):
+                record: dict[str, Any] = {
+                    "record_type": "otlp_request_chunk",
+                    "request_id": request_id,
+                    "received_at": datetime.now(timezone.utc).isoformat(),
+                    "chunk_index": index,
+                    "chunk_count": len(chunks),
+                    "payload": base64.b64encode(chunk).decode("ascii"),
+                }
+                if index == 0:
+                    record.update(
+                        headers=headers,
+                        payload_bytes=len(body),
+                        payload_sha256=hashlib.sha256(body).hexdigest(),
+                    )
+                file.write(json.dumps(record, ensure_ascii=False) + "\n")
+            file.flush()
+            os.fsync(file.fileno())
+
+
+def write_otel_bootstrap(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(OTEL_BOOTSTRAP_SOURCE, encoding="utf-8")
+
+
+def recover_telemetry_artifacts(
+    work_dir: Path,
+    *,
+    wire_file: Path | None = None,
+) -> int:
+    """Rebuild normalized spans and summaries from the incrementally mirrored WAL."""
+    spans: list[dict[str, Any]] = []
+    raw_path = work_dir / "otel_requests.jsonl"
+    for received_at, payload in _read_otlp_payloads(raw_path):
+        spans.extend(_flatten_otlp_traces(payload, received_at))
+    spans.sort(key=lambda span: int(span.get("start_time_unix_nano") or 0))
+    _write_jsonl_atomic(work_dir / "telemetry.jsonl", spans)
+
+    http_calls = [_summarize_http_span(span, i) for i, span in enumerate(spans, 1)]
+    wire = _summarize_wire(wire_file)
+    model_http_calls = [call for call in http_calls if _is_model_endpoint(call.get("url"))]
+    llm_calls: list[dict[str, Any]] = []
+    for index in range(max(len(model_http_calls), len(wire["llm_calls"]))):
+        merged: dict[str, Any] = {"sequence": index + 1}
+        if index < len(model_http_calls):
+            merged.update(model_http_calls[index])
+        if index < len(wire["llm_calls"]):
+            merged.update(wire["llm_calls"][index])
+        merged["sequence"] = index + 1
+        llm_calls.append(merged)
+
+    summary = {
+        "span_count": len(spans),
+        "http_calls": http_calls,
+        "llm_calls": llm_calls,
+        "tool_executions": wire["tool_executions"],
+        "artifacts": {
+            "raw_otlp_requests": raw_path.name,
+            "spans": "telemetry.jsonl",
+            "wire": str(wire_file) if wire_file else None,
+        },
+    }
+    (work_dir / "telemetry_summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return len(spans)
+
+
+def _read_chunked_body(stream: Any) -> bytes:
+    body = bytearray()
+    while size_line := stream.readline():
+        try:
+            size = int(size_line.split(b";", 1)[0].strip(), 16)
+        except ValueError:
+            break
+        if size == 0:
+            stream.readline()
+            break
+        body += stream.read(size)
+        stream.readline()
+    return bytes(body)
+
+
+def _read_otlp_payloads(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
+    state: dict[str, Any] | None = None
+    for record in _iter_jsonl(path):
+        if record.get("record_type") != "otlp_request_chunk":
+            continue
+        request_id = record.get("request_id")
+        if state is None or state["request_id"] != request_id:
+            if state is not None:
+                decoded = _decode_payload(state)
+                if decoded:
+                    yield decoded
+            state = {
+                "request_id": request_id,
+                "received_at": record.get("received_at", ""),
+                "count": record.get("chunk_count"),
+                "sha256": record.get("payload_sha256"),
+                "chunks": {},
+            }
+        try:
+            state["chunks"][int(record["chunk_index"])] = base64.b64decode(
+                record["payload"],
+                validate=True,
+            )
+        except (KeyError, TypeError, ValueError):
+            state["invalid"] = True
+    if state is not None:
+        decoded = _decode_payload(state)
+        if decoded:
+            yield decoded
+
+
+def _decode_payload(state: dict[str, Any]) -> tuple[str, dict[str, Any]] | None:
+    count = state.get("count")
+    chunks = state["chunks"]
+    if state.get("invalid") or not isinstance(count, int) or len(chunks) != count:
+        return None
+    try:
+        body = b"".join(chunks[index] for index in range(count))
+    except KeyError:
+        return None
+    if state.get("sha256") and hashlib.sha256(body).hexdigest() != state["sha256"]:
+        return None
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return (str(state["received_at"]), payload) if isinstance(payload, dict) else None
+
+
+def _flatten_otlp_traces(payload: dict[str, Any], received_at: str) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
+    for resource_span in payload.get("resourceSpans", []):
+        resource = _attributes(resource_span.get("resource", {}).get("attributes", []))
+        for scope_span in resource_span.get("scopeSpans", []):
+            scope_data = scope_span.get("scope", {})
+            scope = {"name": scope_data.get("name"), "version": scope_data.get("version")}
+            for span in scope_span.get("spans", []):
+                spans.append(
+                    {
+                        "received_at": received_at,
+                        "trace_id": span.get("traceId"),
+                        "span_id": span.get("spanId"),
+                        "parent_span_id": span.get("parentSpanId"),
+                        "name": span.get("name"),
+                        "kind": span.get("kind"),
+                        "start_time_unix_nano": span.get("startTimeUnixNano"),
+                        "end_time_unix_nano": span.get("endTimeUnixNano"),
+                        "attributes": _attributes(span.get("attributes", [])),
+                        "status": span.get("status"),
+                        "events": span.get("events", []),
+                        "resource": resource,
+                        "scope": scope,
+                    }
+                )
+    return spans
+
+
+def _summarize_http_span(span: dict[str, Any], sequence: int) -> dict[str, Any]:
+    attrs = span.get("attributes", {})
+    start = _int_or_none(span.get("start_time_unix_nano"))
+    end = _int_or_none(span.get("end_time_unix_nano"))
+    return {
+        "sequence": sequence,
+        "method": attrs.get("http.request.method"),
+        "url": attrs.get("url.full"),
+        "status_code": attrs.get("http.response.status_code"),
+        "started_at": _format_time(start, 1_000_000_000),
+        "completed_at": _format_time(end, 1_000_000_000),
+        "duration_ms": round((end - start) / 1_000_000, 3)
+        if start is not None and end is not None
+        else None,
+        "trace_id": span.get("trace_id"),
+        "span_id": span.get("span_id"),
+    }
+
+
+def _summarize_wire(wire_file: Path | None) -> dict[str, list[dict[str, Any]]]:
+    llm_calls: list[dict[str, Any]] = []
+    tool_executions: list[dict[str, Any]] = []
+    requests: list[dict[str, Any]] = []
+    tools: dict[str, dict[str, Any]] = {}
+    if wire_file is None:
+        return {"llm_calls": llm_calls, "tool_executions": tool_executions}
+    for record in _iter_jsonl(wire_file):
+        if record.get("type") == "llm.request":
+            requests.append(record)
+            continue
+        if record.get("type") != "context.append_loop_event":
+            continue
+        event = record.get("event") or {}
+        event_type = event.get("type")
+        if event_type == "step.end":
+            request = requests.pop(0) if requests else {}
+            usage = event.get("usage") or {}
+            llm_calls.append(
+                {
+                    "model": request.get("model"),
+                    "provider": request.get("provider"),
+                    "thinking_effort": request.get("thinkingEffort"),
+                    "turn_step": request.get("turnStep"),
+                    "request_started_at": _format_time(
+                        _int_or_none(request.get("time")),
+                        1000,
+                    ),
+                    "request_completed_at": _format_time(
+                        _int_or_none(record.get("time")),
+                        1000,
+                    ),
+                    "message_id": event.get("messageId"),
+                    "finish_reason": event.get("finishReason"),
+                    "first_token_ms": event.get("llmFirstTokenLatencyMs"),
+                    "stream_duration_ms": event.get("llmStreamDurationMs"),
+                    "input_tokens": usage.get("inputOther"),
+                    "cache_read_tokens": usage.get("inputCacheRead"),
+                    "cache_creation_tokens": usage.get("inputCacheCreation"),
+                    "output_tokens": usage.get("output"),
+                }
+            )
+        elif event_type == "tool.call":
+            tool_id = event.get("toolCallId") or event.get("uuid")
+            if isinstance(tool_id, str):
+                tools[tool_id] = {
+                    "tool_call_id": tool_id,
+                    "tool_name": event.get("name"),
+                    "arguments": event.get("args"),
+                    "started_at": _format_time(_int_or_none(record.get("time")), 1000),
+                    "_started_ms": _int_or_none(record.get("time")),
+                }
+        elif event_type == "tool.result":
+            tool_id = event.get("toolCallId") or event.get("parentUuid")
+            if not isinstance(tool_id, str):
+                continue
+            tool = tools.pop(tool_id, {"tool_call_id": tool_id, "_started_ms": None})
+            completed = _int_or_none(record.get("time"))
+            started = tool.pop("_started_ms")
+            result = event.get("result") or {}
+            tool.update(
+                sequence=len(tool_executions) + 1,
+                completed_at=_format_time(completed, 1000),
+                duration_ms=completed - started
+                if completed is not None and started is not None
+                else None,
+                success=not bool(result.get("isError")),
+                error=result.get("error"),
+            )
+            tool_executions.append(tool)
+    return {"llm_calls": llm_calls, "tool_executions": tool_executions}
+
+
+def _is_model_endpoint(value: Any) -> bool:
+    return isinstance(value, str) and value.split("?", 1)[0].rstrip("/").endswith(
+        ("/chat/completions", "/responses", "/messages")
+    )
+
+
+def _attributes(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {item["key"]: _any_value(item.get("value")) for item in items if item.get("key")}
+
+
+def _any_value(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    for key in ("stringValue", "boolValue", "doubleValue", "bytesValue"):
+        if key in value:
+            return value[key]
+    if "intValue" in value:
+        return _int_or_none(value["intValue"])
+    if "arrayValue" in value:
+        return [_any_value(item) for item in value["arrayValue"].get("values", [])]
+    if "kvlistValue" in value:
+        return _attributes(value["kvlistValue"].get("values", []))
+    return value
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8", errors="replace") as file:
+        for line in file:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                yield record
+
+
+def _write_jsonl_atomic(path: Path, records: list[dict[str, Any]]) -> None:
+    temp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temp.open("w", encoding="utf-8") as file:
+            for record in records:
+                file.write(json.dumps(record, ensure_ascii=False) + "\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temp, path)
+    finally:
+        temp.unlink(missing_ok=True)
+
+
+def _format_time(value: int | None, divisor: int) -> str | None:
+    if value is None:
+        return None
+    return (
+        datetime.fromtimestamp(value / divisor, timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/ale_run/executors/sandbox.py
+++ b/ale_run/executors/sandbox.py
@@ -100,11 +100,19 @@ _TAIL_RECONCILE_TIMEOUT_S = 60.0
 _TAIL_RECONCILE_RETRIES = 3
 _TAIL_RECONCILE_DELAY_S = 1.0
 _TAIL_CHUNK_BYTES = 16 * 1024 * 1024
+_TAIL_LIVE_MAX_CHUNKS = 4
 
 # _tick_one return sentinels (negative = not a real remote byte size).
 _TICK_FAILED = -2    # download_range failed (transport / remote command error)
 _TICK_NO_FILE = -1   # remote file does not exist (yet)
 _TAIL_LIVE_FAIL_WARN = 3  # consecutive live-tick failures before a WARNING log
+
+
+@dataclass
+class _TailState:
+    committed: int
+    fetched: int
+    pending_path: Path
 
 
 @dataclass
@@ -592,7 +600,7 @@ def _build_launcher(
 async def tail_hot_artifacts(
     *,
     executor: BaseExecutor,
-    targets: list[tuple[str, Path]],   # [(sandbox_src, host_dst), ...]
+    targets: list[tuple[str, Path]],  # [(sandbox_src, host_dst), ...]
     stop_event: asyncio.Event,
     interval_s: float = _TAIL_INTERVAL_S,
 ) -> str | None:
@@ -600,11 +608,11 @@ async def tail_hot_artifacts(
     mirrors at ``interval_s`` cadence. Returns first reconcile error or
     ``None`` on clean stop.
 
-    JSONL boundary-safe: only commit bytes up to the last ``\\n`` so a
-    half-written record isn't appended; the same bytes are re-fetched
-    next tick once the writer flushes a newline.
+    JSONL boundary-safe: complete records are appended to ``dst`` while an
+    incomplete trailing record is spooled to a hidden host-side file. This
+    permits records larger than one range chunk without exposing partial JSONL.
     """
-    offsets: dict[str, int] = {src: _local_offset(dst) for src, dst in targets}
+    states = {src: _init_tail_state(dst) for src, dst in targets}
     fails: dict[str, int] = {src: 0 for src, _ in targets}
     while not stop_event.is_set():
         try:
@@ -613,11 +621,21 @@ async def tail_hot_artifacts(
         except asyncio.TimeoutError:
             pass
         for src, dst in targets:
-            try:
-                rc = await _tick_one(executor, src, dst, offsets)
-            except Exception as e:                                  # noqa: BLE001
-                rc = _TICK_FAILED
-                logger.debug("tail tick raised for %s: %s", src, e)
+            rc = _TICK_NO_FILE
+            for _ in range(_TAIL_LIVE_MAX_CHUNKS):
+                try:
+                    rc, progressed = await _tick_one(
+                        executor,
+                        src,
+                        dst,
+                        states[src],
+                    )
+                except Exception as e:                              # noqa: BLE001
+                    rc = _TICK_FAILED
+                    progressed = False
+                    logger.debug("tail tick raised for %s: %s", src, e)
+                if rc < 0 or not progressed or states[src].fetched >= rc:
+                    break
             # Don't fail silently: a persistently failing pull means the host
             # mirror is stalling (e.g. download_range broken / VM unreachable).
             if rc == _TICK_FAILED:
@@ -626,39 +644,65 @@ async def tail_hot_artifacts(
                     logger.warning(
                         "tail: %d consecutive failed pulls of %s — host mirror "
                         "stalling (retrying; final reconcile will report)",
-                        fails[src], src,
+                        fails[src],
+                        src,
                     )
             else:
                 fails[src] = 0
 
-    # Final reconcile: keep pulling each file until its size stops growing, so
-    # the host mirror is complete. A failed pull (_TICK_FAILED) must NOT be
-    # mistaken for "stable" — doing so silently dropped large transcripts
-    # (the failure sentinel repeated → looked like an unchanging size → break).
-    deadline = time.monotonic() + _TAIL_RECONCILE_TIMEOUT_S
+    # A stable remote size does not mean the host mirror has caught up. Drain
+    # until the fetched offset reaches that size, then confirm it once more.
     last_err: str | None = None
     for src, dst in targets:
+        deadline = time.monotonic() + _TAIL_RECONCILE_TIMEOUT_S
         prev_size: int | None = None
         target_err: str | None = None
-        for _ in range(_TAIL_RECONCILE_RETRIES + 1):
+        failed_pulls = 0
+        while True:
             if time.monotonic() > deadline:
-                target_err = (
-                    f"reconcile timeout after {_TAIL_RECONCILE_TIMEOUT_S}s for {src}"
-                )
+                target_err = f"reconcile timeout after {_TAIL_RECONCILE_TIMEOUT_S}s for {src}"
                 break
             try:
-                size = await _tick_one(executor, src, dst, offsets)
-            except Exception as e:                                  # noqa: BLE001
+                size, progressed = await _tick_one(
+                    executor,
+                    src,
+                    dst,
+                    states[src],
+                )
+            except Exception as e:  # noqa: BLE001
                 target_err = f"tick raised for {src}: {e}"
+                failed_pulls += 1
+                if failed_pulls > _TAIL_RECONCILE_RETRIES:
+                    break
                 await asyncio.sleep(_TAIL_RECONCILE_DELAY_S)
                 continue
             if size == _TICK_FAILED:
                 target_err = f"download_range failed for {src}"
+                failed_pulls += 1
+                if failed_pulls > _TAIL_RECONCILE_RETRIES:
+                    break
                 await asyncio.sleep(_TAIL_RECONCILE_DELAY_S)
                 continue
             target_err = None  # a successful pull clears a prior transient error
+            if size == _TICK_NO_FILE:
+                break
+            if states[src].fetched < size:
+                if progressed:
+                    failed_pulls = 0
+                    continue
+                target_err = (
+                    f"download_range made no progress for {src}: "
+                    f"offset={states[src].fetched} size={size}"
+                )
+                failed_pulls += 1
+                if failed_pulls > _TAIL_RECONCILE_RETRIES:
+                    break
+                await asyncio.sleep(_TAIL_RECONCILE_DELAY_S)
+                continue
+            failed_pulls = 0
             if size == prev_size:
-                break          # size stabilized → host mirror is complete
+                _discard_pending(states[src])
+                break
             prev_size = size
             await asyncio.sleep(_TAIL_RECONCILE_DELAY_S)
         if target_err and last_err is None:
@@ -670,47 +714,90 @@ async def _tick_one(
     executor: BaseExecutor,
     src: str,
     dst: Path,
-    offsets: dict[str, int],
-) -> int:
-    """Pull a chunk starting at ``offsets[src]``, commit jsonl-safe to
-    ``dst``, return the remote size."""
-    start = offsets[src]
+    state: _TailState,
+) -> tuple[int, bool]:
+    """Pull one chunk, commit complete JSONL records, return size/progress."""
+    start = state.fetched
     rr = await executor.download_range(
-        src=src, start=start, max_bytes=_TAIL_CHUNK_BYTES,
+        src=src,
+        start=start,
+        max_bytes=_TAIL_CHUNK_BYTES,
     )
     if not rr.success:
-        return _TICK_FAILED
+        return _TICK_FAILED, False
     size = rr.new_size
     if size == _TICK_NO_FILE:
-        offsets[src] = 0
+        state.committed = 0
+        state.fetched = 0
+        _discard_pending(state)
         if dst.exists():
             try:
                 dst.unlink()
             except OSError:
                 pass
-        return _TICK_NO_FILE
+        return _TICK_NO_FILE, False
     if size < start:
         # rotation/truncation
-        offsets[src] = 0
+        state.committed = 0
+        state.fetched = 0
+        _discard_pending(state)
         if dst.exists():
             try:
                 dst.unlink()
             except OSError:
                 pass
-        return size
+        return size, True
     delta = rr.new_data
     if not delta:
-        return size
+        return size, False
+
+    state.pending_path.parent.mkdir(parents=True, exist_ok=True)
+    pending_size = state.pending_path.stat().st_size if state.pending_path.exists() else 0
+    with state.pending_path.open("ab") as pending:
+        pending.write(delta)
+        pending.flush()
+    state.fetched += len(delta)
+
     last_nl = delta.rfind(b"\n")
     if last_nl == -1:
-        return size
-    safe = delta[: last_nl + 1]
+        return size, True
+
+    commit_bytes = pending_size + last_nl + 1
     dst.parent.mkdir(parents=True, exist_ok=True)
-    with open(dst, "ab") as f:
-        f.write(safe)
-        f.flush()
-    offsets[src] += len(safe)
-    return size
+    with state.pending_path.open("rb") as pending, dst.open("ab") as mirror:
+        remaining = commit_bytes
+        while remaining:
+            chunk = pending.read(min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            mirror.write(chunk)
+            remaining -= len(chunk)
+        mirror.flush()
+        leftover = pending.read()
+    if leftover:
+        state.pending_path.write_bytes(leftover)
+    else:
+        state.pending_path.unlink(missing_ok=True)
+    state.committed += commit_bytes
+    return size, True
+
+
+def _init_tail_state(dst: Path) -> _TailState:
+    committed = _local_offset(dst)
+    if dst.exists() and dst.stat().st_size != committed:
+        with dst.open("r+b") as file:
+            file.truncate(committed)
+    pending_path = dst.with_name(f".{dst.name}.tail-part")
+    pending_path.unlink(missing_ok=True)
+    return _TailState(
+        committed=committed,
+        fetched=committed,
+        pending_path=pending_path,
+    )
+
+
+def _discard_pending(state: _TailState) -> None:
+    state.pending_path.unlink(missing_ok=True)
 
 
 def _local_offset(dst: Path) -> int:
@@ -719,11 +806,20 @@ def _local_offset(dst: Path) -> int:
     if not dst.exists():
         return 0
     try:
-        data = dst.read_bytes()
+        size = dst.stat().st_size
+        with dst.open("rb") as file:
+            end = size
+            while end > 0:
+                start = max(0, end - 64 * 1024)
+                file.seek(start)
+                data = file.read(end - start)
+                last_nl = data.rfind(b"\n")
+                if last_nl != -1:
+                    return start + last_nl + 1
+                end = start
     except OSError:
         return 0
-    last_nl = data.rfind(b"\n")
-    return 0 if last_nl == -1 else last_nl + 1
+    return 0
 
 
 # ======================================================================

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 # check that an agent shortcut is recognized.
 _AGENT_FQNS: dict[str, str] = {
     "claude_code": "ale_run.agents.claude_code.deployer.ClaudeCodeDeployer",
+    "kimi_code": "ale_run.agents.kimi_code.deployer.KimiCodeDeployer",
     "ale_claw": "ale_run.agents.ale_claw.deployer.AleClawDeployer",
     "gemini_cli": "ale_run.agents.gemini_cli.deployer.GeminiCliDeployer",
     "grok_cli": "ale_run.agents.grok_cli.deployer.GrokCliDeployer",

--- a/ale_run/orchestration/lifecycle.py
+++ b/ale_run/orchestration/lifecycle.py
@@ -750,6 +750,7 @@ def _collect_env_passthrough() -> dict[str, str]:
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",
         "GROK_API_KEY",
+        "MOONSHOT_API_KEY",
         "FACTORY_API_KEY",
         "CURSOR_AUTH_JSON_PATH",
         "CURSOR_AUTH_JSON",

--- a/configs/agents/kimi_code.yaml
+++ b/configs/agents/kimi_code.yaml
@@ -11,17 +11,18 @@ config:
   base_url: https://api.moonshot.ai/v1
   provider_type: kimi
 
-  # Model metadata used by Kimi Code's environment-defined model alias.
-  max_context_size: 262144
+  # Kimi K3's tested model metadata.
+  max_context_size: 1048576
   capabilities:
     - image_in
     - thinking
-  thinking_effort: high
+  thinking_effort: max
 
-  # Disable anonymous product telemetry and background self-updates in runs.
+  # Keep Moonshot's anonymous product telemetry disabled. ALE's run-local
+  # OpenTelemetry capture separately records API and tool timings.
   disable_telemetry: true
+  otel_enabled: true
   disable_auto_update: true
 
-  # Official npm package. The deployer installs this exact version when absent
-  # or when the sandbox contains a different version.
+  # Official npm package, dynamically installed when absent or stale.
   cli_version: "@moonshot-ai/kimi-code@0.27.0"

--- a/configs/agents/kimi_code.yaml
+++ b/configs/agents/kimi_code.yaml
@@ -1,0 +1,27 @@
+# Kimi Code CLI using Moonshot's native Kimi API.
+# Auth: export MOONSHOT_API_KEY before launching the experiment.
+
+harness: kimi_code
+model: kimi-k3
+
+config:
+  # Direct Moonshot API routing. KIMI_MODEL_* values are injected only into
+  # the CLI process and are not persisted to Kimi Code's config.toml.
+  api_key_env: MOONSHOT_API_KEY
+  base_url: https://api.moonshot.ai/v1
+  provider_type: kimi
+
+  # Model metadata used by Kimi Code's environment-defined model alias.
+  max_context_size: 262144
+  capabilities:
+    - image_in
+    - thinking
+  thinking_effort: high
+
+  # Disable anonymous product telemetry and background self-updates in runs.
+  disable_telemetry: true
+  disable_auto_update: true
+
+  # Official npm package. The deployer installs this exact version when absent
+  # or when the sandbox contains a different version.
+  cli_version: "@moonshot-ai/kimi-code@0.27.0"

--- a/secret/.env.example
+++ b/secret/.env.example
@@ -16,6 +16,7 @@
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
 OPENAI_API_KEY=
+MOONSHOT_API_KEY=
 
 # Optional — only needed if you re-enable ale_claw's `web_search` tool.
 BRAVE_API_KEY=

--- a/tests/ale_run/test_baked_in_sandbox.py
+++ b/tests/ale_run/test_baked_in_sandbox.py
@@ -127,6 +127,7 @@ def test_reference_password_is_not_forwarded_to_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "agent-key")
+    monkeypatch.setenv("MOONSHOT_API_KEY", "moonshot-key")
     monkeypatch.setenv(
         baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
         "host-only-password",
@@ -135,6 +136,7 @@ def test_reference_password_is_not_forwarded_to_agent(
     env = _collect_env_passthrough()
 
     assert env["OPENAI_API_KEY"] == "agent-key"
+    assert env["MOONSHOT_API_KEY"] == "moonshot-key"
     assert baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV not in env
 
 

--- a/tests/ale_run/test_kimi_code.py
+++ b/tests/ale_run/test_kimi_code.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import json
 import base64
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
 from ale_run.agents.kimi_code.config import KimiCodeConfig
-from ale_run.agents.kimi_code.deployer import (
-    KimiCodeDeployer,
-    _expected_version,
-)
+from ale_run.agents.kimi_code.deployer import KimiCodeDeployer, _expected_version
 from ale_run.base_interface import AgentRunResult, TrajectoryBuilder
 from ale_run.orchestration.factory import AGENT_REGISTRY
 
@@ -23,8 +20,29 @@ def _builder() -> TrajectoryBuilder:
     )
 
 
+def _parse(tmp_path: Path) -> TrajectoryBuilder:
+    builder = _builder()
+    KimiCodeDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=KimiCodeConfig(),
+        run_result=AgentRunResult(status="completed", exit_code=0),
+        builder=builder,
+    )
+    return builder
+
+
 def test_kimi_code_is_registered() -> None:
     assert AGENT_REGISTRY["kimi_code"] is KimiCodeDeployer
+
+
+def test_config_matches_tested_k3_settings() -> None:
+    config = KimiCodeConfig()
+
+    assert config.model == "kimi-k3"
+    assert config.max_context_size == 1_048_576
+    assert config.thinking_effort == "max"
+    assert config.otel_enabled is True
+    assert config.cli_version == "@moonshot-ai/kimi-code@0.27.0"
 
 
 def test_expected_version_parses_scoped_npm_spec() -> None:
@@ -44,9 +62,40 @@ def test_build_env_uses_ephemeral_model_overlay(tmp_path: Path) -> None:
     assert env["KIMI_CODE_HOME"] == str(tmp_path / "kimi-home")
     assert env["KIMI_MODEL_NAME"] == "kimi-k3"
     assert env["KIMI_MODEL_API_KEY"] == "test-key"
+    assert env["KIMI_MODEL_MAX_CONTEXT_SIZE"] == "1048576"
     assert env["KIMI_MODEL_CAPABILITIES"] == "image_in,thinking"
+    assert env["KIMI_MODEL_THINKING_EFFORT"] == "max"
+    assert env["KIMI_MODEL_OUTPUT_FORMAT"] == "stream-json"
     assert env["KIMI_DISABLE_TELEMETRY"] == "1"
     assert env["KIMI_CODE_NO_AUTO_UPDATE"] == "1"
+
+
+def test_build_env_injects_run_local_otel(tmp_path: Path) -> None:
+    executor = SimpleNamespace(
+        config=KimiCodeConfig(),
+        env={"MOONSHOT_API_KEY": "test-key", "NODE_OPTIONS": "--trace-warnings"},
+    )
+    deployer = KimiCodeDeployer(executor)
+    bootstrap = tmp_path / "node_modules" / "ale-kimi-otel" / "bootstrap.mjs"
+    bootstrap.parent.mkdir(parents=True)
+    bootstrap.write_text("", encoding="utf-8")
+
+    env = deployer._build_env(
+        executor.config,
+        work_dir=tmp_path,
+        otel_endpoint="http://127.0.0.1:4318",
+        otel_bootstrap=bootstrap,
+    )
+
+    import_option = f"--import={bootstrap.resolve().as_uri()}"
+    assert env["ALE_KIMI_OTEL_ENDPOINT"] == "http://127.0.0.1:4318"
+    assert env["ALE_KIMI_OTEL_IMPORT_OPTION"] == import_option
+    assert env["NODE_OPTIONS"] == f"--trace-warnings {import_option}"
+
+
+def test_raw_telemetry_wal_is_incrementally_mirrored() -> None:
+    assert "otel_requests.jsonl" in KimiCodeDeployer.hot_artifacts
+    assert "telemetry.jsonl" not in KimiCodeDeployer.hot_artifacts
 
 
 def test_parse_wire_preserves_tools_images_usage_and_latency(tmp_path: Path) -> None:
@@ -123,22 +172,15 @@ def test_parse_wire_preserves_tools_images_usage_and_latency(tmp_path: Path) -> 
                 },
                 "llmFirstTokenLatencyMs": 500,
                 "llmStreamDurationMs": 250,
-                "messageId": "message-1",
             },
         },
     ]
     wire.write_text(
-        "\n".join(json.dumps(record) for record in records),
+        "\n".join(json.dumps(record) for record in records) + "\n",
         encoding="utf-8",
     )
-    builder = _builder()
 
-    KimiCodeDeployer.parse_artifacts(
-        work_dir=tmp_path,
-        config=KimiCodeConfig(),
-        run_result=AgentRunResult(status="completed", exit_code=0),
-        builder=builder,
-    )
+    builder = _parse(tmp_path)
 
     agent_step, environment_step = builder.trajectory.steps
     assert agent_step.reasoning == "Inspect the screen."
@@ -153,100 +195,165 @@ def test_parse_wire_preserves_tools_images_usage_and_latency(tmp_path: Path) -> 
     assert image.type == "base64"
     assert image.media_type == "image/png"
     assert image.data == "aW1hZ2U="
-    assert builder.trajectory.extra["kimi_code"]["llm_requests"][0]["model"] == "kimi-k3"
 
 
-def test_parse_wire_rehydrates_kimi_blobref_images(tmp_path: Path) -> None:
+def test_parse_wire_rehydrates_blobref_image(tmp_path: Path) -> None:
     agent_dir = tmp_path / "kimi-home" / "sessions" / "workspace" / "session" / "agents" / "main"
-    wire = agent_dir / "wire.jsonl"
     blobs = agent_dir / "blobs"
     blobs.mkdir(parents=True)
     image_bytes = b"png-bytes"
     (blobs / "image-hash").write_bytes(image_bytes)
-    records = [
-        {
-            "type": "context.append_loop_event",
-            "event": {"type": "step.begin", "uuid": "step-1"},
-        },
-        {
-            "type": "context.append_loop_event",
-            "event": {
-                "type": "tool.result",
-                "toolCallId": "call-1",
-                "result": {
-                    "output": [
-                        {
-                            "type": "image_url",
-                            "imageUrl": {"url": "blobref:image/png;image-hash"},
-                        }
-                    ]
+    (agent_dir / "wire.jsonl").write_text(
+        "\n".join(
+            json.dumps(record)
+            for record in [
+                {
+                    "type": "context.append_loop_event",
+                    "event": {"type": "step.begin"},
                 },
-            },
-        },
-        {
-            "type": "context.append_loop_event",
-            "event": {"type": "step.end", "usage": {}},
-        },
-    ]
-    wire.write_text(
-        "\n".join(json.dumps(record) for record in records),
+                {
+                    "type": "context.append_loop_event",
+                    "event": {
+                        "type": "tool.result",
+                        "toolCallId": "call-1",
+                        "result": {
+                            "output": [
+                                {
+                                    "type": "image_url",
+                                    "imageUrl": {"url": "blobref:image/png;image-hash"},
+                                }
+                            ]
+                        },
+                    },
+                },
+                {
+                    "type": "context.append_loop_event",
+                    "event": {"type": "step.end", "usage": {}},
+                },
+            ]
+        )
+        + "\n",
         encoding="utf-8",
     )
-    builder = _builder()
 
-    KimiCodeDeployer.parse_artifacts(
-        work_dir=tmp_path,
-        config=KimiCodeConfig(),
-        run_result=AgentRunResult(status="completed", exit_code=0),
-        builder=builder,
-    )
+    image = _parse(tmp_path).trajectory.steps[-1].observation.results[0].content[0].image
 
-    image = builder.trajectory.steps[-1].observation.results[0].content[0].image
     assert image.type == "base64"
-    assert image.media_type == "image/png"
     assert image.data == base64.b64encode(image_bytes).decode("ascii")
 
 
-def test_parse_transcript_fallback(tmp_path: Path) -> None:
-    transcript = tmp_path / "transcript.jsonl"
-    transcript.write_text(
+def test_missing_blob_uses_json_string_transcript_image(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "kimi-home" / "sessions" / "workspace" / "session" / "agents" / "main"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "wire.jsonl").write_text(
         "\n".join(
-            [
-                json.dumps(
-                    {
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "id": "call-1",
-                                "function": {
-                                    "name": "Bash",
-                                    "arguments": '{"command":"pwd"}',
-                                },
-                            }
-                        ],
-                    }
-                ),
-                json.dumps(
-                    {
-                        "role": "tool",
-                        "tool_call_id": "call-1",
-                        "content": "/tmp/work\n",
-                    }
-                ),
-                json.dumps({"role": "assistant", "content": "/tmp/work"}),
+            json.dumps(record)
+            for record in [
+                {
+                    "type": "context.append_loop_event",
+                    "event": {"type": "step.begin"},
+                },
+                {
+                    "type": "context.append_loop_event",
+                    "event": {
+                        "type": "tool.result",
+                        "toolCallId": "call-1",
+                        "result": {
+                            "output": [
+                                {
+                                    "type": "image_url",
+                                    "imageUrl": {"url": "blobref:image/png;already-deleted"},
+                                }
+                            ]
+                        },
+                    },
+                },
+                {
+                    "type": "context.append_loop_event",
+                    "event": {"type": "step.end", "usage": {}},
+                },
             ]
-        ),
+        )
+        + "\n",
         encoding="utf-8",
     )
-    builder = _builder()
-
-    KimiCodeDeployer.parse_artifacts(
-        work_dir=tmp_path,
-        config=KimiCodeConfig(),
-        run_result=AgentRunResult(status="completed", exit_code=0),
-        builder=builder,
+    inline_image = base64.b64encode(b"transcript-image").decode("ascii")
+    (tmp_path / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": json.dumps(
+                    [
+                        {
+                            "type": "image_url",
+                            "imageUrl": {"url": f"data:image/png;base64,{inline_image}"},
+                        }
+                    ]
+                ),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
     )
 
-    assert builder.trajectory.steps[0].tool_calls[0].arguments == {"command": "pwd"}
-    assert builder.trajectory.steps[1].observation.results[0].content[0].text == "/tmp/work\n"
-    assert builder.trajectory.steps[2].message == "/tmp/work"
+    image = _parse(tmp_path).trajectory.steps[-1].observation.results[0].content[0].image
+
+    assert image.type == "base64"
+    assert image.data == inline_image
+
+
+def test_transcript_only_json_string_image_is_preserved(tmp_path: Path) -> None:
+    inline_image = base64.b64encode(b"transcript-only-image").decode("ascii")
+    (tmp_path / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": json.dumps(
+                    [
+                        {"type": "text", "text": "Screenshot captured."},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{inline_image}"},
+                        },
+                    ]
+                ),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    content = _parse(tmp_path).trajectory.steps[0].observation.results[0].content
+
+    assert content[0].text == "Screenshot captured."
+    assert content[1].image.type == "base64"
+    assert content[1].image.data == inline_image
+
+
+def test_transcript_blobref_without_blob_directory_is_not_persisted(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": json.dumps(
+                    [
+                        {
+                            "type": "image_url",
+                            "imageUrl": {"url": "blobref:image/png;already-deleted"},
+                        }
+                    ]
+                ),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    content = _parse(tmp_path).trajectory.steps[0].observation.results[0].content
+
+    assert content == []

--- a/tests/ale_run/test_kimi_code.py
+++ b/tests/ale_run/test_kimi_code.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+from ale_run.agents.kimi_code.config import KimiCodeConfig
+from ale_run.agents.kimi_code.deployer import (
+    KimiCodeDeployer,
+    _expected_version,
+)
+from ale_run.base_interface import AgentRunResult, TrajectoryBuilder
+from ale_run.orchestration.factory import AGENT_REGISTRY
+
+
+def _builder() -> TrajectoryBuilder:
+    return TrajectoryBuilder(
+        agent_name="kimi-code",
+        model="kimi-k3",
+        task_path="demo/seecheck",
+        variant_index=0,
+    )
+
+
+def test_kimi_code_is_registered() -> None:
+    assert AGENT_REGISTRY["kimi_code"] is KimiCodeDeployer
+
+
+def test_expected_version_parses_scoped_npm_spec() -> None:
+    assert _expected_version("@moonshot-ai/kimi-code@0.27.0") == "0.27.0"
+    assert _expected_version("@moonshot-ai/kimi-code") is None
+
+
+def test_build_env_uses_ephemeral_model_overlay(tmp_path: Path) -> None:
+    executor = SimpleNamespace(
+        config=KimiCodeConfig(),
+        env={"MOONSHOT_API_KEY": "test-key"},
+    )
+    deployer = KimiCodeDeployer(executor)
+
+    env = deployer._build_env(executor.config, work_dir=tmp_path)
+
+    assert env["KIMI_CODE_HOME"] == str(tmp_path / "kimi-home")
+    assert env["KIMI_MODEL_NAME"] == "kimi-k3"
+    assert env["KIMI_MODEL_API_KEY"] == "test-key"
+    assert env["KIMI_MODEL_CAPABILITIES"] == "image_in,thinking"
+    assert env["KIMI_DISABLE_TELEMETRY"] == "1"
+    assert env["KIMI_CODE_NO_AUTO_UPDATE"] == "1"
+
+
+def test_parse_wire_preserves_tools_images_usage_and_latency(tmp_path: Path) -> None:
+    wire = (
+        tmp_path
+        / "kimi-home"
+        / "sessions"
+        / "workspace"
+        / "session"
+        / "agents"
+        / "main"
+        / "wire.jsonl"
+    )
+    wire.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "llm.request",
+            "provider": "kimi",
+            "model": "kimi-k3",
+            "turnStep": "0.1",
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {"type": "step.begin", "uuid": "step-1"},
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "part": {"type": "think", "think": "Inspect the screen."},
+            },
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "tool.call",
+                "toolCallId": "call-1",
+                "name": "mcp__cua__screenshot",
+                "args": {},
+            },
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "tool.result",
+                "toolCallId": "call-1",
+                "result": {
+                    "output": [
+                        {"type": "text", "text": "Screenshot captured."},
+                        {
+                            "type": "image_url",
+                            "imageUrl": {"url": "data:image/png;base64,aW1hZ2U="},
+                        },
+                    ]
+                },
+            },
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "part": {"type": "text", "text": "The desktop is visible."},
+            },
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "step.end",
+                "usage": {
+                    "inputOther": 100,
+                    "inputCacheRead": 200,
+                    "inputCacheCreation": 30,
+                    "output": 40,
+                },
+                "llmFirstTokenLatencyMs": 500,
+                "llmStreamDurationMs": 250,
+                "messageId": "message-1",
+            },
+        },
+    ]
+    wire.write_text(
+        "\n".join(json.dumps(record) for record in records),
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    KimiCodeDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=KimiCodeConfig(),
+        run_result=AgentRunResult(status="completed", exit_code=0),
+        builder=builder,
+    )
+
+    agent_step, environment_step = builder.trajectory.steps
+    assert agent_step.reasoning == "Inspect the screen."
+    assert agent_step.message == "The desktop is visible."
+    assert agent_step.tool_calls[0].name == "mcp__cua__screenshot"
+    assert agent_step.metrics.input_tokens == 100
+    assert agent_step.metrics.cache_read_tokens == 200
+    assert agent_step.metrics.cache_creation_tokens == 30
+    assert agent_step.metrics.output_tokens == 40
+    assert agent_step.metrics.duration_ms == 750
+    image = environment_step.observation.results[0].content[1].image
+    assert image.type == "base64"
+    assert image.media_type == "image/png"
+    assert image.data == "aW1hZ2U="
+    assert builder.trajectory.extra["kimi_code"]["llm_requests"][0]["model"] == "kimi-k3"
+
+
+def test_parse_wire_rehydrates_kimi_blobref_images(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "kimi-home" / "sessions" / "workspace" / "session" / "agents" / "main"
+    wire = agent_dir / "wire.jsonl"
+    blobs = agent_dir / "blobs"
+    blobs.mkdir(parents=True)
+    image_bytes = b"png-bytes"
+    (blobs / "image-hash").write_bytes(image_bytes)
+    records = [
+        {
+            "type": "context.append_loop_event",
+            "event": {"type": "step.begin", "uuid": "step-1"},
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "tool.result",
+                "toolCallId": "call-1",
+                "result": {
+                    "output": [
+                        {
+                            "type": "image_url",
+                            "imageUrl": {"url": "blobref:image/png;image-hash"},
+                        }
+                    ]
+                },
+            },
+        },
+        {
+            "type": "context.append_loop_event",
+            "event": {"type": "step.end", "usage": {}},
+        },
+    ]
+    wire.write_text(
+        "\n".join(json.dumps(record) for record in records),
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    KimiCodeDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=KimiCodeConfig(),
+        run_result=AgentRunResult(status="completed", exit_code=0),
+        builder=builder,
+    )
+
+    image = builder.trajectory.steps[-1].observation.results[0].content[0].image
+    assert image.type == "base64"
+    assert image.media_type == "image/png"
+    assert image.data == base64.b64encode(image_bytes).decode("ascii")
+
+
+def test_parse_transcript_fallback(tmp_path: Path) -> None:
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "function": {
+                                    "name": "Bash",
+                                    "arguments": '{"command":"pwd"}',
+                                },
+                            }
+                        ],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call-1",
+                        "content": "/tmp/work\n",
+                    }
+                ),
+                json.dumps({"role": "assistant", "content": "/tmp/work"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    KimiCodeDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=KimiCodeConfig(),
+        run_result=AgentRunResult(status="completed", exit_code=0),
+        builder=builder,
+    )
+
+    assert builder.trajectory.steps[0].tool_calls[0].arguments == {"command": "pwd"}
+    assert builder.trajectory.steps[1].observation.results[0].content[0].text == "/tmp/work\n"
+    assert builder.trajectory.steps[2].message == "/tmp/work"

--- a/tests/ale_run/test_kimi_code_telemetry.py
+++ b/tests/ale_run/test_kimi_code_telemetry.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+import socket
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
+from ale_run.agents.kimi_code.telemetry import (
+    KimiCodeOtelCollector,
+    OTEL_BOOTSTRAP_SOURCE,
+    recover_telemetry_artifacts,
+)
+
+
+def _trace_payload(*spans: dict) -> dict:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {
+                            "key": "service.name",
+                            "value": {"stringValue": "kimi-code"},
+                        }
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {
+                            "name": "@opentelemetry/instrumentation-undici",
+                            "version": "0.30.0",
+                        },
+                        "spans": list(spans),
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _http_span(
+    *,
+    url: str = "https://api.moonshot.ai/v1/chat/completions",
+    start_ns: int = 1_784_407_264_183_000_000,
+    end_ns: int = 1_784_407_270_091_376_893,
+    large_value: str | None = None,
+) -> dict:
+    attributes = [
+        {"key": "http.request.method", "value": {"stringValue": "POST"}},
+        {"key": "url.full", "value": {"stringValue": url}},
+        {"key": "http.response.status_code", "value": {"intValue": 200}},
+    ]
+    if large_value is not None:
+        attributes.append({"key": "test.large", "value": {"stringValue": large_value}})
+    return {
+        "traceId": "4b47440a5c43f2ef9130810c88275e8a",
+        "spanId": "2e8c9e1560d79b14",
+        "name": "POST",
+        "kind": 3,
+        "startTimeUnixNano": str(start_ns),
+        "endTimeUnixNano": str(end_ns),
+        "attributes": attributes,
+        "status": {"code": 0},
+        "events": [],
+    }
+
+
+def _post_json(url: str, payload: dict) -> None:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        assert response.status == 200
+
+
+def _post_chunked(url: str, payload: dict) -> None:
+    parsed = urlparse(url)
+    body = json.dumps(payload).encode()
+    frame = b"%x\r\n%s\r\n0\r\n\r\n" % (len(body), body)
+    request = (
+        f"POST {parsed.path} HTTP/1.1\r\n"
+        f"Host: {parsed.hostname}:{parsed.port}\r\n"
+        "Content-Type: application/json\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "Connection: close\r\n\r\n"
+    ).encode() + frame
+    with socket.create_connection((parsed.hostname, parsed.port), timeout=5) as sock:
+        sock.sendall(request)
+        response = b""
+        while data := sock.recv(4096):
+            response += data
+    assert b"200" in response.split(b"\r\n", 1)[0]
+
+
+def test_collector_reads_chunked_trace_and_builds_summary(tmp_path: Path) -> None:
+    collector = KimiCodeOtelCollector(tmp_path)
+    collector.start()
+    _post_chunked(collector.endpoint + "/v1/traces", _trace_payload(_http_span()))
+    collector.stop()
+
+    spans = [json.loads(line) for line in collector.events_path.read_text().splitlines()]
+    assert len(spans) == 1
+    summary = json.loads(collector.summary_path.read_text())
+    call = summary["http_calls"][0]
+    assert summary["span_count"] == 1
+    assert call["url"] == "https://api.moonshot.ai/v1/chat/completions"
+    assert call["status_code"] == 200
+    assert call["duration_ms"] == 5908.377
+
+
+def test_large_trace_wal_records_are_bounded_and_recoverable(
+    tmp_path: Path,
+) -> None:
+    large_value = "x" * (2 * 1024 * 1024)
+    collector = KimiCodeOtelCollector(tmp_path)
+    collector.start()
+    _post_json(
+        collector.endpoint + "/v1/traces",
+        _trace_payload(_http_span(large_value=large_value)),
+    )
+    collector.stop()
+
+    raw_lines = collector.raw_path.read_bytes().splitlines()
+    assert len(raw_lines) > 1
+    assert max(map(len, raw_lines)) < 1024 * 1024
+
+    collector.events_path.unlink()
+    collector.summary_path.unlink()
+    assert recover_telemetry_artifacts(tmp_path) == 1
+    recovered = json.loads(collector.events_path.read_text())
+    assert recovered["attributes"]["test.large"] == large_value
+
+
+def test_recovery_ignores_incomplete_final_otlp_request(tmp_path: Path) -> None:
+    collector = KimiCodeOtelCollector(tmp_path)
+    collector._store_request({}, json.dumps(_trace_payload(_http_span())).encode())
+    collector._store_request({}, b'{"resourceSpans":"' + b"x" * (2 * 1024 * 1024))
+    lines = collector.raw_path.read_text().splitlines()
+    collector.raw_path.write_text("\n".join(lines[:-1]) + "\n")
+
+    assert recover_telemetry_artifacts(tmp_path) == 1
+    assert json.loads(collector.summary_path.read_text())["span_count"] == 1
+
+
+def test_summary_merges_http_usage_latency_and_tool_timing(tmp_path: Path) -> None:
+    collector = KimiCodeOtelCollector(tmp_path)
+    collector._store_request({}, json.dumps(_trace_payload(_http_span())).encode())
+    wire = tmp_path / "wire.jsonl"
+    wire.write_text(
+        "\n".join(
+            json.dumps(record)
+            for record in [
+                {
+                    "type": "llm.request",
+                    "model": "kimi-k3",
+                    "provider": "kimi",
+                    "thinkingEffort": "max",
+                    "turnStep": "0.1",
+                    "time": 1_784_407_264_183,
+                },
+                {
+                    "type": "context.append_loop_event",
+                    "event": {
+                        "type": "tool.call",
+                        "toolCallId": "Bash_0",
+                        "name": "Bash",
+                        "args": {"command": "sleep 1"},
+                    },
+                    "time": 1_784_407_269_000,
+                },
+                {
+                    "type": "context.append_loop_event",
+                    "event": {
+                        "type": "tool.result",
+                        "toolCallId": "Bash_0",
+                        "result": {"output": "ok"},
+                    },
+                    "time": 1_784_407_270_010,
+                },
+                {
+                    "type": "context.append_loop_event",
+                    "event": {
+                        "type": "step.end",
+                        "finishReason": "tool_use",
+                        "messageId": "chatcmpl-test",
+                        "llmFirstTokenLatencyMs": 4575,
+                        "llmStreamDurationMs": 914,
+                        "llmRequestBuildMs": 15,
+                        "usage": {
+                            "inputOther": 7095,
+                            "inputCacheRead": 18944,
+                            "inputCacheCreation": 0,
+                            "output": 53,
+                        },
+                    },
+                    "time": 1_784_407_270_091,
+                },
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert recover_telemetry_artifacts(tmp_path, wire_file=wire) == 1
+    summary = json.loads(collector.summary_path.read_text())
+    llm = summary["llm_calls"][0]
+    assert llm["model"] == "kimi-k3"
+    assert llm["message_id"] == "chatcmpl-test"
+    assert llm["first_token_ms"] == 4575
+    assert llm["cache_read_tokens"] == 18944
+    assert llm["duration_ms"] == 5908.377
+    tool = summary["tool_executions"][0]
+    assert tool["tool_name"] == "Bash"
+    assert tool["duration_ms"] == 1010
+    assert tool["success"] is True
+
+
+def test_bootstrap_uses_json_otlp_without_console_output() -> None:
+    assert "UndiciInstrumentation" in OTEL_BOOTSTRAP_SOURCE
+    assert "OTLPTraceExporter" in OTEL_BOOTSTRAP_SOURCE
+    assert "SimpleSpanProcessor" in OTEL_BOOTSTRAP_SOURCE
+    assert "ConsoleSpanExporter" not in OTEL_BOOTSTRAP_SOURCE

--- a/tests/test_tail_reconcile.py
+++ b/tests/test_tail_reconcile.py
@@ -8,6 +8,7 @@ The reconcile must now report an error when pulls keep failing.
 
 Run: ``python tests/test_tail_reconcile.py``.
 """
+
 import asyncio
 import os
 import sys
@@ -22,8 +23,13 @@ S._TAIL_RECONCILE_DELAY_S = 0.0  # speed up the bounded reconcile retries
 
 
 class _MockExec:
-    def __init__(self, *, content=b"", fail=False, missing=False):
-        self.content, self.fail, self.missing = content, fail, missing
+    def __init__(self, *, content=b"", fail=False, missing=False, stagnant=False):
+        self.content, self.fail, self.missing, self.stagnant = (
+            content,
+            fail,
+            missing,
+            stagnant,
+        )
         self.calls = 0
 
     async def download_range(self, *, src, start, max_bytes):
@@ -32,20 +38,33 @@ class _MockExec:
             return RangeResult(success=False, error="simulated transport error")
         if self.missing:
             return RangeResult(success=True, new_size=-1)
-        return RangeResult(success=True, new_size=len(self.content),
-                           new_data=self.content[start:start + max_bytes])
+        if self.stagnant:
+            return RangeResult(success=True, new_size=len(self.content), new_data=b"")
+        return RangeResult(
+            success=True,
+            new_size=len(self.content),
+            new_data=self.content[start : start + max_bytes],
+        )
 
 
-def _run(content=b"", fail=False, missing=False):
-    ex = _MockExec(content=content, fail=fail, missing=missing)
+def _run(content=b"", fail=False, missing=False, stagnant=False):
+    ex = _MockExec(
+        content=content,
+        fail=fail,
+        missing=missing,
+        stagnant=stagnant,
+    )
     d = tempfile.mkdtemp()
     dst = os.path.join(d, "transcript.jsonl")
     stop = asyncio.Event()
     stop.set()  # skip the live loop; exercise the reconcile directly
-    err = asyncio.run(S.tail_hot_artifacts(
-        executor=ex, targets=[("C:\\x\\transcript.jsonl", __import__("pathlib").Path(dst))],
-        stop_event=stop,
-    ))
+    err = asyncio.run(
+        S.tail_hot_artifacts(
+            executor=ex,
+            targets=[("C:\\x\\transcript.jsonl", __import__("pathlib").Path(dst))],
+            stop_event=stop,
+        )
+    )
     return err, dst, ex
 
 
@@ -83,9 +102,50 @@ def test_jsonl_boundary_safe():
     assert got == b'{"done":1}\n', f"committed a partial line: {got!r}"
 
 
+def test_reconcile_drains_more_than_two_chunks():
+    original = S._TAIL_CHUNK_BYTES
+    S._TAIL_CHUNK_BYTES = 8
+    try:
+        content = b"".join(b'{"n":%d}\n' % index for index in range(10))
+        err, dst, ex = _run(content=content)
+    finally:
+        S._TAIL_CHUNK_BYTES = original
+    assert err is None
+    with open(dst, "rb") as f:
+        assert f.read() == content
+    assert ex.calls > 2
+
+
+def test_jsonl_record_larger_than_range_chunk():
+    original = S._TAIL_CHUNK_BYTES
+    S._TAIL_CHUNK_BYTES = 8
+    try:
+        content = b'{"image":"' + b"x" * 80 + b'"}\n'
+        err, dst, ex = _run(content=content)
+    finally:
+        S._TAIL_CHUNK_BYTES = original
+    assert err is None
+    with open(dst, "rb") as f:
+        assert f.read() == content
+    assert ex.calls > 10
+    assert not os.path.exists(
+        os.path.join(os.path.dirname(dst), f".{os.path.basename(dst)}.tail-part")
+    )
+
+
+def test_reconcile_reports_repeated_no_progress():
+    err, _, ex = _run(content=b'{"a":1}\n', stagnant=True)
+    assert err is not None
+    assert "no progress" in err
+    assert ex.calls == S._TAIL_RECONCILE_RETRIES + 1
+
+
 if __name__ == "__main__":
     test_persistent_failure_is_reported()
     test_success_mirrors_and_no_error()
     test_missing_file_is_not_an_error()
     test_jsonl_boundary_safe()
+    test_reconcile_drains_more_than_two_chunks()
+    test_jsonl_record_larger_than_range_chunk()
+    test_reconcile_reports_repeated_no_progress()
     print("test_tail_reconcile: ALL PASS")


### PR DESCRIPTION
## Summary

- add a native ALE harness for the official Kimi Code CLI without modifying or vendoring upstream source
- dynamically install and verify `@moonshot-ai/kimi-code@0.27.0` inside each sandbox
- configure Kimi K3 through Kimi Code's supported environment overlay, using the validated 1,048,576-token context and `max` reasoning effort
- expose ALE's existing CUA MCP bridge through a run-local Kimi Code configuration
- produce standard ALE trajectories, token usage, screenshots, output artifacts, and run-local telemetry

## Artifact reliability

Kimi Code has two complementary logs:

- `transcript.jsonl` is the stable streamed CLI output and is incrementally mirrored while the task runs
- `wire.jsonl` is the richer session log used for reasoning, tool calls, token usage, and model latency fields during final parsing

Screenshot tool results require extra handling because Kimi may delete session blob files before ALE gathers the final directory. The parser now:

1. resolves durable `blobref:` files when they still exist
2. decodes JSON-string tool content from the incrementally mirrored transcript
3. falls back to the transcript's inline image when the corresponding blob has already been deleted
4. rejects unresolved `blobref:` values instead of persisting broken image URLs

This preserves the standard ALE behavior: inline images are extracted to the run's `screenshots/` directory and trajectory references are rewritten to paths.

The shared sandbox incremental puller is also fixed for large JSONL artifacts. Final reconciliation now drains until the host offset reaches the remote byte size, rather than treating a stable remote size as proof that the host has caught up. Incomplete records are spooled locally, allowing a single JSONL record to exceed the 16 MiB range chunk without truncation or repeated re-download.

## Telemetry

Each run starts a loopback OTLP/HTTP collector and loads standard OpenTelemetry Undici instrumentation through `NODE_OPTIONS`. No Kimi Code source changes are required.

- `otel_requests.jsonl`: authoritative bounded-record WAL, incrementally mirrored during the run
- `telemetry.jsonl`: normalized HTTP spans rebuilt from the WAL
- `telemetry_summary.json`: API duration/status/trace IDs merged with Kimi wire usage, first-token and stream latency, plus per-tool execution duration

The WAL is split into independently valid JSONL records below 1 MiB, with request IDs, chunk indexes, byte counts, and SHA-256 validation. Derived telemetry can therefore be rebuilt after a partial final gather, while an incomplete final OTLP request is ignored safely.

## Configuration

The preset is `configs/agents/kimi_code.yaml`:

- model: `kimi-k3`
- API: `https://api.moonshot.ai/v1`
- credential: `MOONSHOT_API_KEY`
- context: `1048576`
- reasoning effort: `max`
- CLI: `@moonshot-ai/kimi-code@0.27.0`

The API key is injected only into the CLI process. It is not written to Kimi Code's persistent `config.toml` or ALE's gathered specification.

## Validation

- exact PR tree: `80 passed` across `tests/ale_run`
- targeted Kimi, telemetry, credential, and incremental-tail suite: `28 passed`
- Ruff lint passed for the changed implementation and tests
- Ruff format check passed for the Kimi implementation and tests
- real Node/Undici to OTLP collector test captured a POST span with URL, status `200`, trace/span IDs, and measured duration
- historical K3 log replay restored `14/14` images in a missing-blob run and `52/52` images in a transcript-only run, with no unresolved `blobref:` URLs
- local QEMU/KVM-in-Docker integration on `demo/seecheck`:
  - dynamically verified Kimi Code `0.27.0` with Node `24.12.0`
  - completed with score `1.0`
  - wrote and pulled the required output file
  - persisted the screenshot under `screenshots/`
  - recorded three successful model API spans and both tool durations
  - deleted the QEMU container and runtime slot after completion

## Upstream references

- https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started.html
- https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/config-files.html
- https://www.kimi.com/code/docs/en/kimi-code-cli/customization/mcp.html
- https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/env-vars.html
- https://www.kimi.com/code/docs/en/kimi-code-cli/reference/kimi-command.html
- https://github.com/MoonshotAI/kimi-code
