### PR TITLE
feat(run): enable configurable auto-resume by default

### DIFF
--- a/ale_run/cli.py
+++ b/ale_run/cli.py
@@ -39,10 +39,9 @@ def main(argv: list[str] | None = None) -> int:
     p_run.add_argument("--task", action="append", dest="filter_tasks",
                        metavar="PATH", help="Filter: only run these task paths.")
     p_run.add_argument(
-        "--resume", action="store_true",
-        help="Skip any (agent, task, variant) unit that already has a prior run "
-             "whose status is 'completed' or 'timeout' under the output dir; "
-             "re-run everything else. Lets a re-invocation fill only the gaps.",
+        "--disable-resume", action="store_true",
+        help="Run every selected unit exactly once, without scanning prior "
+             "results or automatically retrying failures.",
     )
     p_run.add_argument("--verbose", "-v", action="store_true")
 
@@ -71,7 +70,8 @@ async def _cmd_run(args: argparse.Namespace) -> int:
     runner = Runner(spec)
     units = _filter_units(runner.enumerate_units(), args)
 
-    if args.resume:
+    auto_resume = spec.auto_resume and not args.disable_resume
+    if auto_resume:
         units = _filter_resume(units, runner.output_root)
 
     if args.dry_run:
@@ -91,7 +91,10 @@ async def _cmd_run(args: argparse.Namespace) -> int:
             print(f"  {u.agent_id:20s}  {u.task_path:40s}  v{u.variant_index}")
         return 0
 
-    results = await runner.run(units)
+    results = await runner.run(
+        units,
+        max_attempts=spec.max_attempts if auto_resume else 1,
+    )
     _print_results_table(results)
     bad = sum(1 for r in results if r.status not in ("completed",))
     return 0 if bad == 0 else 1

--- a/ale_run/orchestration/config_loader.py
+++ b/ale_run/orchestration/config_loader.py
@@ -20,8 +20,8 @@ Shape:
 * ``tasks: <path>`` string form. ``.txt`` → one task path per line
   (variant 0); ``.yaml`` → list of ``{path, variants}`` entries. An inline
   list of ``{path, variants}`` is also accepted.
-* Run-level keys live at the experiment top level: ``output``,
-  ``artifacts_path``, ``concurrency``, ``cleanup_mode``, ``prompt_suffix``.
+* Run-level keys live at the experiment top level: ``output``, ``concurrency``,
+  ``auto_resume``, ``max_attempts``, ``cleanup_mode``, ``prompt_suffix``.
 
 Other behavior:
 
@@ -62,6 +62,8 @@ _TOP_LEVEL_KEYS = frozenset({
     # run-level fields:
     "output",
     "concurrency",
+    "auto_resume",
+    "max_attempts",
     "cleanup_mode",
     "prompt_suffix",
     "wall_time_s",
@@ -198,6 +200,18 @@ def _build_experiment(raw: dict[str, Any], *, base_dir: Path) -> ExperimentSpec:
     # and live in the environment yaml instead (see _build_environment_from_path).
     output = _build_output(raw.get("output") or {})
     concurrency = _build_concurrency(raw)
+    auto_resume = raw.get("auto_resume", True)
+    if not isinstance(auto_resume, bool):
+        raise TypeError(
+            f"auto_resume must be a boolean, got {type(auto_resume).__name__}"
+        )
+    max_attempts = raw.get("max_attempts", 3)
+    if not isinstance(max_attempts, int) or isinstance(max_attempts, bool):
+        raise TypeError(
+            f"max_attempts must be an integer, got {type(max_attempts).__name__}"
+        )
+    if not 1 <= max_attempts <= 3:
+        raise ValueError(f"max_attempts must be between 1 and 3, got {max_attempts}")
     cleanup_mode = _build_cleanup_mode(raw)
     prompt_suffix = str(raw.get("prompt_suffix") or "")
     wall_time_s = raw.get("wall_time_s")
@@ -238,6 +252,8 @@ def _build_experiment(raw: dict[str, Any], *, base_dir: Path) -> ExperimentSpec:
         tasks=tasks,
         artifacts=artifacts,
         concurrency=concurrency,
+        auto_resume=auto_resume,
+        max_attempts=max_attempts,
         cleanup_mode=cleanup_mode,
         prompt_suffix=prompt_suffix,
         wall_time_s=wall_time_s,

--- a/ale_run/orchestration/experiment_spec.py
+++ b/ale_run/orchestration/experiment_spec.py
@@ -138,6 +138,15 @@ class ExperimentSpec:
     ``StaticProvider`` (one shared VM) must stay at 1 to avoid work_dir
     collisions."""
 
+    auto_resume: bool = True
+    """When enabled, skip prior completed/timeout units and automatically
+    retry newly failed units. Disable in YAML or with ``--disable-resume`` to
+    run every selected unit exactly once."""
+
+    max_attempts: int = 3
+    """Maximum total attempts per failed unit in one invocation when
+    ``auto_resume`` is enabled. Must be between 1 and 3."""
+
     cleanup_mode: str = "delete"
     """VM disposition after a unit finishes.
 

--- a/ale_run/orchestration/run_writer.py
+++ b/ale_run/orchestration/run_writer.py
@@ -10,8 +10,9 @@ LOG_SPEC.md is the source of truth; this class is its only writer. Layout:
         origin_log/<agent_name>/    deployer work_dir pulled from VM
         output/                     agent output, when output_path="local"
 
-The constructor refuses to overwrite an existing run dir
-(``FileExistsError``). Each finalize write is wrapped in try/except; the
+The constructor never overwrites an existing run dir. If multiple attempts of
+the same unit start within one second, it appends a numeric suffix to allocate a
+new directory. Each finalize write is wrapped in try/except; the
 ``events.jsonl`` is the authoritative trace even if one of the other writes
 fails.
 """
@@ -67,24 +68,36 @@ class RunWriter:
         task_path: str,
         variant_index: int,
     ):
-        self._ts = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
+        base_ts = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
         self._slug_agent = slug_agent(agent_id)
         self._slug_model = slug_model(model)
         self._slug_task = slug_task(task_path)
         self._variant_index = variant_index
 
-        self._run_dir = (
+        variant_dir = (
             output_root
             / self._slug_agent
             / self._slug_model
             / self._slug_task
             / f"v{variant_index}"
-            / self._ts
         )
-        # Refuse to overwrite — LOG_SPEC §1 collision policy.
-        if self._run_dir.exists():
-            raise FileExistsError(f"run dir already exists: {self._run_dir}")
-        self._run_dir.mkdir(parents=True, exist_ok=False)
+        variant_dir.mkdir(parents=True, exist_ok=True)
+        for collision_index in range(1000):
+            self._ts = (
+                base_ts
+                if collision_index == 0
+                else f"{base_ts}_{collision_index:02d}"
+            )
+            self._run_dir = variant_dir / self._ts
+            try:
+                self._run_dir.mkdir(exist_ok=False)
+            except FileExistsError:
+                continue
+            break
+        else:
+            raise FileExistsError(
+                f"could not allocate a unique run dir under {variant_dir}"
+            )
         (self._run_dir / "origin_log").mkdir(parents=True, exist_ok=True)
         (self._run_dir / "output").mkdir(parents=True, exist_ok=True)
 

--- a/ale_run/orchestration/runner.py
+++ b/ale_run/orchestration/runner.py
@@ -66,12 +66,19 @@ class Runner:
     async def run(
         self,
         units: Iterable[RunUnit] | None = None,
+        *,
+        max_attempts: int = 1,
     ) -> list[UnitResult]:
         """Run all units (or a filtered subset). Returns ``list[UnitResult]``.
 
-        No aggregation, no summary — caller does whatever rollup it wants.
+        Failed units are requeued until they succeed or reach ``max_attempts``.
+        Only the final result for each unit is returned; every attempt retains
+        its own run directory on disk.
         """
         from .lifecycle import install_signal_handlers, run_one_unit
+
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
 
         install_signal_handlers()
         unit_list = list(units) if units is not None else self.enumerate_units()
@@ -86,20 +93,39 @@ class Runner:
         logger.info("runner: %d units, concurrency=%d", len(unit_list), n)
 
         async def _drive(u: RunUnit) -> UnitResult:
-            logger.info("[%s] queued", u.slug)
-            result = await run_one_unit(
-                unit=u,
-                router=self._router,
-                output_root=self._output_root,
-                artifacts=self._spec.artifacts,
-                sem=sem,
-                cleanup_mode=self._spec.cleanup_mode,
-                prompt_suffix=self._spec.prompt_suffix,
-                wall_time_s=self._spec.wall_time_s,
-            )
-            logger.info("[%s] done: status=%s score=%s duration=%.1fs",
-                        u.slug, result.status, result.score, result.duration_s or 0)
-            return result
+            for attempt in range(1, max_attempts + 1):
+                logger.info(
+                    "[%s] queued (attempt %d/%d)", u.slug, attempt, max_attempts,
+                )
+                result = await run_one_unit(
+                    unit=u,
+                    router=self._router,
+                    output_root=self._output_root,
+                    artifacts=self._spec.artifacts,
+                    sem=sem,
+                    cleanup_mode=self._spec.cleanup_mode,
+                    prompt_suffix=self._spec.prompt_suffix,
+                    wall_time_s=self._spec.wall_time_s,
+                )
+                logger.info(
+                    "[%s] done: status=%s score=%s duration=%.1fs (attempt %d/%d)",
+                    u.slug,
+                    result.status,
+                    result.score,
+                    result.duration_s or 0,
+                    attempt,
+                    max_attempts,
+                )
+                if result.status != "failed" or attempt == max_attempts:
+                    return result
+                logger.warning(
+                    "[%s] failed on attempt %d/%d; requeued",
+                    u.slug,
+                    attempt,
+                    max_attempts,
+                )
+
+            raise AssertionError("unreachable")
 
         results = await asyncio.gather(
             *(_drive(u) for u in unit_list),

--- a/docs/ale-docs-site/pages/configure.html
+++ b/docs/ale-docs-site/pages/configure.html
@@ -32,6 +32,8 @@ output:
   root: .logs/ale
 concurrency: 1
 wall_time_s: 7200
+auto_resume: true
+max_attempts: 3
 cleanup_mode: delete</code></pre>
     <p>
       Relative paths resolve from the experiment file's directory. Keep the file
@@ -42,7 +44,7 @@ cleanup_mode: delete</code></pre>
     <table>
       <thead><tr><th>Field</th><th>Meaning</th></tr></thead>
       <tbody>
-        <tr><td><code>name</code></td><td>Names the experiment directory and defines the scope searched by <code>--resume</code>.</td></tr>
+        <tr><td><code>name</code></td><td>Names the experiment directory and defines the scope searched by auto-resume.</td></tr>
         <tr><td><code>secret_file</code></td><td>Loads <code>KEY=value</code> entries before referenced YAML files are parsed.</td></tr>
         <tr><td><code>agents</code></td><td>One or more agent preset paths. ALE runs the Cartesian product of agents and tasks.</td></tr>
         <tr><td><code>environment</code></td><td>Exactly one environment profile, which routes task snapshots to providers.</td></tr>
@@ -50,6 +52,8 @@ cleanup_mode: delete</code></pre>
         <tr><td><code>output.root</code></td><td>The host directory for run records. This is separate from the environment's task-output destination.</td></tr>
         <tr><td><code>concurrency</code></td><td>Maximum run units active at once.</td></tr>
         <tr><td><code>wall_time_s</code></td><td>Optional experiment-wide agent time limit. When omitted, each task card supplies its own timeout.</td></tr>
+        <tr><td><code>auto_resume</code></td><td>Defaults to <code>true</code>. Skips prior completed/timeout units and retries newly failed units.</td></tr>
+        <tr><td><code>max_attempts</code></td><td>Total attempts per failed unit in one invocation when auto-resume is enabled. Accepts 1 through 3 and defaults to 3.</td></tr>
         <tr><td><code>cleanup_mode</code></td><td><code>delete</code>, <code>stop</code>, or <code>keep</code> for provider-managed sandboxes.</td></tr>
         <tr><td><code>prompt_suffix</code></td><td>Optional text appended to every task instruction and recorded in the trajectory.</td></tr>
       </tbody>

--- a/docs/ale-docs-site/pages/run.html
+++ b/docs/ale-docs-site/pages/run.html
@@ -40,13 +40,23 @@ uv run python -m ale_run run my_experiment.yaml \
       latency, and LLM rate limits can all become the practical bound.
     </p>
 
-    <h2>Resume an interrupted sweep</h2>
-    <pre><code>uv run python -m ale_run run my_experiment.yaml --resume</code></pre>
+    <h2>Resume and retry failed units</h2>
+    <pre><code>auto_resume: true
+max_attempts: 3</code></pre>
     <p>
-      Resume scans prior <code>run.json</code> files under the same experiment
-      name and output root. Units with status <code>completed</code> or
-      <code>timeout</code> are skipped. Failed, cancelled, malformed, and missing
-      units run again.
+      Auto-resume is enabled by default. It scans prior <code>run.json</code>
+      files under the same experiment name and output root, skips units with
+      status <code>completed</code> or <code>timeout</code>, and immediately
+      requeues newly failed units. <code>max_attempts</code> accepts 1 through 3
+      and counts the initial run within that invocation. Every attempt keeps
+      its own run directory.
+    </p>
+    <h3>Disable resume for one invocation</h3>
+    <pre><code>uv run python -m ale_run run my_experiment.yaml --disable-resume</code></pre>
+    <p>
+      This command-line override runs every selected unit exactly once. It does
+      not scan prior results or retry failures. Set <code>auto_resume: false</code>
+      in the experiment YAML to make that behavior persistent.
     </p>
 
     <h2 id="output-path">Choose where task output goes</h2>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -178,12 +178,16 @@ Windows snapshots to their corresponding images and zones.
 ```yaml
 tasks: selected_tasks/unlicensed.txt
 concurrency: 8
+auto_resume: true
+max_attempts: 3
 cleanup_mode: delete
 ```
 
 Choose concurrency according to project quota, GPU availability, LLM rate
-limits, and budget. Use `--resume` to skip units already recorded as
-`completed` or `timeout`.
+limits, and budget. Auto-resume is enabled by default: prior `completed` and
+`timeout` units are skipped, and failed units are automatically requeued up to
+`max_attempts`. Use `--disable-resume` for a one-off run of every selected unit
+with no retries.
 
 ## Cleanup and recovery
 

--- a/example_exp.yaml
+++ b/example_exp.yaml
@@ -38,6 +38,8 @@ output:
   root: .logs/ale                                 # host-side run-log dir
 concurrency: 1                                    # units in flight (caps VMs + LLM RPM)
 wall_time_s: 7200                                 # max seconds an agent may run per unit (then stopped, status=timeout)
+auto_resume: true                                 # skip prior completed/timeout units and retry failures
+max_attempts: 3                                   # total attempts per failed unit (1..3)
 cleanup_mode: delete                              # delete | stop | keep
 
 # Appended verbatim (as its own paragraph) to EVERY task's prompt before it

--- a/tests/ale_run/test_auto_resume.py
+++ b/tests/ale_run/test_auto_resume.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from ale_run import cli
+from ale_run.orchestration.config_loader import load_experiment
+from ale_run.orchestration.experiment_spec import (
+    AgentSpec,
+    EnvironmentSpec,
+    ExperimentSpec,
+    OutputSpec,
+    RunUnit,
+    UnitResult,
+)
+from ale_run.orchestration.run_writer import RunWriter
+from ale_run.orchestration.runner import Runner
+
+
+def _spec(
+    tmp_path: Path,
+    *,
+    auto_resume: bool = True,
+    max_attempts: int = 3,
+) -> ExperimentSpec:
+    return ExperimentSpec(
+        name="auto-resume-test",
+        output=OutputSpec(root=str(tmp_path)),
+        environment=EnvironmentSpec(),
+        agents=[],
+        tasks=[],
+        auto_resume=auto_resume,
+        max_attempts=max_attempts,
+    )
+
+
+def _unit() -> RunUnit:
+    agent = AgentSpec(id="dummy", class_="dummy", config={"model": "test"})
+    return RunUnit(
+        agent_id=agent.id,
+        agent_spec=agent,
+        task_path="demo/hello",
+        variant_index=0,
+    )
+
+
+def _write_experiment(tmp_path: Path, run_config: str = "") -> Path:
+    (tmp_path / "agent.yaml").write_text(
+        "harness: dummy\nmodel: test\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "environment.yaml").write_text(
+        "provider: static\nendpoint: http://127.0.0.1:5000\n",
+        encoding="utf-8",
+    )
+    experiment = tmp_path / "experiment.yaml"
+    experiment.write_text(
+        "name: auto-resume-test\n"
+        "agent: agent.yaml\n"
+        "environment: environment.yaml\n"
+        "tasks:\n"
+        "  - path: demo/hello\n"
+        f"{run_config}",
+        encoding="utf-8",
+    )
+    return experiment
+
+
+def test_loader_enables_auto_resume_by_default(tmp_path: Path) -> None:
+    spec = load_experiment(_write_experiment(tmp_path))
+
+    assert spec.auto_resume is True
+    assert spec.max_attempts == 3
+
+
+def test_loader_accepts_auto_resume_config(tmp_path: Path) -> None:
+    spec = load_experiment(
+        _write_experiment(
+            tmp_path,
+            "auto_resume: false\nmax_attempts: 2\n",
+        )
+    )
+
+    assert spec.auto_resume is False
+    assert spec.max_attempts == 2
+
+
+@pytest.mark.parametrize(
+    ("run_config", "error_type", "match"),
+    [
+        ("auto_resume: 'yes'\n", TypeError, "auto_resume must be a boolean"),
+        ("max_attempts: true\n", TypeError, "max_attempts must be an integer"),
+        ("max_attempts: 4\n", ValueError, "max_attempts must be between 1 and 3"),
+    ],
+)
+def test_loader_rejects_invalid_auto_resume_config(
+    tmp_path: Path,
+    run_config: str,
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    with pytest.raises(error_type, match=match):
+        load_experiment(_write_experiment(tmp_path, run_config))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("statuses", "expected_calls", "expected_status"),
+    [
+        (["failed", "failed", "completed"], 3, "completed"),
+        (["failed", "failed", "failed", "completed"], 3, "failed"),
+        (["timeout", "completed"], 1, "timeout"),
+    ],
+)
+async def test_runner_auto_resume_retries_only_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    statuses: list[str],
+    expected_calls: int,
+    expected_status: str,
+) -> None:
+    calls = 0
+
+    async def fake_run_one_unit(**kwargs) -> UnitResult:
+        nonlocal calls
+        status = statuses[calls]
+        calls += 1
+        return UnitResult(unit=kwargs["unit"], status=status)
+
+    monkeypatch.setattr(
+        "ale_run.orchestration.lifecycle.run_one_unit",
+        fake_run_one_unit,
+    )
+
+    results = await Runner(_spec(tmp_path)).run([_unit()], max_attempts=3)
+
+    assert calls == expected_calls
+    assert len(results) == 1
+    assert results[0].status == expected_status
+
+
+@pytest.mark.asyncio
+async def test_runner_default_does_not_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    async def fake_run_one_unit(**kwargs) -> UnitResult:
+        nonlocal calls
+        calls += 1
+        return UnitResult(unit=kwargs["unit"], status="failed")
+
+    monkeypatch.setattr(
+        "ale_run.orchestration.lifecycle.run_one_unit",
+        fake_run_one_unit,
+    )
+
+    results = await Runner(_spec(tmp_path)).run([_unit()])
+
+    assert calls == 1
+    assert results[0].status == "failed"
+
+
+def test_disable_resume_cli_flag_is_parsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = None
+
+    async def fake_cmd_run(args) -> int:
+        nonlocal captured
+        captured = args
+        return 0
+
+    monkeypatch.setattr(cli, "_cmd_run", fake_cmd_run)
+
+    assert cli.main(["run", "experiment.yaml", "--disable-resume"]) == 0
+    assert captured is not None
+    assert captured.disable_resume is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("yaml_enabled", "cli_disabled", "expected_attempts", "filters_prior"),
+    [
+        (True, False, 2, True),
+        (False, False, 1, False),
+        (True, True, 1, False),
+    ],
+)
+async def test_auto_resume_config_and_cli_precedence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    yaml_enabled: bool,
+    cli_disabled: bool,
+    expected_attempts: int,
+    filters_prior: bool,
+) -> None:
+    unit = _unit()
+    captured: dict[str, object] = {}
+
+    class FakeRunner:
+        def __init__(self, spec: ExperimentSpec):
+            self.output_root = tmp_path
+
+        def enumerate_units(self) -> list[RunUnit]:
+            return [unit]
+
+        async def run(
+            self,
+            units: list[RunUnit],
+            *,
+            max_attempts: int,
+        ) -> list[UnitResult]:
+            captured["units"] = units
+            captured["max_attempts"] = max_attempts
+            return [UnitResult(unit=unit, status="completed")]
+
+    def fake_filter_resume(
+        units: list[RunUnit],
+        output_root: Path,
+    ) -> list[RunUnit]:
+        captured["resume_output_root"] = output_root
+        return units
+
+    monkeypatch.setattr(
+        cli,
+        "load_experiment",
+        lambda _: _spec(tmp_path, auto_resume=yaml_enabled, max_attempts=2),
+    )
+    monkeypatch.setattr(cli, "Runner", FakeRunner)
+    monkeypatch.setattr(cli, "_filter_resume", fake_filter_resume)
+    monkeypatch.setattr(cli, "_print_results_table", lambda _: None)
+
+    exit_code = await cli._cmd_run(
+        argparse.Namespace(
+            spec_path=Path("experiment.yaml"),
+            filter_agents=None,
+            filter_tasks=None,
+            disable_resume=cli_disabled,
+            dry_run=False,
+        )
+    )
+
+    assert exit_code == 0
+    assert captured["units"] == [unit]
+    assert captured["max_attempts"] == expected_attempts
+    if filters_prior:
+        assert captured["resume_output_root"] == tmp_path
+    else:
+        assert "resume_output_root" not in captured
+
+
+def test_run_writer_allocates_unique_same_second_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("ale_run.orchestration.run_writer.time.strftime", lambda *_: "fixed")
+
+    first = RunWriter(
+        output_root=tmp_path,
+        agent_id="dummy",
+        model="test",
+        task_path="demo/hello",
+        variant_index=0,
+    )
+    second = RunWriter(
+        output_root=tmp_path,
+        agent_id="dummy",
+        model="test",
+        task_path="demo/hello",
+        variant_index=0,
+    )
+    first.close()
+    second.close()
+
+    assert first.run_dir.name == "fixed"
+    assert second.run_dir.name == "fixed_01"
+    assert first.run_id != second.run_id


### PR DESCRIPTION
## Summary

- enable auto-resume by default, skipping prior completed/timeout units
- requeue failed units only after their attempt fully finishes, with 1-3 YAML-configurable total attempts per invocation
- add `--disable-resume` to bypass history scanning and retries for one invocation
- keep every retry in a distinct run directory and document the new defaults

## Configuration

```yaml
auto_resume: true
max_attempts: 3
```

## Tests

- `uv run ruff check ale_run/cli.py ale_run/orchestration/config_loader.py ale_run/orchestration/experiment_spec.py ale_run/orchestration/runner.py ale_run/orchestration/run_writer.py tests/ale_run/test_auto_resume.py`
- `uv run pytest tests/ale_run/test_auto_resume.py -q` (14 passed)
- `python -m pytest tests/ale_run -q` (78 passed)
