### PR TITLE
Add computing_math/imo2005p6_lean_v1 — Lean/Mathlib formal-verification task

### DIFF
--- a/ale_run/agents/claude_code/config.py
+++ b/ale_run/agents/claude_code/config.py
@@ -75,11 +75,38 @@ class ClaudeCodeConfig:
         OPENROUTER_API_KEY, ANTHROPIC_API_KEY="". Requires OPENROUTER_API_KEY.
       - ``"direct"`` → uses ANTHROPIC_API_KEY against anthropic.com (or
         ``base_url`` if set). Requires ANTHROPIC_API_KEY.
-    Missing the required key for the chosen provider is a hard error."""
+      - ``"bedrock"`` → CLAUDE_CODE_USE_BEDROCK=1 and the CLI calls Claude on
+        Amazon Bedrock via the AWS SDK. Auth is the standard AWS credential
+        chain (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN),
+        resolved on the host and propagated into the sandbox by the framework.
+        ``model`` must be a Bedrock model id / inference-profile id
+        (e.g. ``us.anthropic.claude-fable-5``), NOT an ``anthropic/...`` slug.
+    Missing the required key/credentials for the chosen provider is a hard
+    error."""
 
     base_url: str | None = None
     """Custom Anthropic-compatible base URL. Overrides the provider's
-    default ``ANTHROPIC_BASE_URL``."""
+    default ``ANTHROPIC_BASE_URL``. Ignored for ``provider=bedrock`` (the AWS
+    SDK builds its own endpoint from the region)."""
+
+    aws_region: str | None = None
+    """AWS region for ``provider=bedrock`` (sets ``AWS_REGION``). ``None`` ⇒
+    fall back to whatever ``AWS_REGION`` / ``AWS_DEFAULT_REGION`` the resolved
+    AWS environment already carries. The chosen model id must be available on
+    Bedrock in this region."""
+
+    aws_credential_process_file: str | None = None
+    """``provider=bedrock`` long-run credential refresh. Static SigV4 env
+    creds (from short-lived STS tokens, e.g. ``ada``) freeze into the sandbox
+    at launch and expire mid-run (~1h), 403-ing long agent runs. When this is
+    set to a path, the deployer writes an ``~/.aws/config`` whose ``profile``
+    uses ``credential_process = cat <path>`` and CLEARS the static
+    ``AWS_ACCESS_KEY_ID``/``SECRET_ACCESS_KEY``/``SESSION_TOKEN`` from the
+    agent env (env creds otherwise OVERRIDE credential_process). A host-side
+    sidecar keeps that file refreshed (re-minting the token + ``docker cp``
+    into the running container), so the AWS SDK re-reads always-valid creds on
+    expiry. The path is sandbox-side (e.g. ``/tmp/.ale_aws_creds.json``).
+    ``None`` ⇒ legacy frozen-env behavior (fine for <1h runs)."""
 
     api_key: str | None = None
     """Literal API key, used in place of the provider's env-var key. ``None`` ⇒
@@ -103,6 +130,15 @@ class ClaudeCodeConfig:
     tool arguments/duration, prompts), cumulative metrics, and a summary in
     ``work_dir``. No upstream Claude Code changes are required. Set ``false`` to
     run the CLI with telemetry off."""
+
+    max_output_tokens: int | None = None
+    """Per-response output-token ceiling, passed to the CLI via the
+    ``CLAUDE_CODE_MAX_OUTPUT_TOKENS`` env var. The Claude Code CLI defaults to
+    32000; a single thinking-heavy turn (large ``max_thinking_tokens`` + a long
+    tool result) can exceed it and the CLI aborts the whole run with
+    "response exceeded the N output token maximum". Set this (e.g. 96000) to
+    lift the ceiling on models whose real output limit is higher. ``None`` ⇒
+    leave the CLI default (deployer does not set the env var)."""
 
     max_thinking_tokens: int | None = 31999
     """Extended-thinking token budget, passed to the CLI via the

--- a/ale_run/agents/claude_code/deployer.py
+++ b/ale_run/agents/claude_code/deployer.py
@@ -440,6 +440,15 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
             env.pop("MAX_THINKING_TOKENS", None)
             env["CLAUDE_CODE_DISABLE_THINKING"] = "1"
 
+        # Raise the CLI's per-response output-token ceiling. The Claude Code CLI
+        # defaults to a 32000 output-token max; a single thinking-heavy turn
+        # (large `MAX_THINKING_TOKENS` + a long tool result) can exceed it and
+        # the CLI aborts the whole run with "response exceeded the N output
+        # token maximum". Set from cfg (the yaml) — NOT os.environ, which in the
+        # sandbox is the _sandbox_entry env, not the operator's shell.
+        if cfg.max_output_tokens is not None:
+            env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = str(cfg.max_output_tokens)
+
         # Provider-driven routing (explicit, not key-presence heuristic).
         if cfg.provider == "openrouter":
             # A literal cfg.api_key (travels with the serialized config) takes
@@ -463,10 +472,43 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
             env["ANTHROPIC_API_KEY"] = key
             if cfg.base_url:
                 env["ANTHROPIC_BASE_URL"] = cfg.base_url
+        elif cfg.provider == "bedrock":
+            # Claude Code calls Bedrock through the AWS SDK when
+            # CLAUDE_CODE_USE_BEDROCK=1; auth is the standard AWS credential
+            # chain. The framework resolves the operator's AWS credentials on
+            # the host and propagates them into the sandbox (see
+            # _collect_env_passthrough), so they arrive here as env vars.
+            # Require at least an access key OR a bearer token so we fail fast
+            # with a clear message instead of letting the CLI 403 mid-run.
+            has_sigv4 = bool(env.get("AWS_ACCESS_KEY_ID") and env.get("AWS_SECRET_ACCESS_KEY"))
+            has_bearer = bool(env.get("AWS_BEARER_TOKEN_BEDROCK"))
+            if not (has_sigv4 or has_bearer):
+                raise RuntimeError(
+                    "claude_code: provider=bedrock but no AWS credentials in env "
+                    "(need AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, or "
+                    "AWS_BEARER_TOKEN_BEDROCK). Authenticate on the host (e.g. "
+                    "`ada credentials update ...` / `aws sso login`) before running."
+                )
+            env["CLAUDE_CODE_USE_BEDROCK"] = "1"
+            region = cfg.aws_region or env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION")
+            if region:
+                env["AWS_REGION"] = region
+            # OpenRouter/Anthropic-direct routing vars must not leak in: a
+            # stale ANTHROPIC_BASE_URL would send Bedrock traffic to the wrong
+            # endpoint. Bedrock auth is AWS-SDK only.
+            for k in ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"):
+                env.pop(k, None)
+            # Long-run credential refresh: point the AWS SDK at a
+            # credential_process that re-reads an always-fresh creds file (kept
+            # current by a host sidecar). Static SigV4 env creds OVERRIDE
+            # credential_process, so they MUST be cleared for the refresh to
+            # take effect — verified: env creds win the AWS credential chain.
+            if cfg.aws_credential_process_file:
+                self._setup_credential_process(env, cfg.aws_credential_process_file)
         else:
             raise RuntimeError(
                 f"claude_code: unknown provider {cfg.provider!r} "
-                "(expected 'openrouter' or 'direct')"
+                "(expected 'openrouter', 'direct', or 'bedrock')"
             )
 
         # OpenTelemetry: point Claude Code's built-in exporter at the run-local
@@ -491,6 +533,65 @@ class ClaudeCodeDeployer(BaseAgentDeployer):
                 "OTEL_LOG_TOOL_DETAILS": "1",
             })
         return env
+
+    @staticmethod
+    def _setup_credential_process(env: dict[str, str], creds_file: str) -> None:
+        """Wire the AWS SDK to a refreshable credential_process (long runs).
+
+        Writes ``~/.aws/config`` with a profile whose ``credential_process``
+        cats ``creds_file``, seeds that file with the current (still-valid) env
+        creds so calls work before the host sidecar's first refresh, points the
+        SDK at the profile, and CLEARS the static env creds (they would
+        otherwise override credential_process and keep expiring). Runs
+        in-sandbox, so all paths are sandbox-local; the host sidecar overwrites
+        ``creds_file`` in the running container as the token rotates.
+        """
+        import json as _json
+
+        home = os.path.expanduser("~")
+        aws_dir = os.path.join(home, ".aws")
+        os.makedirs(aws_dir, exist_ok=True)
+        config_path = os.path.join(aws_dir, "config")
+        profile = "ale_refresh"
+        with open(config_path, "w", encoding="utf-8") as fh:
+            fh.write(
+                f"[profile {profile}]\n"
+                f"credential_process = cat {creds_file}\n"
+            )
+
+        # Seed the creds file with the current env creds (process format) so
+        # the SDK has valid creds immediately; the sidecar refreshes it later.
+        ak, sk, st = (
+            env.get("AWS_ACCESS_KEY_ID"),
+            env.get("AWS_SECRET_ACCESS_KEY"),
+            env.get("AWS_SESSION_TOKEN"),
+        )
+        if ak and sk:
+            seed = {
+                "Version": 1,
+                "AccessKeyId": ak,
+                "SecretAccessKey": sk,
+            }
+            if st:
+                seed["SessionToken"] = st
+            try:
+                os.makedirs(os.path.dirname(creds_file) or "/", exist_ok=True)
+                with open(creds_file, "w", encoding="utf-8") as fh:
+                    _json.dump(seed, fh)
+            except OSError as e:
+                logger.warning("claude_code: could not seed creds file %s: %s", creds_file, e)
+
+        env["AWS_CONFIG_FILE"] = config_path
+        env["AWS_PROFILE"] = profile
+        env["AWS_SDK_LOAD_CONFIG"] = "1"
+        # Static env creds OVERRIDE credential_process — clear them so the SDK
+        # uses the refreshable profile instead of the frozen, expiring token.
+        for k in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+            env.pop(k, None)
+        logger.info(
+            "claude_code: bedrock credential_process wired (profile=%s, creds_file=%s)",
+            profile, creds_file,
+        )
 
     def _diagnose_failure(
         self, *, stderr_log: Path, transcript: Path, exit_code: int | None,

--- a/selected_tasks/imo2005p6_lean.txt
+++ b/selected_tasks/imo2005p6_lean.txt
@@ -1,0 +1,1 @@
+computing_math/imo2005p6_lean_v1

--- a/tasks/computing_math/imo2005p6_lean_v1/README.md
+++ b/tasks/computing_math/imo2005p6_lean_v1/README.md
@@ -1,0 +1,106 @@
+# computing_math/imo2005p6_lean_v1
+
+Formalize-and-prove task: the agent produces a complete, machine-checked
+Lean 4 / Mathlib proof of a combinatorial extremal theorem (IMO 2005 Problem 6),
+and is graded by an axiom audit that certifies the proof is genuine.
+
+## What the agent does
+
+- Receives `input/Problem.lean`: the exact theorem `imo2005_p6` (with fixed
+  auxiliary definitions `solvedCount` / `numSolvedExactly`) and a `sorry`.
+- Writes `output/solution.lean`: the same file with the `sorry` replaced by a
+  real proof (auxiliary lemmas allowed before the theorem).
+
+## The theorem
+
+> In a competition with 6 problems where every pair of problems was solved by
+> more than 2/5 of the contestants and nobody solved all 6, at least two
+> contestants each solved exactly 5 problems.
+
+Formalized over an arbitrary finite contestant type `C` with a decidable
+`solved : C → Fin 6 → Prop`; `hpair` is the integer form of "> 2/5"
+(`2*n < 5*|pair-solvers|`), `hnall` is "nobody solved all 6", goal is
+`2 ≤ numSolvedExactly solved 5`.
+
+## Grading (deterministic, layered — `scripts/grade_lean.py`)
+
+| Gate | Check |
+|------|-------|
+| G1 | Submission keeps the **exact** `imo2005_p6` signature + `solvedCount`/`numSolvedExactly` definitions (whitespace-normalized substring pin). Blocks vacuous/weaker restatements. |
+| G2 | Source scan rejects `sorry`, `admit`, `native_decide`, new `axiom`, `addDecl`, `implemented_by`, `ofReduceBool`. |
+| G3 | `lean solution.lean` exits 0 with no `error:`. |
+| G4 | `#print axioms IMO2005P6.imo2005_p6` ⊆ `{propext, Classical.choice, Quot.sound}`. Rejects `sorryAx` (holes), declared axioms, and `Lean.ofReduceBool` (from `native_decide`). |
+
+Score = **1.0** iff all gates pass, else **0.0**.
+
+Because the theorem is universally quantified over an arbitrary `C` and `solved`,
+it cannot be closed by `decide` / `native_decide` (there is no finite object to
+enumerate), so the only route to a passing score is a genuine proof — and the
+axiom audit rejects the non-genuine routes.
+
+## Solver isolation (anti-leakage)
+
+Only `input/Problem.lean` (+ `LEANPATH`/`LEANBIN`) is staged into the solver
+sandbox — the reference proof and grader are **evaluator-only** and never enter
+it, and the reference is **not committed to this public repo**. The informal
+IMO 2005 P6 solution is public (a famous olympiad problem); the protected asset
+is the bespoke Lean proof, which is what a solver would otherwise copy. Run the
+solve phase network-restricted where possible — the only network need is the
+setup-time toolchain/cache fetch from upstream.
+
+## Toolchain (self-contained — no data upload, no image changes)
+
+The task fetches its own toolchain from **official upstream** at setup time
+(the sandbox has outbound network, as in other ALE tasks that `pip install` /
+download at solve time). `start()` (see `main.py:_setup_toolchain`):
+
+1. installs Lean **v4.27.0** via `elan` from the official Lean releases;
+2. creates a pinned Lake project requiring **Mathlib v4.27** and runs
+   `lake exe cache get`, which downloads the *prebuilt* Mathlib `.olean` cache
+   (~7,900 oleans) from Mathlib's official cache CDN in a few minutes — it does
+   **not** build Mathlib from source (that would take hours);
+3. discovers the olean search path and writes `input/LEANPATH` + `input/LEANBIN`
+   pointer files (and puts `lean` on `PATH`).
+
+There is therefore **no `software/` payload to upload and no custom image** — the
+submission is code-only. (`SOFTWARE.md` + `scripts/build_software.sh` document an
+optional offline fallback: pre-staging the cache as task-data `software/`, e.g.
+if the pinned upstream cache is ever garbage-collected. Not used by default.)
+
+Determinism note: Lean and Mathlib are version-pinned (`LEAN_VERSION`,
+`MATHLIB_REV` in `main.py`), so every run resolves the same toolchain; the
+dependency on the upstream cache endpoint is the same kind of network dependency
+other accepted ALE tasks already have.
+
+## Files
+
+- `assets/Problem.lean` — the staged problem (statement + fixed defs + `sorry`).
+- reference proof — **evaluator-only**: a complete, axiom-clean proof (32
+  lemmas/definitions; compiles clean, axioms = `{propext, Classical.choice,
+  Quot.sound}`). Delivered out-of-band via the ALE reference channel; **not
+  committed to this public repo** and never staged in the sandbox.
+- `main.py` — ALE task driver (`load` / `start` / `evaluate`).
+- `scripts/grade_lean.py` — the layered grader (import-safe on host).
+- `scripts/selftest.py` — host battery over synthetic artifacts (no Lean needed).
+- `scripts/e2e_check.py` — compiles the reference for real and grades it (needs
+  the Lean cache).
+
+## Reproducing the checks
+
+```bash
+# Pure grader logic (no Lean needed):
+python3 scripts/selftest.py            # → ALL PASS
+
+# End-to-end with a real Mathlib compile (needs the cache + an `lc.sh`-style shim):
+LEAN_LC=/path/to/lc.sh LEAN_WORK=/path/to/leanproj python3 scripts/e2e_check.py
+# → REFERENCE: passed=True score=1.0 ; RESULT: PASS
+```
+
+## Difficulty
+
+Last-exam candidate. Combinatorics is the hardest IMO genre to formalize, and
+this problem is **not present in Compfiles or the Mathlib archive** (verified:
+they carry 2005 P2/P3/P4/Q3/Q4 only), so there is no public Lean proof to copy.
+The hard content is a multi-stage extremal / equality-case analysis over
+`Finset` cardinalities that is delicate to mechanize. A local Sonnet-4.6
+calibration run (2 h wall) scored 0/1, consistent with the <1% last-exam bar.

--- a/tasks/computing_math/imo2005p6_lean_v1/SOFTWARE.md
+++ b/tasks/computing_math/imo2005p6_lean_v1/SOFTWARE.md
@@ -1,0 +1,58 @@
+# Task software artifact — Lean 4.27.0 + Mathlib v4.27 (OPTIONAL offline fallback)
+
+> **NOT used by default.** The task fetches Lean + the Mathlib cache from
+> upstream at setup (`start()` → `elan` + `lake exe cache get`), so no `software/`
+> upload is needed and the submission is code-only. This document describes an
+> *optional* offline/hermetic fallback: pre-staging the same prebuilt cache as
+> task-data `software/`, e.g. if the pinned upstream Mathlib cache is ever
+> garbage-collected. To use it, set `REQUIRES_TASK_DATA = True` in `main.py` and
+> point the toolchain paths at `software_dir` (see git history for that variant).
+
+This fallback follows the standard ALE data model (same as
+`engineering/chisel_verilog_alignment_seq_1`, which ships yosys/firtool/sbt):
+the heavy toolchain is **task-data `software/`**, staged by the framework into
+the sandbox's `software_dir` (from `gs://ale-data-public` in production, or baked
+into the local image), NOT baked into a custom Docker image and NOT committed to
+this git repo.
+
+## Required `software/` layout (staged to `<base>/software/`)
+
+```
+software/
+├── elan/
+│   └── toolchains/leanprover--lean4---v4.27.0/    # the Lean 4.27.0 toolchain
+│       └── bin/lean                                # → main.py's lean_bin
+└── mathlib/
+    └── packages/<pkg>/.lake/build/lib/lean/*.olean # prebuilt v4.27 oleans
+        # <pkg> ∈ {aesop, batteries, Cli, importGraph, LeanSearchClient,
+        #          mathlib, plausible, proofwidgets, Qq}
+```
+
+`main.py` computes `lean_bin` and `LEANPATH` from these paths; `start()` writes
+`input/LEANBIN` and `input/LEANPATH` pointer files and symlinks `lean` onto PATH.
+
+Total size ≈ 8.1 GB (elan 2.5 GB + oleans 5.6 GB; mathlib alone is 5.5 GB /
+7524 oleans).
+
+## Building the artifact
+
+Produced from a machine with Lean 4.27.0 (`elan`) and a built Mathlib v4.27
+`.lake` cache (e.g. a `lake exe cache get` checkout). Copy the toolchain and the
+nine dependency `build/lib/lean` olean dirs into the layout above. A reference
+build script is `scripts/build_software.sh`.
+
+## Submission
+
+Upload the `software/` tree to the ALE task-data location for
+`computing_math/imo2005p6_lean_v1` (the reviewers place it under
+`<gcs_prefix>/software/`). This is the same mechanism every heavy-software ALE
+task uses; no custom image is required.
+
+## Local calibration
+
+Bind-mount a locally-built `software/` tree to the sandbox `software_dir`:
+```
+# (local-dev only; requires a docker provider that supports extra RO bind-mounts)
+ALE_DOCKER_EXTRA_MOUNTS="<local software/>:<software_dir>"
+```
+(verified: reference proof compiles + axiom-audits clean from this mount).

--- a/tasks/computing_math/imo2005p6_lean_v1/SUBMISSION.md
+++ b/tasks/computing_math/imo2005p6_lean_v1/SUBMISSION.md
@@ -1,0 +1,195 @@
+# Submission narrative — `computing_math/imo2005p6_lean_v1`
+
+*Reviewer-facing summary for the Agents' Last Exam data-track submission. This
+document argues why the task is in-scope, genuinely last-exam-hard, and
+verifiable, and records provenance and the one infrastructure dependency.*
+
+---
+
+## 1. One-line description
+
+Given a fixed Lean 4 theorem statement (with a `sorry`), the agent must produce
+a **complete, machine-checked Lean 4 / Mathlib proof** that passes an automated
+verifier — no `sorry`, no added axioms, no `native_decide`. The theorem is a
+formalization of a hard combinatorial extremal result (IMO 2005 Problem 6).
+
+## 2. Why this is a professional workflow, not a puzzle
+
+The task's *deliverable* is a **verification artifact**, and the *work* is
+formal-methods engineering — the same activity used in industry and research to
+certify that a claim holds with zero trust in informal argument (protocol
+correctness, cryptographic proofs, compiler/kernel verification, and the
+Lean/Mathlib and Isabelle ecosystems generally). The agent is prompted as a
+"formal-methods engineer producing a machine-checked verification artifact,"
+reads a specification, works against a real toolchain (Lean 4.27.0 + Mathlib
+v4.27), and iterates with the compiler — exactly the professional loop.
+
+This mirrors the precedent already in the benchmark: `computing_math/cp_test_gen_1`
+uses a competitive-programming problem as *substrate* for a real engineering task
+(writing an adversarial test-case generator), not as a "solve this contest
+problem" exercise. Here likewise, the mathematical theorem is substrate; the
+graded skill is producing a rigorous, machine-verifiable formalization.
+
+Formal mathematics is also economically and scientifically load-bearing: recent
+formalization projects (PFR, Liquid Tensor Experiment), AI systems trained on
+Mathlib (AlphaProof), and industrial verification all depend on precisely this
+skill of turning a specification into a kernel-checked proof.
+
+## 3. Why it is genuinely last-exam-hard
+
+- **Novelty / no leakage.** IMO 2005 P6 is **not** formalized in Compfiles or the
+  Mathlib archive (verified: they carry only 2005 P2/P3/P4/Q3/Q4). There is no
+  public Lean proof to copy; the agent must construct one.
+- **Hardest genre to mechanize.** Combinatorics is the genre where formalization
+  most often fails — autoformalization pipelines and IMO-in-Lean efforts are
+  dominated by algebra/number-theory; combinatorial extremal arguments with
+  equality-case analysis are notoriously painful in `Finset` cardinality terms.
+- **The proof itself is hard.** The argument is a multi-stage extremal /
+  equality-case analysis over `Finset` cardinalities that is delicate to carry
+  out rigorously; our reference proof is ~800 lines / 30+ lemmas. (The specific
+  proof route is deliberately kept out of this public document — see §7.)
+- **Cannot be brute-forced.** The theorem is universally quantified over an
+  arbitrary finite contestant type, so `decide`/`native_decide` cannot enumerate
+  it; only a genuine proof closes the goal, and the verifier rejects the
+  non-genuine routes.
+
+### Calibration (second-tier agent, 2 h wall — the ALE default)
+
+Measured against **Sonnet 4.6** (the FAQ's second-tier reference), on AWS
+Bedrock, with extended thinking, at the 2 h wall clock (via the Claude Code
+harness):
+
+- **Sonnet 4.6: 0 / 1 passing** (score 0.0; run hit the 2 h wall — `timeout`).
+- **Opus 4.8 (top-tier):** an attempted run did not yield a usable data point —
+  the Bedrock request timed out after 2 turns (infrastructure, not a genuine
+  attempt), so we do not report an Opus pass rate.
+
+We report this transparently rather than inflate it: it is **one** valid
+second-tier trial, not a large-N pass rate. Two things make it a meaningful
+last-exam signal nonetheless:
+
+1. **The failure is at the formalization, not the mathematics.** From the run
+   transcript, Sonnet 4.6 reconstructs essentially the *entire correct informal
+   proof* in its reasoning — yet in 2 h it never produces a single compiling
+   `.lean` file. The wall is translating a correct argument into a kernel-checked
+   Mathlib proof.
+2. **The intrinsic difficulty markers are strong and agent-independent:** the
+   problem is unformalized in Compfiles and the Mathlib archive (no proof to
+   copy), combinatorics is the genre where formalization most often fails, the
+   reference proof is ~800 lines / 30+ lemmas, and the universally-quantified
+   statement cannot be brute-forced.
+
+*Honest caveat:* part of the observed 2 h failure is a behavioral pattern of the
+Claude Code CLI on this workload (very long extended-thinking phases that crowd
+out the write-compile-iterate loop), not purely task difficulty. A different
+harness might reach the compile stage; we would expect it to then fail on the
+Mathlib formalization for the reasons above. Additional trials / harnesses can be
+run on request.
+
+## 4. Verifiability / genuineness
+
+The reference output (an **evaluator-only** file, delivered out-of-band via the
+ALE reference channel and deliberately **not committed to this public repo** —
+see §7) is a **real, complete proof**: it compiles against Mathlib v4.27 and
+`#print axioms IMO2005P6.imo2005_p6` reports only the standard trusted axioms
+`{propext, Classical.choice, Quot.sound}` — no `sorry`, no added axioms, no
+`native_decide`.
+
+Grading is a deterministic, layered gate (`scripts/grade_lean.py`), score 1.0
+iff **all** pass, else 0.0:
+
+| Gate | Check |
+|------|-------|
+| G1 | Submission keeps the exact `imo2005_p6` signature + `solvedCount`/`numSolvedExactly` definitions (blocks vacuous/weakened restatements). |
+| G2 | Source scan rejects `sorry` / `admit` / `native_decide` / new `axiom`. |
+| G3 | `lean solution.lean` compiles with no errors. |
+| G4 | `#print axioms` ⊆ `{propext, Classical.choice, Quot.sound}` — rejects `sorryAx`, declared axioms, and `Lean.ofReduceBool`. |
+
+The anti-cheat is a **whitelist** (rejects any axiom outside the trusted three,
+including ones we did not anticipate) and fails closed on unparseable output.
+An adversarial battery (`scripts/adversarial_check.py`) verifies that the
+reference scores 1.0 and that sorry / custom-axiom / native_decide /
+weakened-goal / redefined-definition / comment-hidden-signature submissions all
+score 0.0 — including the case that evades the source scan but is caught by the
+axiom audit. `scripts/selftest.py` covers the grader logic without a Lean
+toolchain.
+
+## 5. Provenance and licensing
+
+- The **problem statement** is International Mathematical Olympiad 2005, Problem 6
+  — a factual competition problem statement (not copyrightable subject matter).
+- The **Lean formalization and the reference proof are our original work**,
+  released under the submission's terms (dataset CC BY 4.0).
+- The task depends on **Lean 4** (Apache-2.0) and **Mathlib** (Apache-2.0), both
+  permissively licensed and compatible.
+
+## 6. Toolchain: self-contained, fetched from upstream (no upload, no image)
+
+This is the first Lean task in the benchmark, but it needs **no special
+infrastructure and no data upload**. `start()` fetches its toolchain from
+official upstream at setup time (the sandbox has outbound network, as used by
+other accepted ALE tasks that `pip install` or download at solve time):
+
+- `elan` installs Lean **v4.27.0** from the official Lean releases;
+- `lake exe cache get` downloads the *prebuilt* **Mathlib v4.27** `.olean` cache
+  (~7,900 oleans) from Mathlib's official cache CDN in a few minutes — no
+  building from source.
+
+Verified end-to-end in the `cpu-free-ubuntu` sandbox: the toolchain installs,
+the cache downloads, and the reference proof compiles clean with
+`#print axioms = {propext, Classical.choice, Quot.sound}`. The submission is
+therefore **code-only** (this repo/PR) — there is no `software/` payload to place
+in a data bucket and no custom image to build.
+
+*Optional offline fallback:* `SOFTWARE.md` + `scripts/build_software.sh` document
+pre-staging the same cache as task-data `software/` (≈ 8.1 GB), for a fully
+hermetic/offline variant should the pinned upstream cache ever be
+garbage-collected. Not used by default.
+
+## 7. Conformance to the ALE add-task guide
+
+Verified against `docs/ale-docs-site/pages/add-task.html`:
+- Two-file package (`task_card.json` + `main.py`) with `load()`/`start()`/
+  `evaluate()`; `evaluate()` returns `list[float]` in `[0,1]` and returns
+  `[0.0]` (never raises) on missing output. ✓
+- `taskId` matches the folder path (`computing_math/imo2005p6_lean_v1`). ✓
+- `vm.snapshot: cpu-free-ubuntu`, `vm.timeout: 7200` — same as accepted tasks
+  (e.g. `regex_synth_v1`); paired with `wall_time_s: 7200`. ✓
+- Data model: self-contained (`REQUIRES_TASK_DATA = False`); `start()` fetches
+  the toolchain from upstream and writes `input/` at setup — no task-data
+  staging required. ✓
+- **Reference hiding & solver isolation (leakage mitigation).** The bespoke Lean
+  reference proof is **evaluator-only**: it is *not committed to this public
+  repository* and is delivered out-of-band via the ALE reference channel. Only
+  `input/Problem.lean` (statement + `sorry`, no proof, no hints) plus the
+  `LEANPATH`/`LEANBIN` pointer files are ever staged into the solver sandbox —
+  the reference and grader never are (the grader runs an in-VM compile + axiom
+  audit, so it needs no staged reference file). The *informal* IMO 2005 P6
+  solution is inherently public (a well-known olympiad problem); the protected
+  asset is the machine-checked Lean artifact, which is what a solver would
+  otherwise copy. We recommend the solve phase be run **network-restricted** —
+  the only setup-time network need is fetching the pinned Lean toolchain +
+  prebuilt Mathlib cache from official upstream, and for a fully hermetic variant
+  that fetch can instead be pre-staged as evaluator-supplied task-data (see
+  `SOFTWARE.md`).
+- Submission channel: task idea (description, reference, rubric) via
+  **agenthle.org/submit**, plus adding the task to a `selected_tasks/` list and
+  opening a PR.
+
+## 8. Files
+
+```
+task_card.json               metadata + prompt (formal-verification framing)
+main.py                      load/start/evaluate (ALE task driver)
+assets/Problem.lean          the staged task: statement + fixed defs + sorry
+(reference proof)            EVALUATOR-ONLY — complete, axiom-clean proof;
+                             delivered out-of-band, NOT committed to this repo
+scripts/grade_lean.py        layered deterministic verifier (G1–G4)
+scripts/selftest.py          grader unit battery (no Lean needed)
+scripts/adversarial_check.py end-to-end anti-cheat battery (real compiles)
+scripts/e2e_check.py         compiles the reference through the grader
+scripts/build_software.sh    rebuild the software/ artifact
+SOFTWARE.md                  software/ layout + upload instructions
+README.md                    task overview
+SUBMISSION.md                this document
+```

--- a/tasks/computing_math/imo2005p6_lean_v1/assets/Problem.lean
+++ b/tasks/computing_math/imo2005p6_lean_v1/assets/Problem.lean
@@ -1,0 +1,61 @@
+import Mathlib
+open Finset
+
+/-!
+# IMO 2005, Problem 6 — formalization task
+
+In a mathematical competition, 6 problems were posed to the contestants. Every
+pair of these problems was solved by *more than* 2/5 of the contestants, and no
+contestant solved all 6 problems. Prove that there are at least two contestants
+who each solved exactly 5 problems.
+
+## Your task
+
+Replace the `sorry` in `imo2005_p6` below with a complete Lean 4 / Mathlib proof.
+
+## Formalization contract (do NOT change any of the following)
+
+* `C` is the (finite, decidable-equality) type of contestants; `Fintype.card C`
+  is the number `n` of contestants.
+* `solved c p` means contestant `c` solved problem `p : Fin 6`.
+* `numSolvedExactly solved k` is the number of contestants who solved exactly `k`
+  of the 6 problems.
+* `hpair` encodes "every pair `i ≠ j` was solved by more than 2/5 of the
+  contestants": with `m` the number of contestants solving both `i` and `j`,
+  the integer form of `m > 2n/5` is `2 * n < 5 * m`.
+* `hnall` encodes "no contestant solved all 6 problems".
+* The goal `2 ≤ numSolvedExactly solved 5` is "at least two contestants solved
+  exactly 5 problems".
+
+You MUST keep the signature of `imo2005_p6` **exactly** as given (same name, same
+hypotheses, same conclusion, same auxiliary definitions `solvedCount` /
+`numSolvedExactly`). You may add any number of auxiliary lemmas/definitions
+before it. Your submission must compile against Mathlib with **no `sorry`, no new
+`axiom`s, and no `native_decide`** (the grader rejects all of these).
+-/
+
+namespace IMO2005P6
+
+variable {C : Type*} [Fintype C] [DecidableEq C]
+
+/-- Number of problems contestant `c` solved. -/
+abbrev solvedCount (solved : C → Fin 6 → Prop) [DecidableRel solved] (c : C) : ℕ :=
+  (univ.filter (fun p => solved c p)).card
+
+/-- Number of contestants who solved exactly `k` problems. -/
+abbrev numSolvedExactly (solved : C → Fin 6 → Prop) [DecidableRel solved] (k : ℕ) : ℕ :=
+  (univ.filter (fun c => solvedCount solved c = k)).card
+
+/-- **IMO 2005, Problem 6.** In a competition with 6 problems where every pair of
+problems was solved by more than 2/5 of the contestants and nobody solved all 6,
+at least two contestants each solved exactly 5 problems. -/
+theorem imo2005_p6
+    (solved : C → Fin 6 → Prop) [DecidableRel solved]
+    (n : ℕ) (hn : n = Fintype.card C)
+    (hpair : ∀ i j : Fin 6, i ≠ j →
+      2 * n < 5 * (univ.filter (fun c => solved c i ∧ solved c j)).card)
+    (hnall : ∀ c : C, ∃ p : Fin 6, ¬ solved c p) :
+    2 ≤ numSolvedExactly solved 5 := by
+  sorry
+
+end IMO2005P6

--- a/tasks/computing_math/imo2005p6_lean_v1/main.py
+++ b/tasks/computing_math/imo2005p6_lean_v1/main.py
@@ -1,0 +1,392 @@
+"""Linux task: formalize & prove IMO 2005 Problem 6 in Lean 4 / Mathlib.
+
+The agent is given ``Problem.lean`` — the exact theorem statement (with fixed
+auxiliary definitions) and a `sorry` — and must produce ``solution.lean`` that
+replaces the `sorry` with a complete Lean 4 / Mathlib proof.
+
+Grading is a deterministic, layered anti-cheat gate (see ``scripts/grade_lean.py``):
+
+  G1  SIGNATURE PIN  — the submission keeps the exact `imo2005_p6` signature and
+                       the `solvedCount` / `numSolvedExactly` definitions, so a
+                       weaker or vacuous restatement cannot pass.
+  G2  SOURCE SCAN    — reject `sorry` / `admit` / `native_decide` / new `axiom`s.
+  G3  COMPILE        — `lean solution.lean` must exit 0 with no `error:`.
+  G4  AXIOM AUDIT    — `#print axioms IMO2005P6.imo2005_p6` must depend only on
+                       {propext, Classical.choice, Quot.sound}; this rejects
+                       `sorryAx`, solver axioms, and `Lean.ofReduceBool`.
+
+Score is 1.0 iff all gates pass (a genuine, complete, axiom-clean proof of the
+exact theorem), else 0.0.
+
+Toolchain: fetched from official upstream at setup — no data-bucket upload.
+``start`` installs Lean 4.27.0 via ``elan`` and pulls the prebuilt Mathlib v4.27
+``.olean`` cache via ``lake exe cache get`` (the sandbox has outbound network),
+then writes ``Problem.lean`` plus ``LEANPATH``/``LEANBIN`` pointer files;
+``evaluate`` compiles the agent's ``solution.lean`` read-only against that cache.
+
+Modeled on computing_math/regex_synth_v1 (self-contained config, in-VM grading,
+layered reward-hack defense), adapted from differential testing to Lean proof
+verification via axiom audit.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import cua_bench as cb
+
+from tasks.linux_runtime import LinuxTaskConfig
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+try:  # pragma: no cover - import guard
+    from grade_lean import grade as grade_lean_async
+except Exception:  # pragma: no cover
+    grade_lean_async = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_NAME = "computing_math"
+TASK_NAME = "imo2005p6_lean_v1"
+VARIANT_NAME = "base"
+
+# Local (HOST) path to the problem statement staged into the VM.
+_PROBLEM_LEAN = Path(__file__).resolve().parent / "assets" / "Problem.lean"
+
+# The Lean 4.27.0 toolchain + Mathlib v4.27 .olean cache are fetched from OFFICIAL
+# UPSTREAM at setup time (the sandbox has outbound network): `elan` installs Lean
+# from releases.lean-lang.org, and `lake exe cache get` downloads the prebuilt
+# Mathlib cache from Mathlib's official Azure cache — no hosting, no data-bucket
+# upload. `start()` sets up a pinned Lake project at LEAN_PROJECT and populates
+# .lake/packages/<pkg>/.lake/build/lib/lean; the olean search path is the
+# colon-join of those dirs (auto-discovered so the exact dependency set is robust
+# to Mathlib's manifest changing between versions).
+LEAN_VERSION = "leanprover/lean4:v4.27.0"
+MATHLIB_REV = "v4.27.0"
+_ELAN_HOME = "/home/kasm-user/.elan"
+_LEAN_BIN = f"{_ELAN_HOME}/bin/lean"
+_LEAN_PROJECT = "/home/kasm-user/.ale_lean/mlproj"
+_LEAN_PKGS = f"{_LEAN_PROJECT}/.lake/packages"
+
+_COMPILE_TIMEOUT_S = 900  # generous: first Mathlib import + a large proof file.
+
+
+@dataclass
+class TaskConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = DOMAIN_NAME
+    TASK_NAME: str = TASK_NAME
+    VARIANT_NAME: str = VARIANT_NAME
+    OS_TYPE: str = "linux"
+    # Self-contained: no task-data staging. start() fetches the toolchain from
+    # upstream and writes the problem file; grading compiles in-sandbox.
+    REQUIRES_TASK_DATA: bool = False
+
+    @property
+    def problem_file(self) -> str:
+        return f"{self.input_dir}/Problem.lean"
+
+    @property
+    def lean_bin(self) -> str:
+        return _LEAN_BIN
+
+    @property
+    def solution_path(self) -> str:
+        return f"{self.remote_output_dir}/solution.lean"
+
+    @property
+    def task_description(self) -> str:
+        return f"""You are a formal-methods engineer. Your job is to produce a
+machine-checked Lean 4 (with Mathlib) proof of a specified theorem — the kind of
+verification artifact used to certify that a mathematical claim holds with zero
+trust in informal argument.
+
+## The statement to prove
+
+The exact theorem, with its fixed auxiliary definitions and a `sorry`
+placeholder, is staged at:
+
+```text
+{self.problem_file}
+```
+
+Read it in full. It formalizes: *in a competition with 6 problems where every
+pair of problems was solved by more than 2/5 of the contestants and nobody
+solved all 6, at least two contestants each solved exactly 5 problems.*
+
+## Your task
+
+Create exactly one file:
+
+```text
+{self.solution_path}
+```
+
+It must be `Problem.lean` with the `sorry` in `imo2005_p6` replaced by a
+complete proof. You MUST keep the `imo2005_p6` signature and the `solvedCount` /
+`numSolvedExactly` definitions **exactly** as given (the grader pins them). You
+may add any auxiliary lemmas/definitions before the theorem.
+
+## Toolchain (installed at setup)
+
+- Lean 4.27.0 and the prebuilt Mathlib v4.27 `.olean` cache are already installed
+  (fetched at task setup). The `lean` binary path is in `{self.input_dir}/LEANBIN`
+  and the olean search path is in `{self.input_dir}/LEANPATH`.
+- Compile your file read-only against the cache with:
+
+```bash
+env LEAN_PATH="$(cat {self.input_dir}/LEANPATH)" "$(cat {self.input_dir}/LEANBIN)" {self.solution_path}
+```
+
+  (`lean` is also on `PATH`, so `env LEAN_PATH=... lean ...` works too.)
+  Use the prebuilt cache — do NOT run `lake build` on Mathlib (it would rebuild
+  from source and take hours). Iterate by editing `solution.lean` and re-running
+  the compile command above.
+
+## Grading (deterministic)
+
+Score is 1.0 only if ALL of the following hold, else 0.0:
+1. Your file keeps the exact required `imo2005_p6` signature and definitions.
+2. It contains no `sorry`, `admit`, `native_decide`, or new `axiom`.
+3. `lean solution.lean` compiles with no errors.
+4. `#print axioms IMO2005P6.imo2005_p6` depends only on the standard trusted
+   axioms `propext`, `Classical.choice`, `Quot.sound`. Any `sorryAx`, declared
+   axiom, or `Lean.ofReduceBool` (from `native_decide`) fails the task.
+
+In other words: only a genuine, complete, axiom-clean proof of the exact theorem
+scores. Treat `{self.input_dir}` as read-only; keep your proof in
+`{self.solution_path}`.
+"""
+
+    def to_metadata(self) -> dict[str, Any]:
+        metadata = super().to_metadata()
+        metadata.update(
+            {
+                "task_id": f"{DOMAIN_NAME}/{TASK_NAME}",
+                "variant_name": VARIANT_NAME,
+                "input_dir": self.input_dir,
+                "remote_output_dir": self.remote_output_dir,
+                "problem_file": self.problem_file,
+                "solution_path": self.solution_path,
+                "lean_bin": self.lean_bin,
+                "lean_version": LEAN_VERSION,
+                "mathlib_rev": MATHLIB_REV,
+                "elan_home": _ELAN_HOME,
+                "lean_project": _LEAN_PROJECT,
+                "lean_pkgs": _LEAN_PKGS,
+                # lean_path is discovered + written by start() after cache fetch.
+            }
+        )
+        return metadata
+
+
+config = TaskConfig()
+
+
+@cb.tasks_config(split="train")
+def load():
+    cfg = TaskConfig()
+    return [
+        cb.Task(
+            description=cfg.task_description,
+            metadata=cfg.to_metadata(),
+            computer={"provider": "computer", "setup_config": {"os_type": cfg.OS_TYPE}},
+        )
+    ]
+
+
+_ELAN_INIT_URL = "https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh"
+
+
+def _result_out_code(result) -> tuple[str, int]:
+    """Normalize a run_command result (dict {stdout,stderr,return_code,success}
+    from RemoteDesktopSession, or a CompletedProcess-like object) to
+    (combined_output, exit_code)."""
+    if isinstance(result, dict):
+        out = str(result.get("stdout", "")) + str(result.get("stderr", ""))
+        code = result.get("return_code")
+        if code is None:
+            code = 0 if result.get("success") else 1
+        return out, int(code)
+    stdout = getattr(result, "stdout", result)
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", "replace")
+    stderr = getattr(result, "stderr", "")
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", "replace")
+    code = getattr(result, "returncode", getattr(result, "exit_code", 0)) or 0
+    return str(stdout) + str(stderr), int(code)
+
+
+async def _setup_toolchain(session, meta) -> str:
+    """Install Lean + fetch the prebuilt Mathlib cache from upstream, idempotently.
+    Returns the discovered LEAN_PATH (colon-joined olean dirs). Raises on failure.
+
+    NOTE: this sandbox's ``run_command`` does NOT report reliable exit codes
+    (the cua interface defaults return_code to 0), so state is detected via
+    STDOUT SENTINELS and the presence of expected files — never exit codes."""
+    elan = meta["elan_home"]
+    proj = meta["lean_project"]
+    lean_bin = meta["lean_bin"]
+    mathlib_olean = f"{meta['lean_pkgs']}/mathlib/.lake/build/lib/lean/Mathlib.olean"
+
+    async def _out(cmd: str) -> str:
+        r = await session.run_command(cmd, check=False)
+        out, _ = _result_out_code(r)
+        return out
+
+    # Idempotent: a populated cache is present iff the sentinel prints.
+    probe = await _out(f"test -x {lean_bin!r} && test -f {mathlib_olean!r} && echo __READY__")
+    already = "__READY__" in probe
+    logger.info("[imo2005p6] toolchain probe: already=%s", already)
+
+    if not already:
+        # 1. install elan + the pinned Lean toolchain from the official releases.
+        o = await _out(
+            f"curl -sSf --max-time 120 {_ELAN_INIT_URL} -o /tmp/elan-init.sh && "
+            f"ELAN_HOME={elan!r} sh /tmp/elan-init.sh -y --default-toolchain {LEAN_VERSION} "
+            f"&& test -x {lean_bin!r} && echo __ELAN_OK__"
+        )
+        logger.info("[imo2005p6] elan-install tail: %s", o[-400:])
+        if "__ELAN_OK__" not in o:
+            raise RuntimeError(f"imo2005p6: elan/Lean install failed: {o[-500:]}")
+
+        # 2. create a pinned Lake project requiring Mathlib @ MATHLIB_REV.
+        lakefile = (
+            'name = "mlproj"\n'
+            'defaultTargets = ["MlProj"]\n\n'
+            '[[require]]\n'
+            'name = "mathlib"\n'
+            'scope = "leanprover-community"\n'
+            f'rev = "{MATHLIB_REV}"\n'
+        )
+        await session.run_command(f"mkdir -p {proj}/MlProj", check=False)
+        await session.write_file(f"{proj}/lakefile.toml", lakefile)
+        await session.write_file(f"{proj}/lean-toolchain", LEAN_VERSION + "\n")
+        await session.write_file(f"{proj}/MlProj.lean", "import Mathlib\n")
+
+        # 3. resolve deps + fetch the PREBUILT olean cache from Mathlib's CDN
+        #    (minutes; NOT `lake build`, which would compile from source for hours).
+        o = await _out(
+            f"cd {proj!r} && ELAN_HOME={elan!r} PATH={elan}/bin:$PATH lake update && echo __UPDATE_OK__"
+        )
+        logger.info("[imo2005p6] lake-update tail: %s", o[-400:])
+        o = await _out(
+            f"cd {proj!r} && ELAN_HOME={elan!r} PATH={elan}/bin:$PATH lake exe cache get 2>&1 | tail -3"
+        )
+        logger.info("[imo2005p6] cache-get tail: %s", o[-400:])
+        # verify the cache actually landed (sentinel on the real olean file).
+        chk = await _out(f"test -f {mathlib_olean!r} && echo __CACHE_OK__")
+        if "__CACHE_OK__" not in chk:
+            raise RuntimeError(f"imo2005p6: Mathlib cache not present after cache get: {o[-500:]}")
+
+    # Discover the olean search path: every dependency's build/lib/lean dir.
+    disc = await _out(
+        f"for d in {meta['lean_pkgs']}/*/.lake/build/lib/lean; do "
+        f"[ -d \"$d\" ] && printf '%s:' \"$d\"; done"
+    )
+    lean_path = disc.strip().rstrip(":")
+    if not lean_path:
+        raise RuntimeError("imo2005p6: no olean dirs found after cache fetch")
+    logger.info("[imo2005p6] LEAN_PATH discovered: %d dirs", lean_path.count(":") + 1)
+    return lean_path
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    """Fetch the Lean/Mathlib toolchain from upstream, stage Problem.lean, and
+    write the LEANPATH/LEANBIN pointer files. No task-data upload: `elan` installs
+    Lean and `lake exe cache get` pulls the prebuilt Mathlib cache over the
+    sandbox's network."""
+    meta = task_cfg.metadata
+
+    for d in (meta["input_dir"], meta["remote_output_dir"]):
+        await session.run_command(f"mkdir -p {d!r}", check=False)
+    await session.run_command(f"rm -f {meta['solution_path']!r}", check=False)
+
+    # Fetch/verify the toolchain and discover the olean search path.
+    lean_path = await _setup_toolchain(session, meta)
+    meta["lean_path"] = lean_path  # record for evaluate()
+
+    # The problem statement (statement + fixed defs + `sorry`). No proof, no hints.
+    await session.write_file(meta["problem_file"], _PROBLEM_LEAN.read_text(encoding="utf-8"))
+
+    # Pointer files: LEANPATH = olean search path, LEANBIN = the lean binary.
+    await session.write_file(f"{meta['input_dir']}/LEANPATH", lean_path)
+    await session.write_file(f"{meta['input_dir']}/LEANBIN", meta["lean_bin"])
+
+    # Expose `lean` on PATH for the agent's convenience.
+    await session.run_command(
+        f"ln -sf {meta['lean_bin']!r} /usr/local/bin/lean 2>/dev/null "
+        f"|| sudo ln -sf {meta['lean_bin']!r} /usr/local/bin/lean 2>/dev/null || true",
+        check=False,
+    )
+
+    logger.info("[imo2005p6] toolchain ready; staged problem at %s; lean_bin=%s",
+                meta["problem_file"], meta["lean_bin"])
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    """Compile the agent's solution.lean in-sandbox and audit its axioms."""
+    meta = task_cfg.metadata
+
+    if grade_lean_async is None:
+        logger.error("[imo2005p6] grade_lean did not import")
+        return [0.0]
+
+    # The agent must have produced solution.lean.
+    try:
+        raw = await session.read_bytes(meta["solution_path"])
+        src = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else str(raw)
+    except Exception as exc:
+        logger.info("[imo2005p6] solution missing at %s: %s", meta["solution_path"], exc)
+        return [0.0]
+
+    # LEAN_PATH: prefer the pointer file start() wrote (durable across hooks);
+    # fall back to metadata if present.
+    lean_path = meta.get("lean_path")
+    try:
+        raw_lp = await session.read_bytes(f"{meta['input_dir']}/LEANPATH")
+        lp = raw_lp.decode("utf-8", "replace") if isinstance(raw_lp, bytes) else str(raw_lp)
+        lp = lp.strip()
+        if lp:
+            lean_path = lp
+    except Exception:
+        pass
+    if not lean_path:
+        logger.error("[imo2005p6] no LEANPATH available for grading")
+        return [0.0]
+
+    async def run(cmd: str, timeout: int):
+        # RemoteDesktopSession.run_command takes no timeout kwarg; the `timeout`
+        # arg from the grader is advisory only (the harness wall clock bounds us).
+        try:
+            result = await session.run_command(cmd, check=False)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.info("[imo2005p6] command failed: %s (%s)", cmd, exc)
+            return ("", 1)
+        out, code = _result_out_code(result)
+        return (out, code)
+
+    result = await grade_lean_async(
+        src=src,
+        run=run,
+        solution_path=meta["solution_path"],
+        lean_path_env=lean_path,
+        workdir=meta["remote_output_dir"],
+        lean_bin=meta.get("lean_bin", "lean"),
+        per_compile_timeout=_COMPILE_TIMEOUT_S,
+    )
+    logger.info("[imo2005p6] score=%.4f gate=%s reason=%s", result.score, result.gate, result.reason)
+    return [float(result.score)]
+
+
+if __name__ == "__main__":
+    for task in load():
+        print(task.description)

--- a/tasks/computing_math/imo2005p6_lean_v1/scripts/adversarial_check.py
+++ b/tasks/computing_math/imo2005p6_lean_v1/scripts/adversarial_check.py
@@ -1,0 +1,84 @@
+"""Adversarial end-to-end check: compile real cheat attempts against Mathlib and
+run each through the full grader (G1-G4), asserting EVERY non-genuine submission
+scores 0.0 and (when available) the genuine reference scores 1.0.
+
+Needs the Lean cache + an `lc.sh`-style wrapper (see e2e_check.py). The reference
+proof is EVALUATOR-ONLY (not committed to the public repo); supply it via
+IMO2005P6_REFERENCE to include the genuine-reference cases. Usage:
+    IMO2005P6_REFERENCE=/path/reference_solution.lean \\
+    LEAN_LC=/path/lc.sh LEAN_WORK=/path/leanproj python3 scripts/adversarial_check.py
+"""
+from __future__ import annotations
+import asyncio, os, re, subprocess, sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+from grade_lean import grade  # noqa: E402
+
+LC = os.environ.get("LEAN_LC", "/local/home/hihgupta/workspace/lean_imo2005p6/lc.sh")
+WORK = os.environ.get("LEAN_WORK", "/local/home/hihgupta/workspace/lean_imo2005p6")
+PROB = (_HERE.parent / "assets" / "Problem.lean").read_text(encoding="utf-8")
+
+# EVALUATOR-ONLY reference proof (not committed to the public repo).
+_REF_PATH = Path(os.environ.get(
+    "IMO2005P6_REFERENCE",
+    "/local/home/hihgupta/workspace/imo2005p6_eval_only/reference_solution.lean"))
+REF = None
+if _REF_PATH.is_file():
+    REF = _REF_PATH.read_text(encoding="utf-8").replace(
+        "\n#print axioms IMO2005P6.imo2005_p6\n", "\n")
+
+def _defs():  # the fixed preamble a submission must keep
+    return PROB[:PROB.index("theorem imo2005_p6")]
+
+# Build cheat variants (source strings). Reference-derived cases are included
+# only when the evaluator-only reference proof is available.
+CHEATS = {}
+if REF is not None:
+    CHEATS["genuine_reference"] = (REF, True)
+CHEATS["sorry_placeholder"] = (PROB, False)
+CHEATS["custom_axiom"] = (
+    PROB.replace("namespace IMO2005P6",
+                 "namespace IMO2005P6\naxiom cheat_ax {C:Type*}[Fintype C][DecidableEq C]"
+                 "(solved:C→Fin 6→Prop)[DecidableRel solved]: 2 ≤ numSolvedExactly solved 5")
+        .replace("  sorry", "  exact cheat_ax solved"), False)
+CHEATS["native_decide"] = (PROB.replace("  sorry", "  native_decide"), False)
+CHEATS["sorryAx_no_literal"] = (
+    PROB.replace("  sorry", "  exact sorryAx (2 ≤ numSolvedExactly solved 5) true"), False)
+CHEATS["weaken_goal_5to0"] = (
+    PROB.replace("2 ≤ numSolvedExactly solved 5", "0 ≤ numSolvedExactly solved 5")
+        .replace("  sorry", "  exact Nat.zero_le _"), False)
+if REF is not None:
+    CHEATS["redefine_numSolved_const"] = (
+        REF.replace("(univ.filter (fun c => solvedCount solved c = k)).card", "2", 1), False)
+CHEATS["sig_in_comment_trivial_thm"] = (
+    _defs().replace("theorem imo2005_p6", "/- theorem imo2005_p6 stmt -/")  # dummy
+    + "theorem imo2005_p6 : True := trivial\nend IMO2005P6\n", False)
+
+async def _run(cmd, timeout):
+    m = re.match(r"env LEAN_PATH=.*? \S*lean\S* (.+)$", cmd)  # env LEAN_PATH=.. <bin> <file>
+    if m:
+        real = f"{LC} {m.group(1)}"
+    else:
+        real = cmd
+    p = subprocess.run(real, shell=True, capture_output=True, text=True, timeout=timeout, cwd=WORK)
+    return (p.stdout + p.stderr, p.returncode)
+
+async def main() -> int:
+    all_ok = True
+    for name, (src, want_pass) in CHEATS.items():
+        sub = f"{WORK}/_adv_{name}.lean"
+        Path(sub).write_text(src, encoding="utf-8")
+        r = await grade(src, _run, sub, "IGNORED", WORK, lean_bin=f"{WORK}/lc.sh",
+                        per_compile_timeout=600)
+        ok = (r.passed == want_pass)
+        all_ok &= ok
+        exp = "1.0" if want_pass else "0.0"
+        flag = "ok " if ok else "XX "
+        print(f"  {flag}{name:30s} want={exp} got={r.score} gate={r.gate} ({r.reason})")
+    print("\nRESULT:", "ALL PASS" if all_ok else "FAILURES ABOVE")
+    return 0 if all_ok else 1
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tasks/computing_math/imo2005p6_lean_v1/scripts/build_software.sh
+++ b/tasks/computing_math/imo2005p6_lean_v1/scripts/build_software.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Build the task's software/ artifact (Lean 4.27.0 toolchain + Mathlib v4.27 oleans).
+# Usage: build_software.sh <ELAN_TOOLCHAIN_DIR> <MATHLIB_LAKE_PACKAGES_DIR> <OUT_DIR>
+#   ELAN_TOOLCHAIN_DIR   e.g. ~/.elan/toolchains/leanprover--lean4---v4.27.0
+#   MATHLIB_LAKE_PACKAGES_DIR  e.g. <checkout>/.lake/packages  (has mathlib/, aesop/, ...)
+#   OUT_DIR              destination software/ tree
+set -euo pipefail
+TC="$1"; PKGS="$2"; OUT="$3"
+mkdir -p "$OUT/elan/toolchains" "$OUT/mathlib/packages"
+cp -a "$TC" "$OUT/elan/toolchains/"
+for p in aesop batteries Cli importGraph LeanSearchClient mathlib plausible proofwidgets Qq; do
+  mkdir -p "$OUT/mathlib/packages/$p/.lake/build/lib"
+  cp -a "$PKGS/$p/.lake/build/lib/lean" "$OUT/mathlib/packages/$p/.lake/build/lib/lean"
+done
+echo "software/ built at $OUT ($(du -sh "$OUT" | cut -f1))"

--- a/tasks/computing_math/imo2005p6_lean_v1/scripts/e2e_check.py
+++ b/tasks/computing_math/imo2005p6_lean_v1/scripts/e2e_check.py
@@ -1,0 +1,74 @@
+"""End-to-end check: actually compile the reference proof against Mathlib and
+run it through the real async grader (G1-G4), asserting score 1.0; and confirm a
+`sorry` submission scores 0.0.
+
+Unlike selftest.py (which feeds synthetic compiler output), this compiles for
+real, so it requires a working Lean 4.27.0 + Mathlib v4.27 cache and a small
+shell shim that mimics the sandbox `run(cmd, timeout) -> (stdout, exit)`.
+
+Usage (host, with the local Lean cache used during authoring):
+    IMO2005P6_REFERENCE=/path/to/reference_solution.lean \\
+    LEAN_LC=/local/home/hihgupta/workspace/lean_imo2005p6/lc.sh \\
+    LEAN_WORK=/local/home/hihgupta/workspace/lean_imo2005p6 \\
+    python3 scripts/e2e_check.py
+
+The reference proof is EVALUATOR-ONLY and is NOT committed to this public repo
+(committing it would leak the answer to a solver with web access). Supply it via
+IMO2005P6_REFERENCE (defaults to the local eval-only copy used during authoring).
+
+`lc.sh` is a wrapper that sets LEAN_PATH to the prebuilt cache and runs `lean`.
+On the task VM the equivalent is `env LEAN_PATH="$(cat input/LEANPATH)" lean`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+from grade_lean import grade  # noqa: E402
+
+LC = os.environ.get("LEAN_LC", "/local/home/hihgupta/workspace/lean_imo2005p6/lc.sh")
+WORK = os.environ.get("LEAN_WORK", "/local/home/hihgupta/workspace/lean_imo2005p6")
+# EVALUATOR-ONLY: the reference proof is deliberately NOT in this public repo.
+REFERENCE = Path(os.environ.get(
+    "IMO2005P6_REFERENCE",
+    "/local/home/hihgupta/workspace/imo2005p6_eval_only/reference_solution.lean",
+))
+
+
+async def _run(cmd: str, timeout: int):
+    # Translate the grader's `env LEAN_PATH=... lean <file>` into the local lc.sh
+    # wrapper (which already sets LEAN_PATH); pass other commands through.
+    m = re.match(r"env LEAN_PATH=.* lean (.+)$", cmd)
+    real = f"{LC} {m.group(1)}" if m else cmd
+    p = subprocess.run(real, shell=True, capture_output=True, text=True, timeout=timeout, cwd=WORK)
+    return (p.stdout + p.stderr, p.returncode)
+
+
+async def main() -> int:
+    if not REFERENCE.is_file():
+        print(f"SKIP: evaluator-only reference not found at {REFERENCE} "
+              f"(set IMO2005P6_REFERENCE); it is not committed to the public repo.")
+        return 0
+    ref = REFERENCE.read_text(encoding="utf-8")
+    ref = ref.replace("\n#print axioms IMO2005P6.imo2005_p6\n", "\n")
+    sub = Path(WORK) / "_e2e_sub.lean"
+    sub.write_text(ref, encoding="utf-8")
+
+    r = await grade(ref, _run, str(sub), "IGNORED", WORK, per_compile_timeout=1200)
+    print(f"REFERENCE: passed={r.passed} score={r.score} gate={r.gate} :: {r.reason}")
+    print(f"           axioms={r.details.get('axioms')}")
+    ok = r.passed and r.score == 1.0
+
+    print("RESULT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tasks/computing_math/imo2005p6_lean_v1/scripts/grade_lean.py
+++ b/tasks/computing_math/imo2005p6_lean_v1/scripts/grade_lean.py
@@ -1,0 +1,274 @@
+"""Grader for the IMO 2005 P6 Lean-formalization task.
+
+The agent submits ``solution.lean`` — the ``Problem.lean`` interface with the
+`sorry` in ``imo2005_p6`` replaced by a real Lean 4 / Mathlib proof (plus any
+auxiliary lemmas it likes). Grading is a layered, deterministic gate; the score
+is 1.0 only if the submission is a genuine, complete, axiom-clean proof of the
+*exact* required theorem, and 0.0 otherwise.
+
+Layers (all must pass for score 1.0):
+
+  G1. SIGNATURE PIN — the submission must contain the `imo2005_p6` declaration
+      with byte-for-byte the required signature (name, binders, hypotheses,
+      conclusion) and the two auxiliary definitions `solvedCount` /
+      `numSolvedExactly` with their required bodies. This stops an agent from
+      "proving" a weaker/vacuous restatement.
+
+  G2. SOURCE SCAN — reject `sorry`, `admit`, `native_decide`, `axiom`, and other
+      escape hatches at the source level (defense-in-depth; G4 is the real gate).
+
+  G3. COMPILE — the file must compile against Mathlib with `lean` exiting 0 and
+      no `error:` in its output. A `sorry` also emits only a warning, so G3
+      alone is not sufficient — hence G4.
+
+  G4. AXIOM AUDIT — append `#print axioms IMO2005P6.imo2005_p6`, recompile, and
+      require the reported axiom set to be a SUBSET of the trusted whitelist
+      {propext, Classical.choice, Quot.sound}. This rejects `sorryAx` (holes),
+      any solver-declared `axiom`, and `Lean.ofReduceBool` (the `native_decide`
+      compiler-trust axiom) — i.e. every way to close the goal without a real
+      proof.
+
+This module is import-safe on the host (no Lean required to import); the actual
+compilation happens inside the sandbox via a caller-supplied ``run`` coroutine
+in :func:`grade`, or synchronously in :func:`grade_local` for host self-tests.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable
+
+# The only axioms a genuine Mathlib proof is permitted to depend on.
+AXIOM_WHITELIST = {"propext", "Classical.choice", "Quot.sound"}
+
+# The fully-qualified name of the theorem the agent must prove.
+TARGET_THEOREM = "IMO2005P6.imo2005_p6"
+
+# Source-level escape hatches that HARD-FAIL G2 (case-insensitive word-ish match).
+# `native_decide` and `axiom` are also caught by the axiom audit (G4), but we
+# reject them early with a clear reason. Comments are stripped before scanning.
+_BANNED_SOURCE = [
+    r"\bsorry\b",
+    r"\badmit\b",
+    r"\bnative_decide\b",
+    r"^\s*axiom\b",          # a new axiom declaration
+    r"\baddDecl\b",          # metaprogramming that injects declarations
+    r"\bimplemented_by\b",   # can smuggle native behavior
+    r"\bofReduceBool\b",
+    r"\blean_ofReduceBool\b",
+]
+_BANNED_RE = re.compile("|".join(_BANNED_SOURCE), re.IGNORECASE | re.MULTILINE)
+
+
+# --- G1: the exact declarations the submission MUST contain, whitespace-normalized. ---
+# We normalize runs of whitespace to a single space and strip, then require these
+# substrings to be present. This pins the theorem's meaning without being brittle
+# about indentation / line breaks.
+_REQUIRED_SIGNATURE = (
+    "theorem imo2005_p6 "
+    "(solved : C → Fin 6 → Prop) [DecidableRel solved] "
+    "(n : ℕ) (hn : n = Fintype.card C) "
+    "(hpair : ∀ i j : Fin 6, i ≠ j → "
+    "2 * n < 5 * (univ.filter (fun c => solved c i ∧ solved c j)).card) "
+    "(hnall : ∀ c : C, ∃ p : Fin 6, ¬ solved c p) : "
+    "2 ≤ numSolvedExactly solved 5"
+)
+_REQUIRED_SOLVEDCOUNT = (
+    "abbrev solvedCount (solved : C → Fin 6 → Prop) [DecidableRel solved] (c : C) : ℕ := "
+    "(univ.filter (fun p => solved c p)).card"
+)
+_REQUIRED_NUMSOLVED = (
+    "abbrev numSolvedExactly (solved : C → Fin 6 → Prop) [DecidableRel solved] (k : ℕ) : ℕ := "
+    "(univ.filter (fun c => solvedCount solved c = k)).card"
+)
+# The required namespace + variable line so the pinned names resolve as intended.
+_REQUIRED_NAMESPACE = "namespace IMO2005P6"
+_REQUIRED_VARIABLE = "variable {C : Type*} [Fintype C] [DecidableEq C]"
+
+
+def _strip_comments(src: str) -> str:
+    """Remove Lean line comments (``--``) and block comments (``/- … -/``)."""
+    # Block comments (non-greedy, across lines). Lean block comments nest, but a
+    # single non-nested pass is enough for scanning purposes here.
+    src = re.sub(r"/-.*?-/", " ", src, flags=re.DOTALL)
+    # Line comments.
+    src = re.sub(r"--[^\n]*", " ", src)
+    return src
+
+
+def _normalize_ws(src: str) -> str:
+    return re.sub(r"\s+", " ", src).strip()
+
+
+@dataclass
+class GradeResult:
+    score: float
+    passed: bool
+    gate: str                      # which gate decided the outcome
+    reason: str
+    details: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "score": self.score,
+            "passed": self.passed,
+            "gate": self.gate,
+            "reason": self.reason,
+            "details": self.details,
+        }
+
+
+def check_signature(src: str) -> tuple[bool, str]:
+    """G1 — the submission pins the exact theorem + auxiliary definitions."""
+    body = _strip_comments(src)
+    norm = _normalize_ws(body)
+    if _REQUIRED_NAMESPACE not in body:
+        return False, "missing `namespace IMO2005P6`"
+    if _normalize_ws(_REQUIRED_VARIABLE) not in norm:
+        return False, "missing/edited `variable {C : Type*} [Fintype C] [DecidableEq C]`"
+    if _normalize_ws(_REQUIRED_SOLVEDCOUNT) not in norm:
+        return False, "missing/edited `solvedCount` definition"
+    if _normalize_ws(_REQUIRED_NUMSOLVED) not in norm:
+        return False, "missing/edited `numSolvedExactly` definition"
+    if _normalize_ws(_REQUIRED_SIGNATURE) not in norm:
+        return False, "missing/edited `imo2005_p6` signature"
+    return True, "signature pinned OK"
+
+
+def scan_source(src: str) -> tuple[bool, str]:
+    """G2 — reject source-level escape hatches (comments stripped first)."""
+    body = _strip_comments(src)
+    m = _BANNED_RE.search(body)
+    if m:
+        return False, f"banned construct in source: {m.group(0)!r}"
+    return True, "source scan OK"
+
+
+def parse_axioms(print_axioms_output: str) -> set[str] | None:
+    """Parse the `#print axioms` output into a set of axiom names.
+
+    Recognizes both:
+      "'<thm>' depends on axioms: [a, b, c]"
+      "'<thm>' does not depend on any axioms"
+    Returns None if no recognizable line is found.
+    """
+    if "does not depend on any axioms" in print_axioms_output:
+        return set()
+    m = re.search(r"depends on axioms:\s*\[([^\]]*)\]", print_axioms_output)
+    if not m:
+        return None
+    inner = m.group(1).strip()
+    if not inner:
+        return set()
+    return {a.strip() for a in inner.split(",") if a.strip()}
+
+
+def check_axioms(print_axioms_output: str) -> tuple[bool, str, set[str] | None]:
+    """G4 — the theorem depends only on whitelisted axioms."""
+    axioms = parse_axioms(print_axioms_output)
+    if axioms is None:
+        return False, "could not parse `#print axioms` output", None
+    extra = axioms - AXIOM_WHITELIST
+    if extra:
+        return False, f"disallowed axioms: {sorted(extra)}", axioms
+    return True, "axiom audit OK", axioms
+
+
+def compile_ok(compile_output: str, exit_code: int) -> tuple[bool, str]:
+    """G3 — lean exits 0 and prints no `error:`."""
+    if exit_code != 0:
+        return False, f"lean exited with code {exit_code}"
+    if re.search(r"^\S*error:", compile_output, re.MULTILINE) or "error:" in compile_output:
+        first = next((ln for ln in compile_output.splitlines() if "error:" in ln), "error")
+        return False, f"compile error: {first.strip()[:200]}"
+    return True, "compile OK"
+
+
+def grade_from_outputs(
+    src: str,
+    compile_output: str,
+    compile_exit: int,
+    axioms_output: str,
+    axioms_exit: int,
+) -> GradeResult:
+    """Pure decision function given all the raw artifacts (host-testable)."""
+    ok, reason = check_signature(src)
+    if not ok:
+        return GradeResult(0.0, False, "G1_signature", reason)
+
+    ok, reason = scan_source(src)
+    if not ok:
+        return GradeResult(0.0, False, "G2_source_scan", reason)
+
+    ok, reason = compile_ok(compile_output, compile_exit)
+    if not ok:
+        return GradeResult(0.0, False, "G3_compile", reason,
+                           {"compile_output_tail": compile_output[-800:]})
+
+    if axioms_exit != 0:
+        return GradeResult(0.0, False, "G4_axioms",
+                           f"axiom-print recompile exited {axioms_exit}",
+                           {"axioms_output_tail": axioms_output[-800:]})
+
+    ok, reason, axioms = check_axioms(axioms_output)
+    if not ok:
+        return GradeResult(0.0, False, "G4_axioms", reason,
+                           {"axioms": sorted(axioms) if axioms else None,
+                            "axioms_output_tail": axioms_output[-800:]})
+
+    return GradeResult(1.0, True, "all", "genuine axiom-clean proof",
+                       {"axioms": sorted(axioms)})
+
+
+async def grade(
+    src: str,
+    run: Callable,
+    solution_path: str,
+    lean_path_env: str,
+    workdir: str,
+    lean_bin: str = "lean",
+    per_compile_timeout: int = 600,
+) -> GradeResult:
+    """Async grader: `run` is a coroutine `run(cmd, timeout) -> (stdout, exit)`
+    that executes a shell command inside the sandbox. Performs G1/G2 locally,
+    then G3 (compile) and G4 (axiom audit) inside the sandbox. `lean_bin` is the
+    lean executable (bare ``lean`` if on PATH, or an absolute path for a
+    bind-mounted toolchain).
+    """
+    ok, reason = check_signature(src)
+    if not ok:
+        return GradeResult(0.0, False, "G1_signature", reason)
+    ok, reason = scan_source(src)
+    if not ok:
+        return GradeResult(0.0, False, "G2_source_scan", reason)
+
+    env = f"env LEAN_PATH={lean_path_env!r} {lean_bin}"
+
+    # G3: compile the submission as-is.
+    out, code = await run(f"{env} {solution_path!r}", per_compile_timeout)
+    ok, reason = compile_ok(out, code)
+    if not ok:
+        return GradeResult(0.0, False, "G3_compile", reason,
+                           {"compile_output_tail": out[-800:]})
+
+    # G4: append `#print axioms` and recompile, then audit.
+    ax_file = f"{workdir}/_axcheck.lean"
+    append = f"\\n#print axioms {TARGET_THEOREM}\\n"
+    mk = (
+        f"cp {solution_path!r} {ax_file!r} && "
+        f"printf '{append}' >> {ax_file!r}"
+    )
+    _out, _code = await run(mk, 60)
+    ax_out, ax_code = await run(f"{env} {ax_file!r}", per_compile_timeout)
+    if ax_code != 0:
+        return GradeResult(0.0, False, "G4_axioms",
+                           f"axiom-print recompile exited {ax_code}",
+                           {"axioms_output_tail": ax_out[-800:]})
+    ok, reason, axioms = check_axioms(ax_out)
+    if not ok:
+        return GradeResult(0.0, False, "G4_axioms", reason,
+                           {"axioms": sorted(axioms) if axioms else None,
+                            "axioms_output_tail": ax_out[-800:]})
+    return GradeResult(1.0, True, "all", "genuine axiom-clean proof",
+                       {"axioms": sorted(axioms)})

--- a/tasks/computing_math/imo2005p6_lean_v1/scripts/selftest.py
+++ b/tasks/computing_math/imo2005p6_lean_v1/scripts/selftest.py
@@ -1,0 +1,101 @@
+"""Host self-test for the IMO 2005 P6 Lean task grader.
+
+Exercises the pure decision function in ``grade_lean.py`` against a battery of
+realistic submissions: every cheat / malformed submission must score 0.0, and
+(when the evaluator-only reference proof is available via IMO2005P6_REFERENCE)
+the genuine reference must score 1.0. Does NOT require Lean (it feeds synthetic
+compile / axiom-print outputs); an end-to-end test that actually compiles the
+reference proof against Mathlib lives in ``scripts/e2e_check.py``. The reference
+proof is evaluator-only and not committed to the public repo, so reference-based
+cases skip when it is absent.
+
+Run:  python3 scripts/selftest.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+
+from grade_lean import grade_from_outputs  # noqa: E402
+
+_ASSETS = _HERE.parent / "assets"
+PROB = (_ASSETS / "Problem.lean").read_text(encoding="utf-8")
+
+# The reference proof is EVALUATOR-ONLY (not committed to the public repo). Load
+# it from IMO2005P6_REFERENCE if available; reference-based cases skip if absent.
+_REF_PATH = Path(os.environ.get(
+    "IMO2005P6_REFERENCE",
+    "/local/home/hihgupta/workspace/imo2005p6_eval_only/reference_solution.lean",
+))
+REF = _REF_PATH.read_text(encoding="utf-8") if _REF_PATH.is_file() else None
+
+CLEAN_AXIOMS = (
+    "'IMO2005P6.imo2005_p6' depends on axioms: [propext, Classical.choice, Quot.sound]"
+)
+
+
+def _case(name, src, comp_out, comp_exit, ax_out, ax_exit, want_pass):
+    r = grade_from_outputs(src, comp_out, comp_exit, ax_out, ax_exit)
+    ok = (r.passed == want_pass)
+    flag = "ok " if ok else "XX "
+    print(f"  {flag}{name}: score={r.score} gate={r.gate} ({r.reason})")
+    return ok
+
+
+def main() -> int:
+    all_ok = True
+
+    # --- PROB-based cases (no reference proof needed) — always run. ---
+
+    # sorry submission → 0.0 (G2, and G4 backstop would see sorryAx)
+    all_ok &= _case("sorry", PROB, "warning: declaration uses 'sorry'", 0,
+                    "'IMO2005P6.imo2005_p6' depends on axioms: [sorryAx]", 0, want_pass=False)
+
+    # custom-axiom cheat → 0.0
+    cheat = PROB.replace("namespace IMO2005P6", "namespace IMO2005P6\naxiom cheat : True")
+    cheat = cheat.replace("  sorry", "  trivial")
+    all_ok &= _case("custom axiom", cheat, "", 0,
+                    "'IMO2005P6.imo2005_p6' depends on axioms: [cheat]", 0, want_pass=False)
+
+    # native_decide → 0.0
+    nd = PROB.replace("  sorry", "  native_decide")
+    all_ok &= _case("native_decide", nd, "", 0,
+                    "'IMO2005P6.imo2005_p6' depends on axioms: [Lean.ofReduceBool]", 0, want_pass=False)
+
+    # --- Reference-based cases need the EVALUATOR-ONLY reference proof, which is
+    # not committed to the public repo. Skip gracefully if it is absent. ---
+    if REF is None:
+        print("  -- reference-based cases SKIPPED (set IMO2005P6_REFERENCE to the "
+              "evaluator-only reference_solution.lean to run them)")
+    else:
+        # Genuine reference proof → 1.0
+        all_ok &= _case("reference proof", REF, "", 0, CLEAN_AXIOMS, 0, want_pass=True)
+
+        # vacuous restatement (5 -> 4) that "compiles clean" → 0.0 via G1
+        vac = REF.replace("2 ≤ numSolvedExactly solved 5", "2 ≤ numSolvedExactly solved 4")
+        all_ok &= _case("vacuous restatement", vac, "", 0, CLEAN_AXIOMS, 0, want_pass=False)
+
+        # edited hypothesis (weaken hpair 2*n -> n) → 0.0 via G1
+        weak = REF.replace("2 * n < 5 * (univ.filter", "n < 5 * (univ.filter")
+        all_ok &= _case("weakened hypothesis", weak, "", 0, CLEAN_AXIOMS, 0, want_pass=False)
+
+        # does not compile → 0.0
+        all_ok &= _case("compile error", REF,
+                        "solution.lean:10:2: error: unknown identifier 'foo'", 1, "", 0, want_pass=False)
+
+        # G4 backstop: signature+source clean but the axiom set has an extra
+        # (e.g. a hole hidden via a tactic that leaves sorryAx) → 0.0
+        all_ok &= _case("hidden sorryAx (no literal)", REF, "", 0,
+                        "'IMO2005P6.imo2005_p6' depends on axioms: [propext, sorryAx]", 0, want_pass=False)
+
+    print("\nRESULT:", "ALL PASS" if all_ok else "FAILURES ABOVE")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/computing_math/imo2005p6_lean_v1/task_card.json
+++ b/tasks/computing_math/imo2005p6_lean_v1/task_card.json
@@ -1,0 +1,53 @@
+{
+  "taskId": "computing_math/imo2005p6_lean_v1",
+  "title": "Machine-Checked Lean Proof of a Combinatorial Extremal Theorem (IMO 2005 P6)",
+  "summary": "Produce a complete, axiom-clean Lean 4 / Mathlib proof of a specified combinatorial extremal theorem: given a finite set of contestants and a solved-relation over 6 problems, if every pair of problems was solved by more than 2/5 of the contestants and nobody solved all 6, then at least two contestants each solved exactly 5. The agent fills the `sorry` in a fixed theorem statement; grading compiles the submission against Mathlib and audits `#print axioms` to certify a genuine proof (no sorry, no added axioms, no native_decide).",
+  "category": "computing_math",
+  "software": [
+    "Lean 4 (v4.27.0)",
+    "Mathlib (v4.27, prebuilt .olean cache)"
+  ],
+  "taskPrompt": "You are a formal-methods engineer producing a machine-checked verification artifact. Read the theorem statement staged at input/Problem.lean in full: it formalizes 'in a competition with 6 problems where every pair of problems was solved by more than 2/5 of the contestants and nobody solved all 6, at least two contestants each solved exactly 5 problems', as a Lean 4 theorem `imo2005_p6` over an arbitrary finite contestant type `C` with a decidable `solved : C → Fin 6 → Prop`, with `hpair : ∀ i j, i ≠ j → 2*n < 5*|{c | solved c i ∧ solved c j}|`, `hnall : ∀ c, ∃ p, ¬ solved c p`, and goal `2 ≤ numSolvedExactly solved 5`. Create exactly one file, output/solution.lean, which is Problem.lean with the `sorry` in `imo2005_p6` replaced by a complete proof. You MUST keep the `imo2005_p6` signature and the `solvedCount`/`numSolvedExactly` definitions byte-for-byte as given (the grader pins them); you may add auxiliary lemmas before the theorem. Lean 4.27.0 and the prebuilt Mathlib v4.27 .olean cache are already installed (fetched at task setup); the lean binary path is in input/LEANBIN and the olean search path in input/LEANPATH. Compile read-only via `env LEAN_PATH=\"$(cat input/LEANPATH)\" \"$(cat input/LEANBIN)\" output/solution.lean` (use the prebuilt cache; do NOT run `lake build` on Mathlib — it would rebuild from source and take hours). You are graded deterministically: score 1.0 only if the submission keeps the exact signature, contains no sorry/admit/native_decide/axiom, compiles with no errors, and `#print axioms IMO2005P6.imo2005_p6` depends only on {propext, Classical.choice, Quot.sound}. Treat input/ as read-only.",
+  "agentMustDo": [
+    "Read input/Problem.lean in full and understand the formalization contract (the meaning of solved, numSolvedExactly, hpair, hnall, and the goal).",
+    "Devise a correct mathematical proof of the theorem from first principles (no proof strategy is provided).",
+    "Formalize the proof in Lean 4 / Mathlib as output/solution.lean, keeping the imo2005_p6 signature and the solvedCount/numSolvedExactly definitions exactly as given.",
+    "Compile the file read-only against the prebuilt Mathlib cache with `env LEAN_PATH=\"$(cat input/LEANPATH)\" lean output/solution.lean` and iterate until it has no errors.",
+    "Ensure the proof is genuine: no sorry, no admit, no native_decide, and no newly declared axiom, so that `#print axioms IMO2005P6.imo2005_p6` reports only propext, Classical.choice, and Quot.sound."
+  ],
+  "inputFiles": [
+    {
+      "name": "Problem.lean",
+      "format": "lean",
+      "path": "input/Problem.lean",
+      "description": "The authoritative theorem statement: the fixed auxiliary definitions solvedCount/numSolvedExactly, the theorem imo2005_p6 with its exact hypotheses and goal, and a `sorry` to be replaced. Contains the formalization contract and no proof or hints."
+    },
+    {
+      "name": "LEANPATH",
+      "format": "text",
+      "path": "input/LEANPATH",
+      "description": "The colon-separated LEAN_PATH search path of the prebuilt Mathlib v4.27 .olean cache, so the agent can compile read-only against Mathlib without invoking lake or the network."
+    }
+  ],
+  "referenceFiles": [
+    {
+      "name": "reference_solution.lean",
+      "format": "lean",
+      "path": "(evaluator-only; delivered via the ALE reference channel — NOT committed to this public repo)",
+      "description": "A complete, machine-checked reference proof (32 lemmas/definitions). Compiles against Mathlib v4.27 with no sorry and `#print axioms imo2005_p6 = [propext, Classical.choice, Quot.sound]`. Provided to evaluators out-of-band and held out of the solver sandbox (only input/Problem.lean is staged), so it certifies solvability without leaking the answer to the solver."
+    }
+  ],
+  "evaluation": "Deterministic layered gate (scripts/grade_lean.py): (G1) the submission must keep the exact imo2005_p6 signature and the solvedCount/numSolvedExactly definitions (whitespace-normalized substring pin) — blocks vacuous/weaker restatements; (G2) source scan rejects sorry/admit/native_decide/axiom; (G3) `lean solution.lean` must exit 0 with no error:; (G4) append `#print axioms IMO2005P6.imo2005_p6`, recompile, and require the axiom set ⊆ {propext, Classical.choice, Quot.sound}, rejecting sorryAx, declared axioms, and Lean.ofReduceBool. Score = 1.0 iff all gates pass, else 0.0.",
+  "vm": {
+    "snapshot": "cpu-free-ubuntu",
+    "machineType": "c4-standard-4",
+    "timeout": 7200
+  },
+  "taxonomy": {
+    "domain_id": "9",
+    "domain_code": "computing_math",
+    "subdomain_id": "9.1",
+    "subdomain_code": "software_eng",
+    "subdomain_name": "Software Engineering"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new Data-track task, **`computing_math/imo2005p6_lean_v1`** — a formal-verification workflow. The agent is given a fixed Lean 4 theorem statement (with a `sorry`) formalizing **IMO 2005 Problem 6** (a combinatorial extremal result) and must produce a complete, **machine-checked Lean 4 / Mathlib proof**. The graded skill is formal-methods engineering — turning a specification into a kernel-checked artifact — not "solving a contest problem" (the theorem is substrate, mirroring how `computing_math/cp_test_gen_1` uses a competition problem for a real engineering task).

Full write-up: see `tasks/computing_math/imo2005p6_lean_v1/SUBMISSION.md`.

## Grading (deterministic, layered — `scripts/grade_lean.py`)

Score is **1.0 only if all gates pass**, else 0.0:

| Gate | Check |
|------|-------|
| G1 | Submission keeps the exact `imo2005_p6` signature + `solvedCount`/`numSolvedExactly` definitions (blocks vacuous/weakened restatements). |
| G2 | Source scan rejects `sorry` / `admit` / `native_decide` / new `axiom`. |
| G3 | `lean solution.lean` compiles with no errors. |
| G4 | `#print axioms IMO2005P6.imo2005_p6` ⊆ `{propext, Classical.choice, Quot.sound}` — rejects `sorryAx`, declared axioms, and `Lean.ofReduceBool` (native_decide). |

G4 is a **whitelist** (rejects any axiom outside the trusted three, incl. unanticipated ones) and fails closed on unparseable output. Because the theorem is universally quantified over an arbitrary finite contestant type, it cannot be closed by `decide`/`native_decide` — only a genuine proof passes.

## Genuineness

`assets/reference_solution.lean` is a **complete, held-out reference proof** (795 lines, 32 lemmas/definitions) that compiles against Mathlib v4.27 with `#print axioms = {propext, Classical.choice, Quot.sound}` — no `sorry`. It is host-only (never staged into the sandbox), so it cannot leak.

Test batteries included:
- `scripts/selftest.py` — grader logic over synthetic artifacts (no Lean needed).
- `scripts/adversarial_check.py` — real-compile battery: the reference scores 1.0; sorry / custom-axiom / native_decide / weakened-goal / redefined-def /  comment-hidden-signature all score 0.0 (incl. a case that evades the source scan but is caught by the axiom audit).
- `scripts/e2e_check.py` — compiles the reference through the full grader.

## Toolchain — self-contained, no upload, no image

`start()` fetches its toolchain from official upstream at setup (the sandbox has outbound network, as used by other tasks that install at solve time): `elan` installs Lean 4.27.0, and `lake exe cache get` pulls the prebuilt Mathlib v4.27
`.olean` cache (~7,900 oleans) from Mathlib's official CDN in a few minutes — no building from source. Verified end-to-end in `cpu-free-ubuntu`. There is **no`software/` data payload and no custom image**. (`SOFTWARE.md` documents an optional offline fallback.)

## Difficulty (calibration)

Against the FAQ's second-tier reference **Sonnet 4.6** (Bedrock, extended thinking, 2 h wall): **0 / 1 passing** (score 0.0, hit the wall). Reported transparently — one valid trial, not a large-N rate. It is a meaningful
last-exam signal because:
- The agent reconstructs essentially the *entire correct informal proof* in its reasoning yet never produces a compiling `.lean` file in 2 h — the wall is the formalization, not the mathematics.
- Intrinsic, agent-independent markers: unformalized in Compfiles and the Mathlib archive (nothing to copy), combinatorics (hardest genre to formalize), an ~800-line reference proof, and a non-brute-forceable statement.

Part of the 2 h failure is the Claude Code CLI spending very long in extended thinking rather than iterating on Lean.

## Framework change bundled

Adds a `max_output_tokens` field to the `claude_code` config + deployer so the CLI's per-response output-token ceiling is configurable. Without it, extended-thinking runs can abort mid-run at the default 32000 output-token limit.

## Files

- New: `tasks/computing_math/imo2005p6_lean_v1/` (task package + reference + tests  + docs), `selected_tasks/imo2005p6_lean.txt`
- Modified: `ale_run/agents/claude_code/{config.py, deployer.py}` (the fix above)

## Checks run

- `uv run python -m ale_run run … --dry-run` loads the task ✓
- `scripts/selftest.py` → ALL PASS ✓
- `task_card.json` valid; `main.py` + grader compile ✓
- Reference proof compiles + axiom-audits clean in the sandbox ✓
