### PR TITLE
feat(ale-claw): rescale normalized (Gemini) pointer coordinates to pixels

### DIFF
--- a/ale_run/agents/ale_claw/config.py
+++ b/ale_run/agents/ale_claw/config.py
@@ -126,6 +126,25 @@ class AleClawConfig:
     With both transports on ``"mcp"`` (the default), ale_claw never touches
     ``RemoteDesktopSession`` for tool I/O."""
 
+    # ---- pointer coordinate space ----
+    coordinate_space: str | None = None
+    """Coordinate space the GUI model emits for pointer actions.
+
+    - ``None`` (default): auto-detect from :attr:`model` — Gemini-family models
+      ground clicks to a normalized ``[0, 1000)`` grid, everything else emits
+      screen pixels (see ``harness.tools.computer_handler
+      .coordinate_space_for_model``).
+    - ``"pixel"``: coords are already screen pixels; pass through unchanged.
+    - ``"normalized"``: coords are on a ``[0, 1000)`` grid; the computer handler
+      rescales them to pixels using the live screen size before acting.
+
+    Gemini computer-use models ground to a fixed 0-1000 grid regardless of the
+    "Screen resolution: WxH pixels" hint in the ``computer`` tool description, so
+    their raw clicks land in the wrong place unless rescaled. When main and GUI
+    subagent models differ, the space is chosen from the model that actually
+    drives the computer handler (``gui_model`` when ``disable_main_computer``,
+    else ``model``); set this explicitly to override if they disagree."""
+
     # ---- thinking levels (off | low | medium | high) ----
     thinking_level: str | None = None
     """Base thinking level. None → resolved-default for the model
@@ -171,6 +190,14 @@ class AleClawConfig:
             )
         if self.gui_transport is None:
             self.gui_transport = self.substrate_transport
+        if self.coordinate_space is not None and self.coordinate_space not in (
+            "pixel",
+            "normalized",
+        ):
+            raise ValueError(
+                f"AleClawConfig.coordinate_space={self.coordinate_space!r} "
+                "not in {pixel, normalized, None}"
+            )
         for level_field, value in [
             ("thinking_level", self.thinking_level),
             ("flush_thinking_level", self.flush_thinking_level),

--- a/ale_run/agents/ale_claw/deployer.py
+++ b/ale_run/agents/ale_claw/deployer.py
@@ -245,13 +245,35 @@ class AleClawDeployer(BaseAgentDeployer):
         # gui_transport=mcp → drive GUI through the cua bridge; else the session
         # handler. The MCP handler inits lazily (the runtime connects later,
         # around the drive loop), so don't _initialize it here.
+        # Pointer coordinate space — most models emit screen pixels, but the
+        # Gemini family grounds clicks to a normalized [0, 1000) grid. Detect
+        # from the model that actually drives the handler (gui_model when the
+        # main agent has no computer), unless the config forces a space.
+        from .harness.tools.computer_handler import coordinate_space_for_model
+        coord_driver_model = (
+            (cfg.gui_model or cfg.model)
+            if cfg.disable_main_computer
+            else cfg.model
+        )
+        coordinate_space = cfg.coordinate_space or coordinate_space_for_model(
+            coord_driver_model
+        )
+        logger.info(
+            "ale-claw: coordinate_space=%s (driver_model=%s, override=%s)",
+            coordinate_space, coord_driver_model, cfg.coordinate_space,
+        )
+
         computer_handler = None
         if not cfg.disable_main_computer:
             if cfg.gui_transport == "mcp" and mcp_runtime is not None:
                 from .harness.tools.computer_handler import MCPComputerHandler
-                computer_handler = MCPComputerHandler(mcp_runtime, os_type=sb.os)
+                computer_handler = MCPComputerHandler(
+                    mcp_runtime, os_type=sb.os, coordinate_space=coordinate_space
+                )
             else:
-                computer_handler = OpenClawComputerHandler(session.computer)
+                computer_handler = OpenClawComputerHandler(
+                    session.computer, coordinate_space=coordinate_space
+                )
                 await computer_handler._initialize()            # noqa: SLF001
 
         # ---- 6. Tools + disabled_tools filter ----

--- a/ale_run/agents/ale_claw/harness/__init__.py
+++ b/ale_run/agents/ale_claw/harness/__init__.py
@@ -33,7 +33,10 @@ from .model.cache_policy import (
     apply_openclaw_cache_markers,
     supports_anthropic_cache,
 )
-from .tools.computer_handler import OpenClawComputerHandler
+from .tools.computer_handler import (
+    OpenClawComputerHandler,
+    coordinate_space_for_model,
+)
 from .canonical.canonical import (
     CanonicalMessage,
     CompactionSummaryBlock,
@@ -111,6 +114,7 @@ from .model import unified_loop  # noqa: F401
 __all__ = [
     "OpenClawComputerAgent",
     "OpenClawComputerHandler",
+    "coordinate_space_for_model",
     "OpenClawImageRetentionCallback",
     "OpenClawTrajectorySaverCallback",
     "CanonicalMessage",

--- a/ale_run/agents/ale_claw/harness/agent_loop.py
+++ b/ale_run/agents/ale_claw/harness/agent_loop.py
@@ -525,7 +525,10 @@ class OpenClawComputerAgent(ComputerAgent):
             isinstance(handler, cuaComputerHandler)
             and not isinstance(handler, OpenClawComputerHandler)
         ):
-            upgraded = OpenClawComputerHandler(handler.cua_computer)
+            upgraded = OpenClawComputerHandler(
+                handler.cua_computer,
+                coordinate_space=getattr(handler, "_coord_space", "pixel"),
+            )
             await upgraded._initialize()
             self.computer_handler = upgraded
 

--- a/ale_run/agents/ale_claw/harness/subagent/subagent_gui.py
+++ b/ale_run/agents/ale_claw/harness/subagent/subagent_gui.py
@@ -30,6 +30,10 @@ from agent import ComputerAgent
 from agent.callbacks.base import AsyncCallbackHandler
 
 from ..memory.memory import MemoryGetTool, MemorySearchTool, MemoryStore, MemoryWriteTool
+from ..tools.computer_handler import (
+    OpenClawComputerHandler,
+    coordinate_space_for_model,
+)
 from .subagent_registry import (
     SubagentRegistry,
     SubagentUsage,
@@ -303,15 +307,29 @@ class _TranscriptWriter:
 # ---------------------------------------------------------------------------
 
 
-def _build_gui_agent(
+async def _build_gui_agent(
     session: Any,
     model: str,
     thinking_params: dict[str, Any] | None,
     memory_store: MemoryStore | None,
     inbox: "asyncio.Queue[str]",
 ) -> ComputerAgent:
-    """Construct the lightweight GUI ComputerAgent (computer tool + optional memory)."""
-    tools: list[Any] = [session._computer]
+    """Construct the lightweight GUI ComputerAgent (computer tool + optional memory).
+
+    The raw ``session._computer`` is wrapped in an
+    :class:`OpenClawComputerHandler` so the subagent gets the same
+    chord-vs-sequence keypress semantics, tolerant coordinate coercion, and —
+    crucially for Gemini-family GUI models — normalized→pixel scaling as the
+    main agent. The coordinate space is derived from *this subagent's* model,
+    since delegate_gui runs may pick a different model than the main agent.
+    ``make_computer_handler`` returns an already-``AsyncComputerHandler`` as-is
+    without initializing it, so we ``_initialize`` here (idempotent)."""
+    computer = OpenClawComputerHandler(
+        session._computer,
+        coordinate_space=coordinate_space_for_model(model),
+    )
+    await computer._initialize()            # noqa: SLF001
+    tools: list[Any] = [computer]
     if memory_store is not None:
         tools.extend([
             MemorySearchTool(memory_store),
@@ -413,7 +431,7 @@ async def run_gui_subagent(
     registry.attach_inbox(run_id, inbox)
 
     try:
-        agent = _build_gui_agent(session, model, thinking_params, memory_store, inbox)
+        agent = await _build_gui_agent(session, model, thinking_params, memory_store, inbox)
         summary = await _relay_until_done(
             agent, instruction, run_id, max_steps, usage, transcript
         )

--- a/ale_run/agents/ale_claw/harness/tools/computer_handler.py
+++ b/ale_run/agents/ale_claw/harness/tools/computer_handler.py
@@ -38,6 +38,17 @@ Why coerce pointer coordinates:
     ``None`` to the parent. The agent loop converts ``ToolError`` into a
     ``function_call_output`` that the model sees on the next turn, so the
     run stays alive instead of crashing.
+
+Why scale normalized coordinates:
+    Some GUI models (notably the Gemini family) ground clicks to a fixed
+    ``[0, 1000)`` grid rather than to screen pixels — regardless of the
+    "Screen resolution: WxH pixels" hint the ``computer`` tool advertises.
+    Passed through unscaled, a normalized click at ``(500, 500)`` lands near
+    the top-left of a 1920x1080 screen instead of its center. When a handler
+    is told its model emits ``"normalized"`` coordinates, it maps them back to
+    pixels (``px = n / 1000 * W``) before the usual pixel-space path runs; the
+    default ``"pixel"`` space is an unscaled pass-through. See
+    :class:`_PointerCoords` and :func:`coordinate_space_for_model`.
 """
 
 from __future__ import annotations
@@ -99,9 +110,99 @@ def _coerce_xy(x: Any, y: Any) -> Tuple[Optional[int], Optional[int]]:
     return _coerce_int(x), _coerce_int(y)
 
 
-class OpenClawComputerHandler(cuaComputerHandler):
-    """cuaComputerHandler with sequential multi-key keypress and tolerant
-    coercion for malformed pointer coordinates."""
+NORMALIZED_GRID = 1000
+"""Grid size for models that emit *normalized* pointer coordinates.
+
+Gemini-family GUI models ground clicks to a fixed ``[0, 1000)`` grid rather
+than to screen pixels. To recover a pixel coordinate we divide by this and
+multiply by the screen dimension: ``px = n / NORMALIZED_GRID * W``.
+
+Note the model emits values in ``0-999`` but the denominator is ``1000`` (not
+999), per Google's reference denormalization ``int(x / 1000 * width)``. See
+the Gemini computer-use docs: https://ai.google.dev/gemini-api/docs/computer-use
+"""
+
+
+def coordinate_space_for_model(model_id: Optional[str]) -> str:
+    """Best-effort pointer coordinate space for a LiteLLM model id.
+
+    Returns ``"normalized"`` for Gemini-family models (which ground clicks to a
+    fixed ``[0, 1000)`` grid) and ``"pixel"`` for everything else. This is only
+    a default — callers can force either space via
+    ``AleClawConfig.coordinate_space``.
+    """
+    if model_id and "gemini" in model_id.lower():
+        return "normalized"
+    return "pixel"
+
+
+class _PointerCoords:
+    """Coordinate coercion + optional normalized→pixel scaling for pointers.
+
+    Mixed into both computer handlers so the two coordinate conventions live in
+    one place. ``_coord_space`` — set by each handler's ``__init__`` — selects
+    the behavior:
+
+    - ``"pixel"`` (default): the model already emits screen-pixel coords, so
+      just coerce and pass through.
+    - ``"normalized"``: the model emits a :data:`NORMALIZED_GRID` grid (Gemini),
+      so coerce, then scale to pixels using the live screen size.
+
+    Requires the host handler to provide an async ``get_dimensions()`` returning
+    ``(width, height)`` — both handlers satisfy this.
+    """
+
+    _coord_space: str = "pixel"
+
+    def _require_xy(self, action: str, x: Any, y: Any) -> Tuple[int, int]:
+        nx, ny = _coerce_xy(x, y)
+        if nx is None or ny is None:
+            raise ToolError(
+                f"computer.{action} requires both x and y coordinates "
+                f"(got x={x!r}, y={y!r}); pass them as separate integers, "
+                f'e.g. {{"action": "{action}", "x": 420, "y": 390}}.'
+            )
+        return nx, ny
+
+    async def _scale_xy(self, x: int, y: int) -> Tuple[int, int]:
+        """Map (x, y) to pixel space when the model emits normalized coords."""
+        if self._coord_space != "normalized":
+            return x, y
+        w, h = await self.get_dimensions()
+        px = round(x / NORMALIZED_GRID * w)
+        py = round(y / NORMALIZED_GRID * h)
+        return max(0, min(w - 1, px)), max(0, min(h - 1, py))
+
+    async def _pointer_xy(self, action: str, x: Any, y: Any) -> Tuple[int, int]:
+        """Coerce then (for normalized models) scale a single (x, y) pair."""
+        nx, ny = self._require_xy(action, x, y)
+        return await self._scale_xy(nx, ny)
+
+    async def _scale_path(
+        self, path: List[Dict[str, int]]
+    ) -> List[Dict[str, int]]:
+        """Scale every point of a drag ``path`` when coords are normalized."""
+        if self._coord_space != "normalized":
+            return path
+        scaled: List[Dict[str, int]] = []
+        for pt in path:
+            px, py = await self._scale_xy(
+                _coerce_int(pt.get("x")) or 0, _coerce_int(pt.get("y")) or 0
+            )
+            scaled.append({**pt, "x": px, "y": py})
+        return scaled
+
+
+class OpenClawComputerHandler(_PointerCoords, cuaComputerHandler):
+    """cuaComputerHandler with sequential multi-key keypress, tolerant
+    coercion for malformed pointer coordinates, and optional normalized→pixel
+    scaling for models (e.g. Gemini) that emit a ``[0, 1000)`` grid."""
+
+    def __init__(
+        self, cua_computer: Any, *, coordinate_space: str = "pixel"
+    ) -> None:
+        super().__init__(cua_computer)
+        self._coord_space = coordinate_space
 
     def _normalize_key(self, key: str) -> str:
         parent = getattr(super(), "_normalize_key", None)
@@ -117,36 +218,26 @@ class OpenClawComputerHandler(cuaComputerHandler):
         for k in keys:
             await self.interface.press_key(self._normalize_key(k))
 
-    def _require_xy(self, action: str, x: Any, y: Any) -> Tuple[int, int]:
-        nx, ny = _coerce_xy(x, y)
-        if nx is None or ny is None:
-            raise ToolError(
-                f"computer.{action} requires both x and y coordinates "
-                f"(got x={x!r}, y={y!r}); pass them as separate integers, "
-                f'e.g. {{"action": "{action}", "x": 420, "y": 390}}.'
-            )
-        return nx, ny
-
     async def click(self, x: Any, y: Any = None, button: str = "left") -> None:
-        nx, ny = self._require_xy("click", x, y)
+        nx, ny = await self._pointer_xy("click", x, y)
         await super().click(nx, ny, button)
 
     async def double_click(self, x: Any, y: Any = None) -> None:
-        nx, ny = self._require_xy("double_click", x, y)
+        nx, ny = await self._pointer_xy("double_click", x, y)
         await super().double_click(nx, ny)
 
     async def right_click(self, x: Any, y: Any = None) -> None:
-        nx, ny = self._require_xy("right_click", x, y)
+        nx, ny = await self._pointer_xy("right_click", x, y)
         await super().right_click(nx, ny)
 
     async def move(self, x: Any, y: Any = None) -> None:
-        nx, ny = self._require_xy("move", x, y)
+        nx, ny = await self._pointer_xy("move", x, y)
         await super().move(nx, ny)
 
     async def scroll(
         self, x: Any, y: Any = None, scroll_x: Any = 0, scroll_y: Any = 0
     ) -> None:
-        nx, ny = self._require_xy("scroll", x, y)
+        nx, ny = await self._pointer_xy("scroll", x, y)
         sx = _coerce_int(scroll_x) or 0
         sy = _coerce_int(scroll_y) or 0
         await super().scroll(nx, ny, sx, sy)
@@ -160,10 +251,10 @@ class OpenClawComputerHandler(cuaComputerHandler):
         end_y: Any = None,
     ) -> None:
         if path:
-            await super().drag(path=path)
+            await super().drag(path=await self._scale_path(path))
             return
-        sx, sy = self._require_xy("drag (start)", start_x, start_y)
-        ex, ey = self._require_xy("drag (end)", end_x, end_y)
+        sx, sy = await self._pointer_xy("drag (start)", start_x, start_y)
+        ex, ey = await self._pointer_xy("drag (end)", end_x, end_y)
         await super().drag(start_x=sx, start_y=sy, end_x=ex, end_y=ey)
 
 
@@ -176,7 +267,7 @@ def _normalize_key(key: str) -> str:
     return _KEY_MAPPING.get(key.upper(), key.lower())
 
 
-class MCPComputerHandler:
+class MCPComputerHandler(_PointerCoords):
     """GUI computer handler that drives the VM through the cua MCP bridge.
 
     Implements the ``AsyncComputerHandler`` protocol (a ``runtime_checkable``
@@ -185,20 +276,29 @@ class MCPComputerHandler:
     is routed over MCP (Phase 2). Every action becomes a cua-bridge tool call;
     the harness no longer touches ``RemoteDesktopSession`` for GUI.
 
-    Coordinates: the model emits **pixel** coords in screenshot space, but the
-    cua bridge speaks **normalized [0, 1000]**. We convert px→[0,1000] here using
-    the screen size (fetched once via the bridge's ``get_screen_size`` tool); the
-    bridge converts back to pixels. Rounding is ≤ 1px at typical resolutions.
+    Coordinates: the model emits **pixel** coords in screenshot space (or, for
+    ``coordinate_space="normalized"`` models like Gemini, a [0, 1000) grid that
+    :class:`_PointerCoords` first rescales to pixels), but the cua bridge speaks
+    **normalized [0, 1000]**. We convert px→[0,1000] here using the screen size
+    (fetched once via the bridge's ``get_screen_size`` tool); the bridge converts
+    back to pixels. Rounding is ≤ 1px at typical resolutions.
 
     Keypress keeps the harness's chord-vs-sequence rule (mirrors
     :class:`OpenClawComputerHandler`): a list is a *sequence* of independent
     presses (one ``key`` call each), a ``+``/``-`` string is a *chord*.
     """
 
-    def __init__(self, runtime: "MCPRuntime", *, os_type: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        runtime: "MCPRuntime",
+        *,
+        os_type: Optional[str] = None,
+        coordinate_space: str = "pixel",
+    ) -> None:
         self._runtime = runtime
         self._os_type = (os_type or "").lower()
         self._dims: Optional[Tuple[int, int]] = None
+        self._coord_space = coordinate_space
         # Present for parity with cua handlers that expose ``.interface``; the
         # MCP path has no direct interface object.
         self.interface = None
@@ -262,23 +362,23 @@ class MCPComputerHandler:
     # -- pointer --
 
     async def click(self, x: Any, y: Any = None, button: str = "left") -> None:
-        nx, ny = self._require_xy("click", x, y)
+        nx, ny = await self._pointer_xy("click", x, y)
         await self._call_cua("click", {"coordinate": await self._to_norm(nx, ny), "button": button})
 
     async def double_click(self, x: Any, y: Any = None) -> None:
-        nx, ny = self._require_xy("double_click", x, y)
+        nx, ny = await self._pointer_xy("double_click", x, y)
         await self._call_cua("click", {"coordinate": await self._to_norm(nx, ny), "clicks": 2})
 
     async def right_click(self, x: Any, y: Any = None) -> None:
-        nx, ny = self._require_xy("right_click", x, y)
+        nx, ny = await self._pointer_xy("right_click", x, y)
         await self._call_cua("click", {"coordinate": await self._to_norm(nx, ny), "button": "right"})
 
     async def move(self, x: Any, y: Any = None) -> None:
-        nx, ny = self._require_xy("move", x, y)
+        nx, ny = await self._pointer_xy("move", x, y)
         await self._call_cua("mouse_move", {"coordinate": await self._to_norm(nx, ny)})
 
     async def scroll(self, x: Any, y: Any = None, scroll_x: Any = 0, scroll_y: Any = 0) -> None:
-        nx, ny = self._require_xy("scroll", x, y)
+        nx, ny = await self._pointer_xy("scroll", x, y)
         coord = await self._to_norm(nx, ny)
         sx = _coerce_int(scroll_x) or 0
         sy = _coerce_int(scroll_y) or 0
@@ -298,11 +398,12 @@ class MCPComputerHandler:
         end_y: Any = None,
     ) -> None:
         if path:
+            path = await self._scale_path(path)
             sx, sy = path[0]["x"], path[0]["y"]
             ex, ey = path[-1]["x"], path[-1]["y"]
         else:
-            sx, sy = self._require_xy("drag (start)", start_x, start_y)
-            ex, ey = self._require_xy("drag (end)", end_x, end_y)
+            sx, sy = await self._pointer_xy("drag (start)", start_x, start_y)
+            ex, ey = await self._pointer_xy("drag (end)", end_x, end_y)
         await self._call_cua("drag", {
             "start_coordinate": await self._to_norm(sx, sy),
             "coordinate": await self._to_norm(ex, ey),
@@ -341,12 +442,3 @@ class MCPComputerHandler:
 
     async def terminate(self, status: str = "success") -> Dict[str, Any]:
         return {"status": status}
-
-    def _require_xy(self, action: str, x: Any, y: Any) -> Tuple[int, int]:
-        nx, ny = _coerce_xy(x, y)
-        if nx is None or ny is None:
-            raise ToolError(
-                f"computer.{action} requires both x and y coordinates "
-                f"(got x={x!r}, y={y!r}); pass them as separate integers."
-            )
-        return nx, ny

--- a/tests/ale_claw/test_coordinate_scaling.py
+++ b/tests/ale_claw/test_coordinate_scaling.py
@@ -1,0 +1,185 @@
+"""Tests for pointer coordinate handling in the ale_claw computer handlers.
+
+Covers the Gemini "normalized [0, 1000) grid" fix:
+  - coordinate_space_for_model() auto-detection
+  - "pixel" space is an unscaled pass-through (default, back-compat)
+  - "normalized" space rescales model coords to pixels via screen size
+  - both handlers (OpenClawComputerHandler + MCPComputerHandler) scale
+    click / drag (start-end and path) consistently
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ale_run.agents.ale_claw.harness.tools.computer_handler import (
+    NORMALIZED_GRID,
+    MCPComputerHandler,
+    OpenClawComputerHandler,
+    coordinate_space_for_model,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+SCREEN_W, SCREEN_H = 1920, 1080
+
+
+def _norm_to_px(n: int, dim: int) -> int:
+    return round(n / NORMALIZED_GRID * dim)
+
+
+# ---------------------------------------------------------------------------
+# coordinate_space_for_model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_id,expected",
+    [
+        ("openrouter/google/gemini-3.1-pro-preview", "normalized"),
+        ("openrouter/google/gemini-2.5-flash", "normalized"),
+        ("GEMINI-pro", "normalized"),
+        ("openrouter/anthropic/claude-sonnet-4.6", "pixel"),
+        ("openrouter/openai/gpt-5.4", "pixel"),
+        (None, "pixel"),
+        ("", "pixel"),
+    ],
+)
+def test_coordinate_space_for_model(model_id, expected):
+    assert coordinate_space_for_model(model_id) == expected
+
+
+# ---------------------------------------------------------------------------
+# OpenClawComputerHandler (session path — coords flow straight to interface)
+# ---------------------------------------------------------------------------
+
+
+def _make_openclaw_handler(coordinate_space):
+    handler = OpenClawComputerHandler(
+        MagicMock(), coordinate_space=coordinate_space
+    )
+    # Bypass cua interface plumbing: stub get_dimensions + the parent methods
+    # that would otherwise hit a real RemoteDesktop interface.
+    handler.get_dimensions = AsyncMock(return_value=(SCREEN_W, SCREEN_H))
+    handler.interface = MagicMock()
+    return handler
+
+
+def test_openclaw_pixel_passthrough(monkeypatch):
+    handler = _make_openclaw_handler("pixel")
+    seen = {}
+
+    async def fake_click(self, x, y, button="left"):
+        seen["xy"] = (x, y)
+
+    monkeypatch.setattr(
+        "agent.computers.cua.cuaComputerHandler.click", fake_click
+    )
+    _run(handler.click(640, 480))
+    assert seen["xy"] == (640, 480)
+
+
+def test_openclaw_normalized_scales_to_pixels(monkeypatch):
+    handler = _make_openclaw_handler("normalized")
+    seen = {}
+
+    async def fake_click(self, x, y, button="left"):
+        seen["xy"] = (x, y)
+
+    monkeypatch.setattr(
+        "agent.computers.cua.cuaComputerHandler.click", fake_click
+    )
+    # Model emits normalized center (500, 500) → screen center in pixels.
+    _run(handler.click(500, 500))
+    assert seen["xy"] == (_norm_to_px(500, SCREEN_W), _norm_to_px(500, SCREEN_H))
+    assert seen["xy"] == (960, 540)
+
+
+def test_openclaw_normalized_clamps_to_screen(monkeypatch):
+    handler = _make_openclaw_handler("normalized")
+    seen = {}
+
+    async def fake_click(self, x, y, button="left"):
+        seen["xy"] = (x, y)
+
+    monkeypatch.setattr(
+        "agent.computers.cua.cuaComputerHandler.click", fake_click
+    )
+    # 999 is the max grid value; must never exceed the pixel bounds.
+    _run(handler.click(999, 999))
+    px, py = seen["xy"]
+    assert 0 <= px <= SCREEN_W - 1
+    assert 0 <= py <= SCREEN_H - 1
+
+
+def test_openclaw_normalized_drag_path(monkeypatch):
+    handler = _make_openclaw_handler("normalized")
+    seen = {}
+
+    async def fake_drag(self, path=None, start_x=None, start_y=None,
+                        end_x=None, end_y=None):
+        seen["path"] = path
+
+    monkeypatch.setattr(
+        "agent.computers.cua.cuaComputerHandler.drag", fake_drag
+    )
+    # Use a mid grid value (500) to avoid the edge clamp; 1000 would clamp to
+    # w-1/h-1 which is verified separately in test_openclaw_normalized_clamps.
+    _run(handler.drag(path=[{"x": 0, "y": 0}, {"x": 500, "y": 500}]))
+    assert seen["path"][0] == {"x": 0, "y": 0}
+    assert seen["path"][-1]["x"] == _norm_to_px(500, SCREEN_W)
+    assert seen["path"][-1]["y"] == _norm_to_px(500, SCREEN_H)
+
+
+# ---------------------------------------------------------------------------
+# MCPComputerHandler (bridge path — px→[0,1000] happens in _to_norm)
+# ---------------------------------------------------------------------------
+
+
+def _make_mcp_handler(coordinate_space):
+    handler = MCPComputerHandler(
+        MagicMock(), os_type="windows", coordinate_space=coordinate_space
+    )
+    handler._dims = (SCREEN_W, SCREEN_H)  # skip get_screen_size round-trip
+    handler._call_cua = AsyncMock()
+    return handler
+
+
+def test_mcp_pixel_click_norm_roundtrip():
+    handler = _make_mcp_handler("pixel")
+    # Pixel center → bridge-normalized ~500.
+    _run(handler.click(960, 540))
+    args = handler._call_cua.call_args
+    assert args[0][0] == "click"
+    coord = args[0][1]["coordinate"]
+    assert coord == [500, 500]
+
+
+def test_mcp_normalized_click_roundtrips_back():
+    handler = _make_mcp_handler("normalized")
+    # Model emits normalized (500, 500). Handler scales →px (960,540), then
+    # _to_norm converts back →[500,500] for the bridge. Net: identity.
+    _run(handler.click(500, 500))
+    coord = handler._call_cua.call_args[0][1]["coordinate"]
+    assert coord == [500, 500]
+
+
+def test_mcp_normalized_differs_from_pixel_for_offcenter():
+    """A raw normalized coord treated as pixels would land wrong; scaling fixes it."""
+    norm = _make_mcp_handler("normalized")
+    _run(norm.click(250, 250))
+    norm_coord = norm._call_cua.call_args[0][1]["coordinate"]
+    # Scaled: normalized 250 → pixel 480/270 → bridge norm back to ~250.
+    assert norm_coord == [250, 250]
+
+    pixel = _make_mcp_handler("pixel")
+    _run(pixel.click(250, 250))
+    pixel_coord = pixel._call_cua.call_args[0][1]["coordinate"]
+    # Treated as pixels: 250/1920*1000 ≈ 130 — the wrong place.
+    assert pixel_coord == [round(250 / SCREEN_W * 1000),
+                           round(250 / SCREEN_H * 1000)]
+    assert pixel_coord != norm_coord


### PR DESCRIPTION
## Problem
Gemini-family GUI models ground clicks to a fixed **[0, 1000) normalized grid**, not screen pixels — a value of `(800, 500)` means "80% across, 50% down", regardless of the `Screen resolution: WxH` hint in the `computer` tool description. The ale_claw harness forwarded those values through as if they were pixels, so clicks landed further from their target the further from the top-left corner they were (off by `frac*(dim-1000)` px — e.g. ~736px in x at 1920 wide). This is the "Gemini clicks are off" symptom.

## Fix
A coordinate-space concept in the computer handlers: when the driving model emits `"normalized"` coordinates, rescale to pixels (`px = n / 1000 * dim`) using the live screen size **before** the existing pixel-space path. Default `"pixel"` is an unchanged pass-through, so Claude/GPT are untouched. Denominator `1000` confirmed against [Google's Gemini computer-use docs](https://ai.google.dev/gemini-api/docs/computer-use) (models emit `0-999`; denormalize divides by `1000`).

- `computer_handler.py`: shared `_PointerCoords` mixin — coercion + optional normalized→pixel scaling for click/double/right/move/scroll/drag (start-end and path) in **both** `OpenClawComputerHandler` (session) and `MCPComputerHandler` (bridge); `coordinate_space_for_model()` auto-detects Gemini.
- `config.py`: `coordinate_space` knob (`null`=auto | `pixel` | `normalized`).
- `deployer.py` resolves the space from the driving model; `agent_loop.py` + `subagent_gui.py` propagate it (the `delegate_gui` subagent now wraps its computer too).
- `tests/ale_claw/test_coordinate_scaling.py`: detection, pass-through, scaling, edge clamping, drag paths, both handlers (14 tests).

## Scope note
This is the **fix only**. The demo probes (`tasks/demo/clickhit`, `clickhit_win`) and the example `ale_claw_gemini.yaml` that validate/exercise the fix live on the `fix/gemini-normalized-coords` branch, kept off `main` per request.

## Validation
Unit tests pass (14). The fix was also validated end-to-end on live Windows and Linux VMs via the demo probes: `coordinate_space: pixel` misses the target by hundreds of px → `0.0`; `normalized`/auto hits → `1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)