### PR TITLE
feat(agents): add Grok Build harness

### DIFF
--- a/ale_run/agents/grok_build/README.md
+++ b/ale_run/agents/grok_build/README.md
@@ -58,18 +58,24 @@ the complete `total_cost_usd` field.
 
 ## Telemetry
 
-Grok Build records native session events for each model loop and tool call. The
-harness normalizes them into:
+The harness enables Grok Build's native **external OpenTelemetry** stream and
+points it at a run-local OTLP/HTTP protobuf receiver. SpaceXAI product analytics,
+Mixpanel, and trace upload are separately forced off. The external content gates
+remain closed, so prompts, source paths, and tool parameters are not exported.
 
-- `telemetry.jsonl`: the session's timestamped native events
-- `telemetry_summary.json`: request/session IDs, aggregate API duration and
-  usage, per-loop first-token and generation timing, plus native and MCP tool
-  durations and outcomes
+- `otel_requests.jsonl`: complete raw OTLP batches in a bounded-record WAL,
+  incrementally mirrored from the sandbox
+- `telemetry.jsonl`: flattened `grok_code.*` OTLP log events
+- `telemetry_metrics.jsonl`: flattened token, turn, tool, session, and error
+  metric points
+- `telemetry_summary.json`: API calls/errors, tool decisions/results, MCP
+  connections, event counts, and aggregate metrics
 
-Unlike Kimi Code's JavaScript client, Grok Build runs its model transport in a
-native binary, so Node/Undici OpenTelemetry injection cannot observe its HTTP
-trace IDs or status codes. The harness uses Grok's own events rather than
-adding a duplicate proxy or modifying upstream.
+Grok also records richer run-local session events used by the trajectory parser.
+The harness keeps those independently as `native_telemetry.jsonl` and
+`native_telemetry_summary.json`, including loop timing, first-token timing, and
+MCP durations. They are not mislabeled as OTEL or allowed to overwrite the
+external stream.
 
 ## MCP And Screenshots
 
@@ -119,9 +125,17 @@ config:
 ```
 
 Supported `api_backend` values are `chat_completions`, `responses`, and
-`messages`. Custom gateways must emit the selected protocol exactly. For
-example, a Responses gateway that adds unknown SSE event types can be rejected
-by Grok Build's strict event decoder.
+`messages`; all three are implemented by Grok Build. `base_url` must be the API
+root that exposes the selected wire protocol: `<base_url>/chat/completions`,
+`<base_url>/responses`, or `<base_url>/messages`. Custom gateways must emit that
+protocol exactly. For example, a Responses gateway that adds unknown SSE event
+types can be rejected by Grok Build's strict event decoder.
+
+`reasoning_effort` is passed as `--reasoning-effort`. Grok Build accepts the
+canonical levels `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`
+plus model-specific menu IDs, but the selected model must advertise or accept
+the value. The built-in `grok-4.5` catalog supports `high`, `medium`, and `low`;
+ALE pins `high`.
 
 `context_window` is optional custom-model metadata used to schedule automatic
 context compaction. When it is omitted (or `null` in a programmatic config), the
@@ -146,4 +160,5 @@ both process-only.
 - https://docs.x.ai/build/cli/headless-scripting
 - https://docs.x.ai/build/features/mcp-servers
 - https://docs.x.ai/build/settings
+- https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/24-monitoring-usage.md
 - https://www.npmjs.com/package/@xai-official/grok

--- a/ale_run/agents/grok_build/README.md
+++ b/ale_run/agents/grok_build/README.md
@@ -34,6 +34,12 @@ The harness passes:
 - `--no-plan` because ALE episodes have no interactive plan-approval client
 - `--output-format streaming-json` for incremental output and final usage
 
+These are harness invariants, not experiment knobs. Grok's built-in web tools
+remain enabled: `web_search` searches the internet and `web_fetch` retrieves a
+URL. They are separate from `search_tool`, which searches the schemas exposed by
+connected MCP servers (for example, discovering the `cua__*` tools). An
+experiment can remove any additional built-in tool through `disabled_tools`.
+
 `transcript.jsonl` contains `thought`, `text`, `end`, and `error` events. Grok
 Build does not emit tool calls on stdout. The harness therefore parses the
 run-local session's `chat_history.jsonl` for model messages and tool results,
@@ -74,9 +80,10 @@ The deployer writes this shape to `$GROK_HOME/config.toml`:
 command = "/path/to/node"
 args = ["/path/to/cua_mcp_server/src/index.js"]
 env = { CUA_SERVER_URL = "http://127.0.0.1:5000" }
-startup_timeout_sec = 60
-tool_timeout_sec = 6000
 ```
+
+The harness uses the pinned Grok Build release's MCP defaults rather than
+exposing transport deadlines as agent configuration.
 
 Grok Build namespaces MCP tools as `cua__<tool>`. The model discovers and
 invokes them through Grok's `search_tool` and `use_tool` wrappers.

--- a/ale_run/agents/grok_build/README.md
+++ b/ale_run/agents/grok_build/README.md
@@ -1,0 +1,136 @@
+# Grok Build Agent
+
+This harness runs xAI's official Grok Build CLI inside the ALE sandbox. It is
+separate from the legacy `grok_cli` harness, which integrates the older
+`superagent-ai/grok-cli` product.
+
+## Runtime
+
+- Official package: `@xai-official/grok`
+- Default model: `grok-4.5`
+- Headless entry point: `grok --prompt-file ... --output-format streaming-json`
+- Authentication: `XAI_API_KEY`
+- Internal state: isolated under the episode's `GROK_HOME`
+- GUI access: ALE's existing CUA MCP bridge, registered as the `cua` server
+
+The package version is pinned in `GrokBuildConfig.cli_version`. The deployer
+installs the matching official platform package with npm and verifies both the
+package metadata and native binary version. The large native binary is kept
+outside the episode work directory so artifact gathering does not copy it.
+
+On Windows, Grok's project cwd is a short per-run path under
+`~/.ale-grok-build/cwd/`. Grok percent-encodes that cwd inside its session path;
+using the full ALE run id would otherwise exceed the legacy Windows path limit
+and prevent session trajectories from being gathered. `GROK_HOME`, transcripts,
+and all ALE artifacts remain under the normal episode work directory.
+
+## Headless Behavior
+
+The harness passes:
+
+- `--always-approve` so tool calls do not wait for an interactive user
+- `--no-auto-update` so a benchmark run cannot change its own CLI version
+- `--sandbox off` because the ALE VM is already the isolation boundary
+- `--output-format streaming-json` for incremental output and final usage
+
+`transcript.jsonl` contains `thought`, `text`, `end`, and `error` events. Grok
+Build does not emit tool calls on stdout. The harness therefore parses the
+run-local session's `chat_history.jsonl` for model messages and tool results,
+and uses `updates.jsonl` for tool status and fallback usage metadata.
+
+When Grok exits, the harness also exports the primary session's chat, updates,
+events, and MCP image results to fixed top-level files. Those files are hot
+artifacts, so ALE's incremental puller performs a final bounded reconciliation
+even if the nested session tree cannot be gathered. Large JSONL records are
+spooled across range chunks without exposing or truncating partial records.
+
+The final `end` event is the authoritative accounting source. Its
+`input_tokens` field is uncached input, while `cache_read_input_tokens` is
+recorded separately. Reported cost is persisted only when Grok Build supplies
+the complete `total_cost_usd` field.
+
+## Telemetry
+
+Grok Build records native session events for each model loop and tool call. The
+harness normalizes them into:
+
+- `telemetry.jsonl`: the session's timestamped native events
+- `telemetry_summary.json`: request/session IDs, aggregate API duration and
+  usage, per-loop first-token and generation timing, plus native and MCP tool
+  durations and outcomes
+
+Unlike Kimi Code's JavaScript client, Grok Build runs its model transport in a
+native binary, so Node/Undici OpenTelemetry injection cannot observe its HTTP
+trace IDs or status codes. The harness uses Grok's own events rather than
+adding a duplicate proxy or modifying upstream.
+
+## MCP And Screenshots
+
+The deployer writes this shape to `$GROK_HOME/config.toml`:
+
+```toml
+[mcp_servers.cua]
+command = "/path/to/node"
+args = ["/path/to/cua_mcp_server/src/index.js"]
+env = { CUA_SERVER_URL = "http://127.0.0.1:5000" }
+startup_timeout_sec = 60
+tool_timeout_sec = 6000
+```
+
+Grok Build namespaces MCP tools as `cua__<tool>`. The model discovers and
+invokes them through Grok's `search_tool` and `use_tool` wrappers.
+The trajectory parser unwraps `use_tool` so ALE records the underlying CUA tool
+name and arguments.
+
+ALE launches with `--no-plan` by default. Grok Build's plan approval is an
+interactive client flow, so `exit_plan_mode` cannot complete in a headless
+episode even when `--always-approve` is set. The default
+`--disallowed-tools` list therefore removes `ask_user_question`,
+`enter_plan_mode`, and `exit_plan_mode`.
+
+MCP image results are stored as data URLs in Grok's chat history or its
+run-local MCP spill files. The parser converts them to
+`ImageSource(type="base64")`; the framework then writes them under the standard
+`screenshots/` directory before serializing the trajectory.
+
+## Custom Models
+
+Set `base_url` to route Grok Build through another supported endpoint. The
+harness writes a run-local custom model entry and keeps the key in the process
+environment rather than `config.toml` or ALE's gathered `_spec.json`.
+
+```yaml
+harness: grok_build
+model: kimi-k2.5
+
+config:
+  base_url: https://api.moonshot.ai/v1
+  api_backend: chat_completions
+  api_key: ${env:MOONSHOT_API_KEY}
+  context_window: 262144
+```
+
+Supported `api_backend` values are `chat_completions`, `responses`, and
+`messages`. Custom gateways must emit the selected protocol exactly. For
+example, a Responses gateway that adds unknown SSE event types can be rejected
+by Grok Build's strict event decoder.
+
+`api_key` may be supplied directly through `${env:...}`, or `api_key_env` may
+name the executor environment variable to read. In both cases the deployer
+passes the resolved value through the private `ALE_GROK_BUILD_API_KEY` process
+variable named by the generated model's `env_key`; the value is never written
+to Grok's TOML.
+
+The custom model credential does not replace authentication for Grok Build's
+built-in xAI Imagine tools. `image_gen`, `image_edit`, `image_to_video`, and
+`reference_to_video` still require a valid `XAI_API_KEY`. To use a custom model
+endpoint and those tools together, provide both credentials; the harness keeps
+both process-only.
+
+## Upstream References
+
+- https://docs.x.ai/build/overview
+- https://docs.x.ai/build/cli/headless-scripting
+- https://docs.x.ai/build/features/mcp-servers
+- https://docs.x.ai/build/settings
+- https://www.npmjs.com/package/@xai-official/grok

--- a/ale_run/agents/grok_build/README.md
+++ b/ale_run/agents/grok_build/README.md
@@ -31,6 +31,7 @@ The harness passes:
 - `--always-approve` so tool calls do not wait for an interactive user
 - `--no-auto-update` so a benchmark run cannot change its own CLI version
 - `--sandbox off` because the ALE VM is already the isolation boundary
+- `--no-plan` because ALE episodes have no interactive plan-approval client
 - `--output-format streaming-json` for incremental output and final usage
 
 `transcript.jsonl` contains `thought`, `text`, `end`, and `error` events. Grok
@@ -82,11 +83,11 @@ invokes them through Grok's `search_tool` and `use_tool` wrappers.
 The trajectory parser unwraps `use_tool` so ALE records the underlying CUA tool
 name and arguments.
 
-ALE launches with `--no-plan` by default. Grok Build's plan approval is an
-interactive client flow, so `exit_plan_mode` cannot complete in a headless
-episode even when `--always-approve` is set. The default
-`--disallowed-tools` list therefore removes `ask_user_question`,
-`enter_plan_mode`, and `exit_plan_mode`.
+These are harness invariants rather than user-facing options. Grok Build's plan
+approval is an interactive client flow, so `exit_plan_mode` cannot complete in
+a headless episode even when `--always-approve` is set. The harness always
+removes `ask_user_question`, `enter_plan_mode`, and `exit_plan_mode`.
+`disabled_tools` only adds further exclusions.
 
 MCP image results are stored as data URLs in Grok's chat history or its
 run-local MCP spill files. The parser converts them to
@@ -114,6 +115,11 @@ Supported `api_backend` values are `chat_completions`, `responses`, and
 `messages`. Custom gateways must emit the selected protocol exactly. For
 example, a Responses gateway that adds unknown SSE event types can be rejected
 by Grok Build's strict event decoder.
+
+`context_window` is optional custom-model metadata used to schedule automatic
+context compaction. When it is omitted (or `null` in a programmatic config), the
+harness does not write the field and Grok Build uses its catalog/provider
+metadata. Direct xAI catalog models do not need this override.
 
 `api_key` may be supplied directly through `${env:...}`, or `api_key_env` may
 name the executor environment variable to read. In both cases the deployer

--- a/ale_run/agents/grok_build/__init__.py
+++ b/ale_run/agents/grok_build/__init__.py
@@ -1,0 +1,6 @@
+"""Grok Build in-sandbox deployer."""
+
+from .config import GrokBuildConfig
+from .deployer import GrokBuildDeployer
+
+__all__ = ["GrokBuildConfig", "GrokBuildDeployer"]

--- a/ale_run/agents/grok_build/config.py
+++ b/ale_run/agents/grok_build/config.py
@@ -29,14 +29,8 @@ class GrokBuildConfig:
     reasoning_effort: str | None = None
     max_turns: int | None = None
 
-    always_approve: bool = True
-    disable_auto_update: bool = True
-    disable_web_search: bool = False
     disabled_tools: tuple[str, ...] = ()
     """Additional tools to remove beyond ALE's mandatory headless exclusions."""
-
-    mcp_startup_timeout_s: int = 60
-    mcp_tool_timeout_s: int = 6000
 
     cli_version: str = "@xai-official/grok@0.2.112"
     """Pinned official npm package installed dynamically when missing or stale."""

--- a/ale_run/agents/grok_build/config.py
+++ b/ale_run/agents/grok_build/config.py
@@ -1,0 +1,49 @@
+"""Configuration for the official xAI Grok Build CLI deployer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+_HEADLESS_DISABLED_TOOLS = (
+    "ask_user_question",
+    "enter_plan_mode",
+    "exit_plan_mode",
+)
+
+
+@dataclass
+class GrokBuildConfig:
+    """Per-episode Grok Build settings."""
+
+    name: ClassVar[str] = "grok-build"
+
+    model: str = "grok-4.5"
+
+    api_key: str | None = None
+    """Literal API key. ``None`` reads :attr:`api_key_env` from the executor."""
+
+    api_key_env: str = "XAI_API_KEY"
+    base_url: str | None = None
+    """Optional custom model endpoint. ``None`` uses xAI's built-in model catalog."""
+
+    api_backend: str = "responses"
+    """Custom endpoint protocol: ``chat_completions``, ``responses``, or ``messages``."""
+
+    context_window: int | None = None
+    max_completion_tokens: int | None = None
+    reasoning_effort: str | None = None
+    max_turns: int | None = None
+
+    always_approve: bool = True
+    disable_auto_update: bool = True
+    disable_web_search: bool = False
+    plan_mode: bool = False
+    sandbox_profile: str = "off"
+    disabled_tools: tuple[str, ...] = _HEADLESS_DISABLED_TOOLS
+
+    mcp_startup_timeout_s: int = 60
+    mcp_tool_timeout_s: int = 6000
+
+    cli_version: str = "@xai-official/grok@0.2.112"
+    """Pinned official npm package installed dynamically when missing or stale."""

--- a/ale_run/agents/grok_build/config.py
+++ b/ale_run/agents/grok_build/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 
 @dataclass
@@ -21,16 +21,21 @@ class GrokBuildConfig:
     base_url: str | None = None
     """Optional custom model endpoint. ``None`` uses xAI's built-in model catalog."""
 
-    api_backend: str = "responses"
-    """Custom endpoint protocol: ``chat_completions``, ``responses``, or ``messages``."""
+    api_backend: Literal["chat_completions", "responses", "messages"] = "responses"
+    """Any Grok-supported wire protocol; it must match the routes at ``base_url``."""
 
     context_window: int | None = None
     max_completion_tokens: int | None = None
-    reasoning_effort: str | None = None
+    reasoning_effort: str | None = "high"
+    """Reasoning level passed through ``--reasoning-effort`` when non-null."""
+
     max_turns: int | None = None
 
     disabled_tools: tuple[str, ...] = ()
     """Additional tools to remove beyond ALE's mandatory headless exclusions."""
+
+    otel_enabled: bool = True
+    """Capture Grok Build's native external OpenTelemetry stream run-locally."""
 
     cli_version: str = "@xai-official/grok@0.2.112"
     """Pinned official npm package installed dynamically when missing or stale."""

--- a/ale_run/agents/grok_build/config.py
+++ b/ale_run/agents/grok_build/config.py
@@ -5,12 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-_HEADLESS_DISABLED_TOOLS = (
-    "ask_user_question",
-    "enter_plan_mode",
-    "exit_plan_mode",
-)
-
 
 @dataclass
 class GrokBuildConfig:
@@ -38,9 +32,8 @@ class GrokBuildConfig:
     always_approve: bool = True
     disable_auto_update: bool = True
     disable_web_search: bool = False
-    plan_mode: bool = False
-    sandbox_profile: str = "off"
-    disabled_tools: tuple[str, ...] = _HEADLESS_DISABLED_TOOLS
+    disabled_tools: tuple[str, ...] = ()
+    """Additional tools to remove beyond ALE's mandatory headless exclusions."""
 
     mcp_startup_timeout_s: int = 60
     mcp_tool_timeout_s: int = 6000

--- a/ale_run/agents/grok_build/deployer.py
+++ b/ale_run/agents/grok_build/deployer.py
@@ -37,6 +37,12 @@ _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _MIN_NODE_VERSION = (20, 0, 0)
 _DATA_URL_RE = re.compile(r"data:(image/[A-Za-z0-9.+-]+);base64,([A-Za-z0-9+/=_-]+)")
 _CUSTOM_MODEL_ALIAS = "ale-custom"
+_SANDBOX_PROFILE = "off"
+_HEADLESS_DISABLED_TOOLS = (
+    "ask_user_question",
+    "enter_plan_mode",
+    "exit_plan_mode",
+)
 _SESSION_EXPORTS = {
     "chat_history.jsonl": "session_chat_history.jsonl",
     "updates.jsonl": "session_updates.jsonl",
@@ -443,7 +449,7 @@ class GrokBuildDeployer(BaseAgentDeployer):
                 # including API keys. Session JSONL is the trajectory source,
                 # so discard this unsafe duplicate rather than gathering it.
                 "GROK_LOG_FILE": os.devnull,
-                "GROK_SANDBOX": config.sandbox_profile,
+                "GROK_SANDBOX": _SANDBOX_PROFILE,
                 "GROK_MEMORY": "0",
                 "GROK_CURSOR_SKILLS_ENABLED": "0",
                 "GROK_CURSOR_RULES_ENABLED": "0",
@@ -486,7 +492,8 @@ class GrokBuildDeployer(BaseAgentDeployer):
             "--output-format",
             "streaming-json",
             "--sandbox",
-            config.sandbox_profile,
+            _SANDBOX_PROFILE,
+            "--no-plan",
         ]
         if config.always_approve:
             argv.append("--always-approve")
@@ -494,15 +501,13 @@ class GrokBuildDeployer(BaseAgentDeployer):
             argv.append("--no-auto-update")
         if config.disable_web_search:
             argv.append("--disable-web-search")
-        if not config.plan_mode:
-            argv.append("--no-plan")
-        if config.disabled_tools:
-            argv.extend(
-                [
-                    "--disallowed-tools",
-                    ",".join(config.disabled_tools),
-                ]
-            )
+        disabled_tools = tuple(dict.fromkeys((*_HEADLESS_DISABLED_TOOLS, *config.disabled_tools)))
+        argv.extend(
+            [
+                "--disallowed-tools",
+                ",".join(disabled_tools),
+            ]
+        )
         if config.reasoning_effort:
             argv.extend(["--reasoning-effort", config.reasoning_effort])
         if config.max_turns is not None:

--- a/ale_run/agents/grok_build/deployer.py
+++ b/ale_run/agents/grok_build/deployer.py
@@ -388,7 +388,7 @@ class GrokBuildDeployer(BaseAgentDeployer):
         lines.extend(
             [
                 "[cli]",
-                f"auto_update = {'false' if config.disable_auto_update else 'true'}",
+                "auto_update = false",
                 "",
                 "[compat.cursor]",
                 "skills = false",
@@ -419,8 +419,6 @@ class GrokBuildDeployer(BaseAgentDeployer):
                     + "]"
                 ),
                 ("env = { CUA_SERVER_URL = " + _toml_string(self.executor.cua_bridge_url()) + " }"),
-                f"startup_timeout_sec = {config.mcp_startup_timeout_s}",
-                f"tool_timeout_sec = {config.mcp_tool_timeout_s}",
                 "",
             ]
         )
@@ -461,12 +459,9 @@ class GrokBuildDeployer(BaseAgentDeployer):
                 "GROK_CLAUDE_AGENTS_ENABLED": "0",
                 "GROK_CLAUDE_MCPS_ENABLED": "0",
                 "GROK_CLAUDE_HOOKS_ENABLED": "0",
+                "GROK_DISABLE_AUTOUPDATER": "1",
             }
         )
-        if config.disable_auto_update:
-            env["GROK_DISABLE_AUTOUPDATER"] = "1"
-        else:
-            env.pop("GROK_DISABLE_AUTOUPDATER", None)
         if config.base_url:
             env["ALE_GROK_BUILD_API_KEY"] = api_key
         else:
@@ -494,13 +489,9 @@ class GrokBuildDeployer(BaseAgentDeployer):
             "--sandbox",
             _SANDBOX_PROFILE,
             "--no-plan",
+            "--always-approve",
+            "--no-auto-update",
         ]
-        if config.always_approve:
-            argv.append("--always-approve")
-        if config.disable_auto_update:
-            argv.append("--no-auto-update")
-        if config.disable_web_search:
-            argv.append("--disable-web-search")
         disabled_tools = tuple(dict.fromkeys((*_HEADLESS_DISABLED_TOOLS, *config.disabled_tools)))
         argv.extend(
             [

--- a/ale_run/agents/grok_build/deployer.py
+++ b/ale_run/agents/grok_build/deployer.py
@@ -26,7 +26,8 @@ from ale_run.base_interface import (
 )
 
 from .config import GrokBuildConfig
-from .telemetry import recover_telemetry_artifacts
+from .otel import GrokBuildOtelCollector, recover_otel_artifacts
+from .telemetry import recover_native_telemetry_artifacts
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +151,7 @@ class GrokBuildDeployer(BaseAgentDeployer):
         "session_events.jsonl",
         "session_summary.json",
         "session_media.jsonl",
+        "otel_requests.jsonl",
     )
 
     @property
@@ -289,76 +291,92 @@ class GrokBuildDeployer(BaseAgentDeployer):
                 pass
         prompt_file.write_text(prompt, encoding="utf-8")
 
-        env = self._build_env(config, work_dir=work_dir)
         grok_cwd = _grok_cwd(
             work_dir,
             is_linux=self.executor.sandbox.is_linux,
         )
         grok_cwd.mkdir(parents=True, exist_ok=True)
         argv = self._build_argv(config, grok_cwd=grok_cwd, prompt_file=prompt_file)
+        collector = GrokBuildOtelCollector(work_dir) if config.otel_enabled else None
+        process: subprocess.Popen[bytes] | None = None
         started = time.monotonic()
-        stdout = await asyncio.to_thread(transcript_file.open, "wb")
-        stderr = await asyncio.to_thread(stderr_file.open, "wb")
         try:
-            process = await asyncio.to_thread(
-                subprocess.Popen,
-                argv,
-                stdin=subprocess.DEVNULL,
-                stdout=stdout,
-                stderr=stderr,
-                cwd=str(grok_cwd),
-                env=env,
-                start_new_session=hasattr(os, "setsid"),
-            )
-        finally:
-            await asyncio.to_thread(stdout.close)
-            await asyncio.to_thread(stderr.close)
-        pid_file.write_text(str(process.pid), encoding="ascii")
-        logger.info("grok_build: spawned pid=%s", process.pid)
-
-        try:
-            while process.poll() is None:
-                await asyncio.sleep(_POLL_INTERVAL_S)
-        except asyncio.CancelledError:
-            try:
-                process.terminate()
-            except ProcessLookupError:
-                pass
-            try:
-                await asyncio.wait_for(
-                    asyncio.to_thread(process.wait),
-                    timeout=_TERM_GRACE_S,
+            if collector is not None:
+                collector.start()
+                logger.info(
+                    "grok_build: external OTel collector listening at %s",
+                    collector.endpoint,
                 )
-            except (TimeoutError, asyncio.CancelledError):
+            env = self._build_env(
+                config,
+                work_dir=work_dir,
+                otel_endpoint=collector.endpoint if collector else None,
+            )
+            stdout = await asyncio.to_thread(transcript_file.open, "wb")
+            stderr = await asyncio.to_thread(stderr_file.open, "wb")
+            try:
+                process = await asyncio.to_thread(
+                    subprocess.Popen,
+                    argv,
+                    stdin=subprocess.DEVNULL,
+                    stdout=stdout,
+                    stderr=stderr,
+                    cwd=str(grok_cwd),
+                    env=env,
+                    start_new_session=hasattr(os, "setsid"),
+                )
+            finally:
+                await asyncio.to_thread(stdout.close)
+                await asyncio.to_thread(stderr.close)
+            pid_file.write_text(str(process.pid), encoding="ascii")
+            logger.info("grok_build: spawned pid=%s", process.pid)
+
+            try:
+                while process.poll() is None:
+                    await asyncio.sleep(_POLL_INTERVAL_S)
+            except asyncio.CancelledError:
                 try:
-                    process.kill()
+                    process.terminate()
                 except ProcessLookupError:
                     pass
-            raise
+                try:
+                    await asyncio.wait_for(
+                        asyncio.to_thread(process.wait),
+                        timeout=_TERM_GRACE_S,
+                    )
+                except (TimeoutError, asyncio.CancelledError):
+                    try:
+                        process.kill()
+                    except ProcessLookupError:
+                        pass
+                raise
 
-        await asyncio.to_thread(
-            self._export_session_artifacts,
-            work_dir,
-            transcript_file,
-        )
-        duration_s = time.monotonic() - started
-        status = "completed" if process.returncode == 0 else "failed"
-        error = None
-        if status == "failed":
-            error = self._diagnose_failure(
-                transcript_file=transcript_file,
-                stderr_file=stderr_file,
-                exit_code=process.returncode,
+            await asyncio.to_thread(
+                self._export_session_artifacts,
+                work_dir,
+                transcript_file,
             )
-        return AgentRunResult(
-            status=status,
-            pid=process.pid,
-            exit_code=process.returncode,
-            transcript_path=str(transcript_file),
-            stderr_path=str(stderr_file),
-            duration_s=duration_s,
-            error=error,
-        )
+            duration_s = time.monotonic() - started
+            status = "completed" if process.returncode == 0 else "failed"
+            error = None
+            if status == "failed":
+                error = self._diagnose_failure(
+                    transcript_file=transcript_file,
+                    stderr_file=stderr_file,
+                    exit_code=process.returncode,
+                )
+            return AgentRunResult(
+                status=status,
+                pid=process.pid,
+                exit_code=process.returncode,
+                transcript_path=str(transcript_file),
+                stderr_path=str(stderr_file),
+                duration_s=duration_s,
+                error=error,
+            )
+        finally:
+            if collector is not None:
+                collector.stop()
 
     def _write_config(self, config: GrokBuildConfig, *, work_dir: Path) -> None:
         sandbox = self.executor.sandbox
@@ -383,10 +401,24 @@ class GrokBuildDeployer(BaseAgentDeployer):
                 lines.append(f"context_window = {config.context_window}")
             if config.max_completion_tokens is not None:
                 lines.append(f"max_completion_tokens = {config.max_completion_tokens}")
+            if config.reasoning_effort is not None:
+                lines.extend(
+                    [
+                        "supports_reasoning_effort = true",
+                        f"reasoning_effort = {_toml_string(config.reasoning_effort)}",
+                    ]
+                )
             lines.append("")
 
         lines.extend(
             [
+                "[features]",
+                "telemetry = false",
+                "",
+                "[telemetry]",
+                "trace_upload = false",
+                "mixpanel_enabled = false",
+                "",
                 "[cli]",
                 "auto_update = false",
                 "",
@@ -429,6 +461,7 @@ class GrokBuildDeployer(BaseAgentDeployer):
         config: GrokBuildConfig,
         *,
         work_dir: Path,
+        otel_endpoint: str | None = None,
     ) -> dict[str, str]:
         env = os.environ.copy()
         env.update(self.executor.env or {})
@@ -460,8 +493,39 @@ class GrokBuildDeployer(BaseAgentDeployer):
                 "GROK_CLAUDE_MCPS_ENABLED": "0",
                 "GROK_CLAUDE_HOOKS_ENABLED": "0",
                 "GROK_DISABLE_AUTOUPDATER": "1",
+                "GROK_TELEMETRY_ENABLED": "0",
+                "GROK_TELEMETRY_TRACE_UPLOAD": "0",
+                "GROK_TELEMETRY_MIXPANEL_ENABLED": "0",
+                "GROK_EXTERNAL_OTEL": "0",
+                "OTEL_LOGS_EXPORTER": "none",
+                "OTEL_METRICS_EXPORTER": "none",
+                "OTEL_TRACES_EXPORTER": "none",
             }
         )
+        for variable in (
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+            "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+        ):
+            env.pop(variable, None)
+        if otel_endpoint is not None:
+            env.update(
+                {
+                    "GROK_EXTERNAL_OTEL": "1",
+                    "OTEL_LOGS_EXPORTER": "otlp",
+                    "OTEL_METRICS_EXPORTER": "otlp",
+                    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+                    "OTEL_EXPORTER_OTLP_ENDPOINT": otel_endpoint,
+                    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": f"{otel_endpoint}/v1/logs",
+                    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": f"{otel_endpoint}/v1/metrics",
+                    "OTEL_EXPORTER_OTLP_TIMEOUT": "10000",
+                    "OTEL_BLRP_SCHEDULE_DELAY": "1000",
+                    "OTEL_LOGS_EXPORT_INTERVAL": "1000",
+                    "OTEL_METRIC_EXPORT_INTERVAL": "1000",
+                    "OTEL_LOG_USER_PROMPTS": "0",
+                    "OTEL_LOG_TOOL_DETAILS": "0",
+                }
+            )
         if config.base_url:
             env["ALE_GROK_BUILD_API_KEY"] = api_key
         else:
@@ -658,14 +722,18 @@ class GrokBuildDeployer(BaseAgentDeployer):
         usage_source = terminal_event if terminal_event.get("usage") else update_terminal
         cls._apply_usage(usage_source, builder)
         try:
-            recover_telemetry_artifacts(
+            recover_native_telemetry_artifacts(
                 work_dir,
                 events_file=events_file,
                 updates_file=updates_file,
                 terminal_event=terminal_event,
             )
         except (OSError, TypeError, ValueError) as exc:
-            logger.warning("grok_build: telemetry recovery failed: %s", exc)
+            logger.warning("grok_build: native telemetry recovery failed: %s", exc)
+        try:
+            recover_otel_artifacts(work_dir)
+        except (OSError, TypeError, ValueError) as exc:
+            logger.warning("grok_build: OTel recovery failed: %s", exc)
 
         metadata = {
             "exit_code": run_result.exit_code,
@@ -677,7 +745,10 @@ class GrokBuildDeployer(BaseAgentDeployer):
             "updates_path": str(updates_file) if updates_file else None,
             "events_path": str(events_file) if events_file else None,
             "telemetry_path": str(work_dir / "telemetry.jsonl"),
+            "telemetry_metrics_path": str(work_dir / "telemetry_metrics.jsonl"),
             "telemetry_summary_path": str(work_dir / "telemetry_summary.json"),
+            "native_telemetry_path": str(work_dir / "native_telemetry.jsonl"),
+            "native_telemetry_summary_path": str(work_dir / "native_telemetry_summary.json"),
             "stop_reason": terminal_event.get("stopReason") or update_terminal.get("stop_reason"),
             "num_turns": terminal_event.get("num_turns") or update_terminal.get("numTurns"),
             "model_usage": terminal_event.get("modelUsage")

--- a/ale_run/agents/grok_build/deployer.py
+++ b/ale_run/agents/grok_build/deployer.py
@@ -1,0 +1,1026 @@
+"""Run the official xAI Grok Build CLI inside an ALE sandbox."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, ClassVar
+
+from ale_run.base_interface import (
+    AgentRunResult,
+    BaseAgentDeployer,
+    ContentPart,
+    ImageSource,
+    Observation,
+    ToolCall,
+    ToolResult,
+    TrajectoryBuilder,
+)
+
+from .config import GrokBuildConfig
+from .telemetry import recover_telemetry_artifacts
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_S = 2.0
+_TERM_GRACE_S = 2.0
+_MAX_MCP_SPILL_BYTES = 32 * 1024 * 1024
+_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+_MIN_NODE_VERSION = (20, 0, 0)
+_DATA_URL_RE = re.compile(r"data:(image/[A-Za-z0-9.+-]+);base64,([A-Za-z0-9+/=_-]+)")
+_CUSTOM_MODEL_ALIAS = "ale-custom"
+_SESSION_EXPORTS = {
+    "chat_history.jsonl": "session_chat_history.jsonl",
+    "updates.jsonl": "session_updates.jsonl",
+    "events.jsonl": "session_events.jsonl",
+    "summary.json": "session_summary.json",
+}
+_SESSION_MEDIA_EXPORT = "session_media.jsonl"
+
+
+def _expected_version(npm_spec: str | None) -> str | None:
+    if not npm_spec:
+        return None
+    match = _VERSION_RE.search(npm_spec.rsplit("@", 1)[-1])
+    return match.group(1) if match else None
+
+
+def _node_version(node_path: str) -> tuple[int, int, int] | None:
+    try:
+        probe = subprocess.run(
+            [node_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = _VERSION_RE.search((probe.stdout or "") + (probe.stderr or ""))
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))  # type: ignore[return-value]
+
+
+def _installed_package_version(npm_path: str, prefix: Path) -> str | None:
+    try:
+        probe = subprocess.run(
+            [npm_path, "root", "--global", "--prefix", str(prefix)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+        if probe.returncode != 0 or not probe.stdout.strip():
+            return None
+        package_json = Path(probe.stdout.strip()) / "@xai-official" / "grok" / "package.json"
+        metadata = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+    version = metadata.get("version")
+    return version if isinstance(version, str) else None
+
+
+def _native_binary(grok_install_home: Path, expected: str | None) -> Path | None:
+    bin_dir = grok_install_home / "bin"
+    candidates = [
+        bin_dir / ("grok.exe" if os.name == "nt" else "grok"),
+    ]
+    if expected:
+        candidates.append(bin_dir / f"grok-{expected}{'.exe' if os.name == 'nt' else ''}")
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _installed_binary_version(grok_path: Path) -> str | None:
+    try:
+        probe = subprocess.run(
+            [str(grok_path), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = _VERSION_RE.search((probe.stdout or "") + (probe.stderr or ""))
+    return match.group(1) if match else None
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _grok_cwd(work_dir: Path, *, is_linux: bool) -> Path:
+    if is_linux:
+        return work_dir
+    digest = hashlib.sha256(str(work_dir).encode("utf-8")).hexdigest()[:12]
+    return Path.home() / ".ale-grok-build" / "cwd" / digest
+
+
+class GrokBuildDeployer(BaseAgentDeployer):
+    """Sandbox deployer for ``@xai-official/grok``."""
+
+    default_executor: ClassVar[str] = "sandbox"
+    supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
+    hot_artifacts: ClassVar[tuple[str, ...]] = (
+        "transcript.jsonl",
+        "stderr.log",
+        "session_chat_history.jsonl",
+        "session_updates.jsonl",
+        "session_events.jsonl",
+        "session_summary.json",
+        "session_media.jsonl",
+    )
+
+    @property
+    def version(self) -> str | None:
+        config: GrokBuildConfig = self.config  # type: ignore[assignment]
+        return config.cli_version
+
+    async def install(self) -> None:
+        config: GrokBuildConfig = self.config  # type: ignore[assignment]
+        sandbox = self.executor.sandbox
+
+        from ale_run.agents._bootstrap import ensure_cua_mcp_server, ensure_node_npm
+
+        node_path, npm_path = await ensure_node_npm()
+        installed_node = await asyncio.to_thread(_node_version, node_path)
+        if installed_node is None or installed_node < _MIN_NODE_VERSION:
+            rendered = ".".join(str(part) for part in installed_node or ())
+            raise RuntimeError(
+                "grok_build: Grok Build requires Node.js >=20, "
+                f"found {rendered or 'an unreadable version'} at {node_path}"
+            )
+
+        work_dir = Path(self.executor.work_dir)
+        grok_home = work_dir / "grok-home"
+        grok_home.mkdir(parents=True, exist_ok=True)
+
+        install_root = Path(os.path.expanduser("~")) / ".ale-grok-build"
+        npm_prefix = install_root / "npm"
+        grok_install_home = install_root / "home"
+        npm_prefix.mkdir(parents=True, exist_ok=True)
+        grok_install_home.mkdir(parents=True, exist_ok=True)
+
+        expected = _expected_version(config.cli_version)
+        installed_package = await asyncio.to_thread(
+            _installed_package_version,
+            npm_path,
+            npm_prefix,
+        )
+        grok_path = _native_binary(grok_install_home, expected)
+        installed_binary = (
+            await asyncio.to_thread(_installed_binary_version, grok_path)
+            if grok_path is not None
+            else None
+        )
+        if grok_path is None or (
+            expected is not None and (installed_package != expected or installed_binary != expected)
+        ):
+            logger.info(
+                "grok_build: installing %s (package=%s binary=%s expected=%s)",
+                config.cli_version,
+                installed_package or "missing",
+                installed_binary or "missing",
+                expected or "unpinned",
+            )
+            npm_env = {
+                **os.environ,
+                "GROK_HOME": str(grok_install_home),
+                "npm_config_cache": str(install_root / "npm-cache"),
+            }
+            process = await asyncio.to_thread(
+                subprocess.run,
+                [
+                    npm_path,
+                    "install",
+                    "-g",
+                    "--force",
+                    "--prefix",
+                    str(npm_prefix),
+                    config.cli_version,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=1200,
+                env=npm_env,
+            )
+            if process.returncode != 0:
+                raise RuntimeError(
+                    "grok_build: npm install failed "
+                    f"(rc={process.returncode}, package={config.cli_version}): "
+                    f"{(process.stderr or process.stdout or '')[-800:]}"
+                )
+            installed_package = await asyncio.to_thread(
+                _installed_package_version,
+                npm_path,
+                npm_prefix,
+            )
+            grok_path = _native_binary(grok_install_home, expected)
+            installed_binary = (
+                await asyncio.to_thread(_installed_binary_version, grok_path)
+                if grok_path is not None
+                else None
+            )
+
+        if grok_path is None:
+            raise RuntimeError(
+                f"grok_build: official binary missing under {grok_install_home / 'bin'}"
+            )
+        if expected is not None and (installed_package != expected or installed_binary != expected):
+            raise RuntimeError(
+                "grok_build: post-install version mismatch "
+                f"(package={installed_package!r}, binary={installed_binary!r}, "
+                f"expected={expected!r})"
+            )
+
+        self._grok_path = str(grok_path)
+        self._node_path = node_path
+        logger.info(
+            "grok_build: CLI ready at %s (version %s, node %s)",
+            grok_path,
+            installed_binary or installed_package or "unknown",
+            ".".join(str(part) for part in installed_node),
+        )
+
+        await ensure_cua_mcp_server(sandbox)
+        self._write_config(config, work_dir=work_dir)
+
+    async def launch(self, prompt: str) -> AgentRunResult:
+        config: GrokBuildConfig = self.config  # type: ignore[assignment]
+        work_dir = Path(self.executor.work_dir)
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        prompt_file = work_dir / "prompt.txt"
+        transcript_file = work_dir / "transcript.jsonl"
+        stderr_file = work_dir / "stderr.log"
+        pid_file = work_dir / "grok.pid"
+        stale_paths = [
+            transcript_file,
+            stderr_file,
+            pid_file,
+            *(work_dir / export_name for export_name in _SESSION_EXPORTS.values()),
+            work_dir / _SESSION_MEDIA_EXPORT,
+        ]
+        for path in stale_paths:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        prompt_file.write_text(prompt, encoding="utf-8")
+
+        env = self._build_env(config, work_dir=work_dir)
+        grok_cwd = _grok_cwd(
+            work_dir,
+            is_linux=self.executor.sandbox.is_linux,
+        )
+        grok_cwd.mkdir(parents=True, exist_ok=True)
+        argv = self._build_argv(config, grok_cwd=grok_cwd, prompt_file=prompt_file)
+        started = time.monotonic()
+        stdout = await asyncio.to_thread(transcript_file.open, "wb")
+        stderr = await asyncio.to_thread(stderr_file.open, "wb")
+        try:
+            process = await asyncio.to_thread(
+                subprocess.Popen,
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout,
+                stderr=stderr,
+                cwd=str(grok_cwd),
+                env=env,
+                start_new_session=hasattr(os, "setsid"),
+            )
+        finally:
+            await asyncio.to_thread(stdout.close)
+            await asyncio.to_thread(stderr.close)
+        pid_file.write_text(str(process.pid), encoding="ascii")
+        logger.info("grok_build: spawned pid=%s", process.pid)
+
+        try:
+            while process.poll() is None:
+                await asyncio.sleep(_POLL_INTERVAL_S)
+        except asyncio.CancelledError:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(process.wait),
+                    timeout=_TERM_GRACE_S,
+                )
+            except (TimeoutError, asyncio.CancelledError):
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+            raise
+
+        await asyncio.to_thread(
+            self._export_session_artifacts,
+            work_dir,
+            transcript_file,
+        )
+        duration_s = time.monotonic() - started
+        status = "completed" if process.returncode == 0 else "failed"
+        error = None
+        if status == "failed":
+            error = self._diagnose_failure(
+                transcript_file=transcript_file,
+                stderr_file=stderr_file,
+                exit_code=process.returncode,
+            )
+        return AgentRunResult(
+            status=status,
+            pid=process.pid,
+            exit_code=process.returncode,
+            transcript_path=str(transcript_file),
+            stderr_path=str(stderr_file),
+            duration_s=duration_s,
+            error=error,
+        )
+
+    def _write_config(self, config: GrokBuildConfig, *, work_dir: Path) -> None:
+        sandbox = self.executor.sandbox
+        grok_home = work_dir / "grok-home"
+        lines = [
+            "[models]",
+            f"default = {_toml_string(_CUSTOM_MODEL_ALIAS if config.base_url else config.model)}",
+            "",
+        ]
+        if config.base_url:
+            lines.extend(
+                [
+                    f'[model."{_CUSTOM_MODEL_ALIAS}"]',
+                    f"model = {_toml_string(config.model)}",
+                    f"base_url = {_toml_string(config.base_url)}",
+                    f"name = {_toml_string(f'ALE {config.model}')}",
+                    'env_key = "ALE_GROK_BUILD_API_KEY"',
+                    f"api_backend = {_toml_string(config.api_backend)}",
+                ]
+            )
+            if config.context_window is not None:
+                lines.append(f"context_window = {config.context_window}")
+            if config.max_completion_tokens is not None:
+                lines.append(f"max_completion_tokens = {config.max_completion_tokens}")
+            lines.append("")
+
+        lines.extend(
+            [
+                "[cli]",
+                f"auto_update = {'false' if config.disable_auto_update else 'true'}",
+                "",
+                "[compat.cursor]",
+                "skills = false",
+                "rules = false",
+                "agents = false",
+                "mcps = false",
+                "hooks = false",
+                "",
+                "[compat.claude]",
+                "skills = false",
+                "rules = false",
+                "agents = false",
+                "mcps = false",
+                "hooks = false",
+                "",
+                "[mcp_servers.cua]",
+                f"command = {_toml_string(self._node_path)}",
+                (
+                    "args = ["
+                    + _toml_string(
+                        self._join(
+                            sandbox.mcp_server_dir,
+                            "src",
+                            "index.js",
+                            is_linux=sandbox.is_linux,
+                        )
+                    )
+                    + "]"
+                ),
+                ("env = { CUA_SERVER_URL = " + _toml_string(self.executor.cua_bridge_url()) + " }"),
+                f"startup_timeout_sec = {config.mcp_startup_timeout_s}",
+                f"tool_timeout_sec = {config.mcp_tool_timeout_s}",
+                "",
+            ]
+        )
+        (grok_home / "config.toml").write_text("\n".join(lines), encoding="utf-8")
+
+    def _build_env(
+        self,
+        config: GrokBuildConfig,
+        *,
+        work_dir: Path,
+    ) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(self.executor.env or {})
+
+        api_key = config.api_key or env.get(config.api_key_env)
+        if not api_key:
+            raise RuntimeError(
+                f"grok_build: no API key configured; set config.api_key or {config.api_key_env}"
+            )
+
+        env.update(
+            {
+                "GROK_HOME": str(work_dir / "grok-home"),
+                "GROK_MANAGED_BY_NPM": "1",
+                # The CLI's debug log includes its resolved sampler config,
+                # including API keys. Session JSONL is the trajectory source,
+                # so discard this unsafe duplicate rather than gathering it.
+                "GROK_LOG_FILE": os.devnull,
+                "GROK_SANDBOX": config.sandbox_profile,
+                "GROK_MEMORY": "0",
+                "GROK_CURSOR_SKILLS_ENABLED": "0",
+                "GROK_CURSOR_RULES_ENABLED": "0",
+                "GROK_CURSOR_AGENTS_ENABLED": "0",
+                "GROK_CURSOR_MCPS_ENABLED": "0",
+                "GROK_CURSOR_HOOKS_ENABLED": "0",
+                "GROK_CLAUDE_SKILLS_ENABLED": "0",
+                "GROK_CLAUDE_RULES_ENABLED": "0",
+                "GROK_CLAUDE_AGENTS_ENABLED": "0",
+                "GROK_CLAUDE_MCPS_ENABLED": "0",
+                "GROK_CLAUDE_HOOKS_ENABLED": "0",
+            }
+        )
+        if config.disable_auto_update:
+            env["GROK_DISABLE_AUTOUPDATER"] = "1"
+        else:
+            env.pop("GROK_DISABLE_AUTOUPDATER", None)
+        if config.base_url:
+            env["ALE_GROK_BUILD_API_KEY"] = api_key
+        else:
+            env["XAI_API_KEY"] = api_key
+        return env
+
+    def _build_argv(
+        self,
+        config: GrokBuildConfig,
+        *,
+        grok_cwd: Path,
+        prompt_file: Path,
+    ) -> list[str]:
+        runtime_model = _CUSTOM_MODEL_ALIAS if config.base_url else config.model
+        argv = [
+            self._grok_path,
+            "--prompt-file",
+            str(prompt_file),
+            "--cwd",
+            str(grok_cwd),
+            "--model",
+            runtime_model,
+            "--output-format",
+            "streaming-json",
+            "--sandbox",
+            config.sandbox_profile,
+        ]
+        if config.always_approve:
+            argv.append("--always-approve")
+        if config.disable_auto_update:
+            argv.append("--no-auto-update")
+        if config.disable_web_search:
+            argv.append("--disable-web-search")
+        if not config.plan_mode:
+            argv.append("--no-plan")
+        if config.disabled_tools:
+            argv.extend(
+                [
+                    "--disallowed-tools",
+                    ",".join(config.disabled_tools),
+                ]
+            )
+        if config.reasoning_effort:
+            argv.extend(["--reasoning-effort", config.reasoning_effort])
+        if config.max_turns is not None:
+            argv.extend(["--max-turns", str(config.max_turns)])
+        return argv
+
+    @staticmethod
+    def _join(*parts: str, is_linux: bool) -> str:
+        separator = "/" if is_linux else "\\"
+        head = parts[0].rstrip("/\\")
+        tail = separator.join(part.strip("/\\") for part in parts[1:])
+        return f"{head}{separator}{tail}" if tail else head
+
+    @classmethod
+    def _export_session_artifacts(
+        cls,
+        work_dir: Path,
+        transcript_file: Path,
+    ) -> None:
+        transcript_events = list(cls._json_lines(transcript_file))
+        terminal_event = next(
+            (
+                event
+                for event in reversed(transcript_events)
+                if event.get("type") in {"end", "error"}
+            ),
+            {},
+        )
+        session_dir = cls._find_session_dir(
+            work_dir / "grok-home",
+            terminal_event.get("sessionId"),
+        )
+        if session_dir is None:
+            return
+
+        for source_name, export_name in _SESSION_EXPORTS.items():
+            source = session_dir / source_name
+            destination = work_dir / export_name
+            try:
+                shutil.copyfile(source, destination)
+            except (FileNotFoundError, OSError) as exc:
+                logger.debug(
+                    "grok_build: could not export %s from %s: %s",
+                    source_name,
+                    session_dir,
+                    exc,
+                )
+
+        media_file = work_dir / _SESSION_MEDIA_EXPORT
+        media_file.unlink(missing_ok=True)
+        media_records: list[dict[str, str]] = []
+        for spill_file in sorted((session_dir / "mcp").glob("*.txt")):
+            tool_call_id = spill_file.stem
+            if not tool_call_id or Path(tool_call_id).name != tool_call_id:
+                continue
+            try:
+                if spill_file.stat().st_size > _MAX_MCP_SPILL_BYTES:
+                    continue
+                raw = spill_file.read_text(encoding="utf-8", errors="replace")
+            except (FileNotFoundError, OSError):
+                continue
+            if _DATA_URL_RE.search(raw):
+                media_records.append(
+                    {
+                        "tool_call_id": tool_call_id,
+                        "content": raw,
+                    }
+                )
+        if media_records:
+            with media_file.open("w", encoding="utf-8") as handle:
+                for record in media_records:
+                    handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def _session_artifact(
+        work_dir: Path,
+        session_dir: Path | None,
+        *,
+        source_name: str,
+    ) -> Path | None:
+        if session_dir is not None:
+            session_path = session_dir / source_name
+            if session_path.is_file():
+                return session_path
+        export_name = _SESSION_EXPORTS[source_name]
+        export_path = work_dir / export_name
+        return export_path if export_path.is_file() else None
+
+    @classmethod
+    def _session_media(cls, path: Path) -> dict[str, list[ContentPart]]:
+        results: dict[str, list[ContentPart]] = {}
+        for event in cls._json_lines(path):
+            tool_call_id = event.get("tool_call_id")
+            content = event.get("content")
+            if not isinstance(tool_call_id, str) or not isinstance(content, str):
+                continue
+            images = [part for part in cls._content_parts(content) if part.type == "image"]
+            if images:
+                results[tool_call_id] = images
+        return results
+
+    @classmethod
+    def parse_artifacts(
+        cls,
+        *,
+        work_dir: Path,
+        config: GrokBuildConfig,
+        run_result: AgentRunResult,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        transcript_file = work_dir / "transcript.jsonl"
+        transcript_events = list(cls._json_lines(transcript_file))
+        terminal_event = next(
+            (
+                event
+                for event in reversed(transcript_events)
+                if event.get("type") in {"end", "error"}
+            ),
+            {},
+        )
+        session_id = terminal_event.get("sessionId")
+        session_dir = cls._find_session_dir(work_dir / "grok-home", session_id)
+        chat_file = cls._session_artifact(
+            work_dir,
+            session_dir,
+            source_name="chat_history.jsonl",
+        )
+        updates_file = cls._session_artifact(
+            work_dir,
+            session_dir,
+            source_name="updates.jsonl",
+        )
+        events_file = cls._session_artifact(
+            work_dir,
+            session_dir,
+            source_name="events.jsonl",
+        )
+        media_results = cls._session_media(work_dir / _SESSION_MEDIA_EXPORT)
+
+        tool_errors: dict[str, bool] = {}
+        update_terminal: dict[str, Any] = {}
+        if updates_file is not None:
+            tool_errors, update_terminal = cls._updates_metadata(updates_file)
+
+        parsed_chat = False
+        if chat_file is not None and chat_file.exists():
+            parsed_chat = cls._parse_chat_history(
+                chat_file,
+                builder,
+                tool_errors=tool_errors,
+                session_dir=session_dir,
+                media_results=media_results,
+            )
+        if not parsed_chat:
+            cls._parse_stream(transcript_events, transcript_file, builder)
+
+        usage_source = terminal_event if terminal_event.get("usage") else update_terminal
+        cls._apply_usage(usage_source, builder)
+        try:
+            recover_telemetry_artifacts(
+                work_dir,
+                events_file=events_file,
+                updates_file=updates_file,
+                terminal_event=terminal_event,
+            )
+        except (OSError, TypeError, ValueError) as exc:
+            logger.warning("grok_build: telemetry recovery failed: %s", exc)
+
+        metadata = {
+            "exit_code": run_result.exit_code,
+            "transcript_path": str(transcript_file),
+            "stderr_path": run_result.stderr_path,
+            "session_id": session_id or update_terminal.get("sessionId"),
+            "session_dir": str(session_dir) if session_dir else None,
+            "chat_history_path": str(chat_file) if chat_file else None,
+            "updates_path": str(updates_file) if updates_file else None,
+            "events_path": str(events_file) if events_file else None,
+            "telemetry_path": str(work_dir / "telemetry.jsonl"),
+            "telemetry_summary_path": str(work_dir / "telemetry_summary.json"),
+            "stop_reason": terminal_event.get("stopReason") or update_terminal.get("stop_reason"),
+            "num_turns": terminal_event.get("num_turns") or update_terminal.get("numTurns"),
+            "model_usage": terminal_event.get("modelUsage")
+            or (update_terminal.get("usage") or {}).get("modelUsage"),
+        }
+        builder.trajectory.extra.setdefault("grok_build", {}).update(metadata)
+
+    @classmethod
+    def _parse_chat_history(
+        cls,
+        chat_file: Path,
+        builder: TrajectoryBuilder,
+        *,
+        tool_errors: dict[str, bool],
+        session_dir: Path | None,
+        media_results: dict[str, list[ContentPart]],
+    ) -> bool:
+        pending_reasoning: list[str] = []
+        added = False
+        for event in cls._json_lines(chat_file):
+            event_type = event.get("type")
+            if event_type == "reasoning":
+                for item in event.get("summary") or []:
+                    if isinstance(item, dict) and isinstance(item.get("text"), str):
+                        pending_reasoning.append(item["text"])
+                continue
+            if event_type == "assistant":
+                tool_calls: list[ToolCall] = []
+                for raw_call in event.get("tool_calls") or []:
+                    if not isinstance(raw_call, dict):
+                        continue
+                    arguments = cls._tool_arguments(raw_call.get("arguments"))
+                    name = str(raw_call.get("name") or "")
+                    if name == "use_tool" and isinstance(arguments.get("tool_name"), str):
+                        name = arguments["tool_name"]
+                        tool_input = arguments.get("tool_input")
+                        arguments = tool_input if isinstance(tool_input, dict) else {}
+                    tool_calls.append(
+                        ToolCall(
+                            id=str(raw_call.get("id") or ""),
+                            name=name,
+                            arguments=arguments,
+                        )
+                    )
+                message = cls._message_text(event.get("content"))
+                reasoning = "\n".join(pending_reasoning).strip() or None
+                pending_reasoning.clear()
+                if message is not None or reasoning is not None or tool_calls:
+                    builder.add_step(
+                        source="agent",
+                        message=message,
+                        reasoning=reasoning,
+                        tool_calls=tool_calls,
+                    )
+                    added = True
+                continue
+            if event_type == "tool_result":
+                tool_call_id = str(event.get("tool_call_id") or "")
+                content = cls._content_parts(event.get("content"))
+                if not any(part.type == "image" for part in content):
+                    if session_dir is not None:
+                        content.extend(
+                            cls._images_from_mcp_spill(
+                                session_dir=session_dir,
+                                tool_call_id=tool_call_id,
+                            )
+                        )
+                    if not any(part.type == "image" for part in content):
+                        content.extend(media_results.get(tool_call_id, []))
+                builder.add_step(
+                    source="environment",
+                    observation=Observation(
+                        results=[
+                            ToolResult(
+                                tool_call_id=tool_call_id,
+                                content=content,
+                                is_error=tool_errors.get(tool_call_id, False),
+                            )
+                        ]
+                    ),
+                )
+                added = True
+        if pending_reasoning:
+            builder.add_step(
+                source="agent",
+                reasoning="\n".join(pending_reasoning).strip(),
+            )
+            added = True
+        return added
+
+    @classmethod
+    def _images_from_mcp_spill(
+        cls,
+        *,
+        session_dir: Path,
+        tool_call_id: str,
+    ) -> list[ContentPart]:
+        if not tool_call_id or Path(tool_call_id).name != tool_call_id:
+            return []
+        spill_file = session_dir / "mcp" / f"{tool_call_id}.txt"
+        try:
+            if spill_file.stat().st_size > _MAX_MCP_SPILL_BYTES:
+                return []
+            raw = spill_file.read_text(encoding="utf-8", errors="replace")
+        except (FileNotFoundError, OSError):
+            return []
+        return [part for part in cls._content_parts(raw) if part.type == "image"]
+
+    @classmethod
+    def _parse_stream(
+        cls,
+        events: list[dict[str, Any]],
+        transcript_file: Path,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        if not transcript_file.exists():
+            builder.add_step(
+                source="system",
+                message=f"grok-build: no transcript at {transcript_file}",
+                extra={"reason": "no_transcript"},
+            )
+            return
+        text: list[str] = []
+        reasoning: list[str] = []
+        errors: list[str] = []
+        for event in events:
+            event_type = event.get("type")
+            if event_type == "text" and isinstance(event.get("data"), str):
+                text.append(event["data"])
+            elif event_type == "thought" and isinstance(event.get("data"), str):
+                reasoning.append(event["data"])
+            elif event_type == "error" and isinstance(event.get("message"), str):
+                errors.append(event["message"])
+        message = "".join(text).strip() or None
+        thought = "".join(reasoning).strip() or None
+        if message is not None or thought is not None:
+            builder.add_step(source="agent", message=message, reasoning=thought)
+        for error in errors:
+            builder.add_step(
+                source="system",
+                message=error,
+                extra={"grok_build_error": True},
+            )
+        if message is None and thought is None and not errors:
+            builder.add_step(
+                source="system",
+                message=f"grok-build: transcript at {transcript_file} contained no events",
+                extra={"reason": "empty_transcript"},
+            )
+
+    @classmethod
+    def _updates_metadata(
+        cls,
+        updates_file: Path,
+    ) -> tuple[dict[str, bool], dict[str, Any]]:
+        tool_errors: dict[str, bool] = {}
+        terminal: dict[str, Any] = {}
+        for event in cls._json_lines(updates_file):
+            params = event.get("params") or {}
+            update = params.get("update") or {}
+            update_type = update.get("sessionUpdate")
+            if update_type == "tool_call_update":
+                tool_call_id = update.get("toolCallId")
+                status = str(update.get("status") or "").lower()
+                if isinstance(tool_call_id, str) and status:
+                    tool_errors[tool_call_id] = status in {
+                        "failed",
+                        "error",
+                        "cancelled",
+                    }
+            elif update_type == "turn_completed":
+                terminal = {
+                    **update,
+                    "sessionId": params.get("sessionId"),
+                }
+        return tool_errors, terminal
+
+    @staticmethod
+    def _tool_arguments(raw: Any) -> dict[str, Any]:
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError:
+                return {"raw": raw}
+            if isinstance(decoded, dict):
+                return decoded
+            return {"value": decoded}
+        return {"value": raw}
+
+    @staticmethod
+    def _message_text(content: Any) -> str | None:
+        if isinstance(content, str):
+            return content.strip() or None
+        if not isinstance(content, list):
+            return None
+        parts = [
+            item.get("text", "")
+            for item in content
+            if isinstance(item, dict)
+            and item.get("type") in {"text", "output_text"}
+            and isinstance(item.get("text"), str)
+        ]
+        return "".join(parts).strip() or None
+
+    @classmethod
+    def _content_parts(cls, content: Any) -> list[ContentPart]:
+        if isinstance(content, list):
+            parts: list[ContentPart] = []
+            for item in content:
+                if not isinstance(item, dict):
+                    parts.append(ContentPart(type="text", text=str(item)))
+                    continue
+                item_type = item.get("type")
+                if item_type == "text":
+                    parts.extend(cls._content_parts(item.get("text", "")))
+                elif item_type == "image" and isinstance(item.get("data"), str):
+                    parts.append(
+                        ContentPart(
+                            type="image",
+                            image=ImageSource(
+                                type="base64",
+                                data=item["data"],
+                                media_type=str(item.get("mimeType") or "image/png"),
+                            ),
+                        )
+                    )
+            return parts
+        if not isinstance(content, str):
+            return [
+                ContentPart(
+                    type="text",
+                    text=json.dumps(content, ensure_ascii=False, default=str),
+                )
+            ]
+
+        parts = []
+        cursor = 0
+        for match in _DATA_URL_RE.finditer(content):
+            text = content[cursor : match.start()]
+            if text:
+                parts.append(ContentPart(type="text", text=text))
+            parts.append(
+                ContentPart(
+                    type="image",
+                    image=ImageSource(
+                        type="base64",
+                        data=match.group(2),
+                        media_type=match.group(1),
+                    ),
+                )
+            )
+            cursor = match.end()
+        tail = content[cursor:]
+        if tail:
+            parts.append(ContentPart(type="text", text=tail))
+        return parts or [ContentPart(type="text", text=content)]
+
+    @classmethod
+    def _apply_usage(
+        cls,
+        terminal_event: dict[str, Any],
+        builder: TrajectoryBuilder,
+    ) -> None:
+        usage = terminal_event.get("usage")
+        if not isinstance(usage, dict):
+            return
+        if "input_tokens" in usage:
+            input_tokens = usage.get("input_tokens")
+            cache_read_tokens = usage.get("cache_read_input_tokens")
+            output_tokens = usage.get("output_tokens")
+        else:
+            full_input = usage.get("inputTokens")
+            cache_read_tokens = usage.get("cachedReadTokens")
+            if isinstance(full_input, int) and isinstance(cache_read_tokens, int):
+                input_tokens = max(0, full_input - cache_read_tokens)
+            else:
+                input_tokens = full_input
+            output_tokens = usage.get("outputTokens")
+        builder.override_final_metrics(
+            total_input_tokens=input_tokens,
+            total_output_tokens=output_tokens,
+            total_cache_read_tokens=cache_read_tokens,
+            total_cost_usd=terminal_event.get("total_cost_usd"),
+        )
+
+    @staticmethod
+    def _find_session_dir(grok_home: Path, session_id: Any) -> Path | None:
+        sessions_root = grok_home / "sessions"
+        if isinstance(session_id, str) and session_id:
+            matches = [path for path in sessions_root.glob(f"**/{session_id}") if path.is_dir()]
+            if matches:
+                return max(matches, key=lambda path: path.stat().st_mtime)
+        summaries = [path for path in sessions_root.glob("**/summary.json") if path.is_file()]
+        if not summaries:
+            return None
+        return max(summaries, key=lambda path: path.stat().st_mtime).parent
+
+    @staticmethod
+    def _json_lines(path: Path):
+        try:
+            handle = path.open(encoding="utf-8", errors="replace")
+        except (FileNotFoundError, OSError):
+            return
+        with handle:
+            for line in handle:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict):
+                    yield event
+
+    @staticmethod
+    def _diagnose_failure(
+        *,
+        transcript_file: Path,
+        stderr_file: Path,
+        exit_code: int | None,
+    ) -> str:
+        transcript = (
+            transcript_file.read_text(encoding="utf-8", errors="replace")
+            if transcript_file.exists()
+            else ""
+        )
+        stderr = (
+            stderr_file.read_text(encoding="utf-8", errors="replace")
+            if stderr_file.exists()
+            else ""
+        )
+        parts = [
+            f"agent failed (rc={exit_code})",
+            f"stderr={len(stderr)}B transcript={len(transcript)}B",
+        ]
+        if '"http_status": 429' in transcript or "429" in stderr:
+            parts.append("LLM rate-limited")
+        if stderr.strip():
+            parts.append(f"stderr tail: ...{stderr[-800:]}")
+        if transcript.strip():
+            parts.append(f"transcript tail: ...{transcript[-800:]}")
+        return " | ".join(parts)

--- a/ale_run/agents/grok_build/otel.py
+++ b/ale_run/agents/grok_build/otel.py
@@ -1,0 +1,490 @@
+"""Run-local OTLP/HTTP protobuf receiver for Grok Build."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import json
+import os
+import threading
+import uuid
+from collections import Counter
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import DecodeError
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+    ExportLogsServiceResponse,
+)
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+    ExportMetricsServiceRequest,
+    ExportMetricsServiceResponse,
+)
+
+_RAW_CHUNK_BYTES = 512 * 1024
+_SIGNAL_BY_PATH = {
+    "/v1/logs": "logs",
+    "/v1/metrics": "metrics",
+}
+
+
+class GrokBuildOtelCollector:
+    """Receive Grok Build's external OTEL stream and persist complete batches."""
+
+    def __init__(self, work_dir: Path):
+        self.work_dir = work_dir
+        self.raw_path = work_dir / "otel_requests.jsonl"
+        self.events_path = work_dir / "telemetry.jsonl"
+        self.metrics_path = work_dir / "telemetry_metrics.jsonl"
+        self.summary_path = work_dir / "telemetry_summary.json"
+        self._lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def endpoint(self) -> str:
+        if self._server is None:
+            raise RuntimeError("Grok Build OTel collector has not been started")
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def start(self) -> None:
+        self.work_dir.mkdir(parents=True, exist_ok=True)
+        for path in (
+            self.raw_path,
+            self.events_path,
+            self.metrics_path,
+            self.summary_path,
+        ):
+            path.unlink(missing_ok=True)
+
+        collector = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                signal = _SIGNAL_BY_PATH.get(self.path)
+                if signal is None:
+                    self.send_error(404)
+                    return
+
+                body = self._read_body()
+                if self.headers.get("Content-Encoding", "").lower() == "gzip":
+                    try:
+                        body = gzip.decompress(body)
+                    except (OSError, EOFError):
+                        pass
+
+                collector._store_request(signal, dict(self.headers), body)
+                response = _response_body(signal)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/x-protobuf")
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+            def _read_body(self) -> bytes:
+                if "chunked" in self.headers.get("Transfer-Encoding", "").lower():
+                    return _read_chunked_body(self.rfile)
+                length = int(self.headers.get("Content-Length", "0"))
+                return self.rfile.read(length)
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="grok-build-otel-collector",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+        self._write_derived()
+
+    def _store_request(self, signal: str, headers: dict[str, str], body: bytes) -> None:
+        payload = _decode_payload(signal, body)
+        events = _flatten_otlp_logs(payload) if signal == "logs" else []
+        metrics = _flatten_otlp_metrics(payload) if signal == "metrics" else []
+        request_id = uuid.uuid4().hex
+        chunks = [
+            body[offset : offset + _RAW_CHUNK_BYTES]
+            for offset in range(0, len(body), _RAW_CHUNK_BYTES)
+        ] or [b""]
+        payload_sha256 = hashlib.sha256(body).hexdigest()
+
+        with self._lock:
+            with self.raw_path.open("a", encoding="utf-8") as file:
+                for index, chunk in enumerate(chunks):
+                    record: dict[str, Any] = {
+                        "record_type": "otlp_request_chunk",
+                        "signal": signal,
+                        "request_id": request_id,
+                        "chunk_index": index,
+                        "chunk_count": len(chunks),
+                        "payload_encoding": "base64",
+                        "payload": base64.b64encode(chunk).decode("ascii"),
+                    }
+                    if index == 0:
+                        record["headers"] = headers
+                        record["payload_bytes"] = len(body)
+                        record["payload_sha256"] = payload_sha256
+                    file.write(json.dumps(record, ensure_ascii=False) + "\n")
+                file.flush()
+                os.fsync(file.fileno())
+
+            _append_jsonl(self.events_path, events)
+            _append_jsonl(self.metrics_path, metrics)
+
+    def _write_derived(
+        self,
+        events: list[dict[str, Any]] | None = None,
+        metrics: list[dict[str, Any]] | None = None,
+    ) -> None:
+        events = _read_jsonl(self.events_path) if events is None else events
+        metrics = _read_jsonl(self.metrics_path) if metrics is None else metrics
+        events.sort(key=_event_sort_key)
+        names = Counter(
+            str(event.get("attributes", {}).get("event.name") or "unknown") for event in events
+        )
+        summary = {
+            "event_count": len(events),
+            "events_by_name": dict(sorted(names.items())),
+            "api_calls": _events_named(events, "grok_code.api_request"),
+            "api_errors": _events_named(events, "grok_code.api_error"),
+            "tool_executions": _events_named(events, "grok_code.tool_result"),
+            "tool_decisions": _events_named(events, "grok_code.tool_decision"),
+            "mcp_connections": _events_named(events, "grok_code.mcp_server_connection"),
+            "metric_totals": _summarize_metrics(metrics),
+            "artifacts": {
+                "raw_otlp_requests": self.raw_path.name,
+                "events": self.events_path.name,
+                "metrics": self.metrics_path.name,
+            },
+        }
+        self.summary_path.write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+def recover_otel_artifacts(work_dir: Path) -> int:
+    """Rebuild derived external-OTEL artifacts from the raw request WAL."""
+    raw_path = work_dir / "otel_requests.jsonl"
+    if not raw_path.exists():
+        return 0
+
+    events: list[dict[str, Any]] = []
+    metrics: list[dict[str, Any]] = []
+    for signal, payload in _read_otlp_payloads(raw_path):
+        if signal == "metrics":
+            metrics.extend(_flatten_otlp_metrics(payload))
+        else:
+            events.extend(_flatten_otlp_logs(payload))
+
+    events.sort(key=_event_sort_key)
+    _write_jsonl_atomic(work_dir / "telemetry.jsonl", events)
+    _write_jsonl_atomic(work_dir / "telemetry_metrics.jsonl", metrics)
+    GrokBuildOtelCollector(work_dir)._write_derived(events, metrics)
+    return len(events)
+
+
+def _response_body(signal: str) -> bytes:
+    if signal == "metrics":
+        return ExportMetricsServiceResponse().SerializeToString()
+    return ExportLogsServiceResponse().SerializeToString()
+
+
+def _decode_payload(signal: str, body: bytes) -> dict[str, Any]:
+    request = ExportMetricsServiceRequest() if signal == "metrics" else ExportLogsServiceRequest()
+    try:
+        request.ParseFromString(body)
+    except DecodeError:
+        return {}
+    return MessageToDict(request)
+
+
+def _read_chunked_body(rfile: Any) -> bytes:
+    body = bytearray()
+    while True:
+        size_line = rfile.readline()
+        if not size_line:
+            break
+        try:
+            size = int(size_line.split(b";", 1)[0].strip(), 16)
+        except ValueError:
+            break
+        if size == 0:
+            rfile.readline()
+            break
+        body += rfile.read(size)
+        rfile.readline()
+    return bytes(body)
+
+
+def _read_otlp_payloads(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
+    current_request_id: str | None = None
+    current_state: dict[str, Any] | None = None
+
+    for record in _iter_jsonl(path):
+        if record.get("record_type") != "otlp_request_chunk":
+            continue
+        request_id = record.get("request_id")
+        chunk_index = record.get("chunk_index")
+        chunk_count = record.get("chunk_count")
+        encoded = record.get("payload")
+        if (
+            not isinstance(request_id, str)
+            or not isinstance(chunk_index, int)
+            or not isinstance(chunk_count, int)
+            or chunk_count < 1
+            or not isinstance(encoded, str)
+        ):
+            continue
+
+        if request_id != current_request_id:
+            if current_state is not None:
+                decoded = _decode_chunked_payload(current_state)
+                if decoded is not None:
+                    yield decoded
+            current_request_id = request_id
+            current_state = {
+                "signal": str(record.get("signal") or "logs"),
+                "chunk_count": chunk_count,
+                "chunks": {},
+                "payload_sha256": record.get("payload_sha256"),
+            }
+
+        if current_state["chunk_count"] != chunk_count or not 0 <= chunk_index < chunk_count:
+            current_state["invalid"] = True
+            continue
+        try:
+            current_state["chunks"][chunk_index] = base64.b64decode(
+                encoded,
+                validate=True,
+            )
+        except (TypeError, ValueError):
+            current_state["invalid"] = True
+
+    if current_state is not None:
+        decoded = _decode_chunked_payload(current_state)
+        if decoded is not None:
+            yield decoded
+
+
+def _decode_chunked_payload(
+    state: dict[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    chunks = state["chunks"]
+    if state.get("invalid") or len(chunks) != state["chunk_count"]:
+        return None
+    body = b"".join(chunks[index] for index in range(state["chunk_count"]))
+    expected_sha256 = state.get("payload_sha256")
+    if expected_sha256 and hashlib.sha256(body).hexdigest() != expected_sha256:
+        return None
+    signal = str(state.get("signal") or "logs")
+    return signal, _decode_payload(signal, body)
+
+
+def _flatten_otlp_logs(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for resource_log in payload.get("resourceLogs", []):
+        resource = _attributes(resource_log.get("resource", {}).get("attributes", []))
+        for scope_log in resource_log.get("scopeLogs", []):
+            scope_data = scope_log.get("scope", {})
+            scope = {
+                "name": scope_data.get("name"),
+                "version": scope_data.get("version"),
+                "attributes": _attributes(scope_data.get("attributes", [])),
+            }
+            for record in scope_log.get("logRecords", []):
+                attributes = _attributes(record.get("attributes", []))
+                event_name = record.get("eventName")
+                if isinstance(event_name, str) and event_name:
+                    attributes.setdefault("event.name", event_name)
+                events.append(
+                    {
+                        "time_unix_nano": record.get("timeUnixNano"),
+                        "observed_time_unix_nano": record.get("observedTimeUnixNano"),
+                        "severity_number": record.get("severityNumber"),
+                        "severity_text": record.get("severityText"),
+                        "body": _any_value(record.get("body")),
+                        "attributes": attributes,
+                        "resource": resource,
+                        "scope": scope,
+                        "trace_id": record.get("traceId"),
+                        "span_id": record.get("spanId"),
+                        "flags": record.get("flags"),
+                    }
+                )
+    return events
+
+
+def _flatten_otlp_metrics(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    points: list[dict[str, Any]] = []
+    for resource_metric in payload.get("resourceMetrics", []):
+        resource = _attributes(resource_metric.get("resource", {}).get("attributes", []))
+        for scope_metric in resource_metric.get("scopeMetrics", []):
+            scope = scope_metric.get("scope", {})
+            for metric in scope_metric.get("metrics", []):
+                for kind in ("sum", "gauge", "histogram"):
+                    container = metric.get(kind)
+                    if not isinstance(container, dict):
+                        continue
+                    for point in container.get("dataPoints", []):
+                        points.append(
+                            {
+                                "name": metric.get("name"),
+                                "description": metric.get("description"),
+                                "unit": metric.get("unit"),
+                                "kind": kind,
+                                "value": _metric_value(point),
+                                "start_time_unix_nano": point.get("startTimeUnixNano"),
+                                "time_unix_nano": point.get("timeUnixNano"),
+                                "attributes": _attributes(point.get("attributes", [])),
+                                "resource": resource,
+                                "scope": {
+                                    "name": scope.get("name"),
+                                    "version": scope.get("version"),
+                                },
+                            }
+                        )
+    return points
+
+
+def _metric_value(point: dict[str, Any]) -> int | float | None:
+    for key in ("asInt", "asDouble", "sum", "count"):
+        value = point.get(key)
+        if isinstance(value, (int, float)):
+            return value
+        if isinstance(value, str):
+            try:
+                return float(value) if "." in value else int(value)
+            except ValueError:
+                return None
+    return None
+
+
+def _attributes(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        str(item["key"]): _any_value(item.get("value"))
+        for item in items
+        if isinstance(item, dict) and item.get("key")
+    }
+
+
+def _any_value(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "boolValue" in value:
+        return value["boolValue"]
+    if "intValue" in value:
+        try:
+            return int(value["intValue"])
+        except (TypeError, ValueError):
+            return value["intValue"]
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    if "bytesValue" in value:
+        return value["bytesValue"]
+    if "arrayValue" in value:
+        return [_any_value(item) for item in value["arrayValue"].get("values", [])]
+    if "kvlistValue" in value:
+        return _attributes(value["kvlistValue"].get("values", []))
+    return value
+
+
+def _events_named(
+    events: list[dict[str, Any]],
+    event_name: str,
+) -> list[dict[str, Any]]:
+    return [
+        event.get("attributes", {})
+        for event in events
+        if event.get("attributes", {}).get("event.name") == event_name
+    ]
+
+
+def _summarize_metrics(metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    totals: dict[str, float] = {}
+    token_usage: dict[str, float] = {}
+    for point in metrics:
+        name = point.get("name")
+        value = point.get("value")
+        if not isinstance(name, str) or not isinstance(value, (int, float)):
+            continue
+        totals[name] = totals.get(name, 0.0) + value
+        if name == "grok_code.token.usage":
+            token_type = str(point.get("attributes", {}).get("type") or "unknown")
+            token_usage[token_type] = token_usage.get(token_type, 0.0) + value
+    return {
+        "by_metric": {name: _clean_number(value) for name, value in sorted(totals.items())},
+        "tokens_by_type": {
+            name: _clean_number(value) for name, value in sorted(token_usage.items())
+        },
+    }
+
+
+def _clean_number(value: float) -> int | float:
+    return int(value) if value.is_integer() else value
+
+
+def _event_sort_key(event: dict[str, Any]) -> tuple[int, str]:
+    sequence = event.get("attributes", {}).get("event.sequence")
+    return (
+        sequence if isinstance(sequence, int) else 2**63 - 1,
+        str(event.get("time_unix_nano") or event.get("observed_time_unix_nano") or ""),
+    )
+
+
+def _append_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    if not records:
+        return
+    with path.open("a", encoding="utf-8") as file:
+        for record in records:
+            file.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return list(_iter_jsonl(path))
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8", errors="replace") as file:
+        for line in file:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                yield record
+
+
+def _write_jsonl_atomic(path: Path, records: list[dict[str, Any]]) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as file:
+            for record in records:
+                file.write(json.dumps(record, ensure_ascii=False) + "\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/ale_run/agents/grok_build/pyproject.toml
+++ b/ale_run/agents/grok_build/pyproject.toml
@@ -3,7 +3,9 @@ name = "ale-grok-build"
 version = "0.1.0"
 description = "xAI Grok Build in-sandbox deployer for ALE."
 requires-python = ">=3.12,<3.14"
-dependencies = []
+dependencies = [
+    "opentelemetry-proto==1.44.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/ale_run/agents/grok_build/pyproject.toml
+++ b/ale_run/agents/grok_build/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "ale-grok-build"
+version = "0.1.0"
+description = "xAI Grok Build in-sandbox deployer for ALE."
+requires-python = ">=3.12,<3.14"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = []
+sources = {}
+bypass-selection = true

--- a/ale_run/agents/grok_build/telemetry.py
+++ b/ale_run/agents/grok_build/telemetry.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 
-def recover_telemetry_artifacts(
+def recover_native_telemetry_artifacts(
     work_dir: Path,
     *,
     events_file: Path | None,
@@ -24,7 +24,7 @@ def recover_telemetry_artifacts(
     """
     events = list(_json_lines(events_file))
     updates = list(_json_lines(updates_file))
-    _write_jsonl_atomic(work_dir / "telemetry.jsonl", events)
+    _write_jsonl_atomic(work_dir / "native_telemetry.jsonl", events)
 
     terminal = terminal_event or {}
     usage, session_id = _terminal_usage(updates, terminal)
@@ -45,10 +45,10 @@ def recover_telemetry_artifacts(
         "artifacts": {
             "events": str(events_file) if events_file else None,
             "updates": str(updates_file) if updates_file else None,
-            "normalized_events": "telemetry.jsonl",
+            "normalized_events": "native_telemetry.jsonl",
         },
     }
-    (work_dir / "telemetry_summary.json").write_text(
+    (work_dir / "native_telemetry_summary.json").write_text(
         json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )

--- a/ale_run/agents/grok_build/telemetry.py
+++ b/ale_run/agents/grok_build/telemetry.py
@@ -1,0 +1,266 @@
+"""Normalize Grok Build's native session telemetry into ALE artifacts."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def recover_telemetry_artifacts(
+    work_dir: Path,
+    *,
+    events_file: Path | None,
+    updates_file: Path | None,
+    terminal_event: dict[str, Any] | None = None,
+) -> int:
+    """Write normalized events and a compact run summary.
+
+    Grok Build already records first-token, tool, MCP, and aggregate API timing
+    events, so no injected HTTP instrumentation is needed.
+    """
+    events = list(_json_lines(events_file))
+    updates = list(_json_lines(updates_file))
+    _write_jsonl_atomic(work_dir / "telemetry.jsonl", events)
+
+    terminal = terminal_event or {}
+    usage, session_id = _terminal_usage(updates, terminal)
+    normalized_usage = _normalize_usage(usage)
+    if normalized_usage.get("model_usage") is None:
+        normalized_usage["model_usage"] = terminal.get("modelUsage")
+    summary = {
+        "event_count": len(events),
+        "events_by_type": dict(Counter(str(event.get("type") or "unknown") for event in events)),
+        "session_id": session_id,
+        "request_id": _string_or_none(terminal.get("requestId")),
+        "stop_reason": terminal.get("stopReason"),
+        "num_turns": terminal.get("num_turns"),
+        "total_cost_usd": terminal.get("total_cost_usd"),
+        "llm_calls": _summarize_llm_calls(events),
+        "usage": normalized_usage,
+        "tool_executions": _summarize_tools(events),
+        "artifacts": {
+            "events": str(events_file) if events_file else None,
+            "updates": str(updates_file) if updates_file else None,
+            "normalized_events": "telemetry.jsonl",
+        },
+    }
+    (work_dir / "telemetry_summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return len(events)
+
+
+def _summarize_llm_calls(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    active: dict[str, Any] | None = None
+    model: str | None = None
+    for event in events:
+        event_type = event.get("type")
+        if event_type == "turn_started":
+            model = _string_or_none(event.get("model_id"))
+            continue
+        if event_type == "loop_started":
+            if active is not None:
+                _finish_call(active, event.get("ts"))
+                calls.append(active)
+            active = {
+                "sequence": len(calls) + 1,
+                "loop_index": event.get("loop_index"),
+                "model": model,
+                "started_at": event.get("ts"),
+                "first_token_at": None,
+                "completed_at": None,
+            }
+            continue
+        if active is None:
+            continue
+        if event_type == "first_token" and active["first_token_at"] is None:
+            active["first_token_at"] = event.get("ts")
+        elif event_type in {"tool_started", "turn_ended"}:
+            _finish_call(active, event.get("ts"))
+            calls.append(active)
+            active = None
+    if active is not None:
+        _finish_call(active, None)
+        calls.append(active)
+    return calls
+
+
+def _finish_call(call: dict[str, Any], completed_at: Any) -> None:
+    call["completed_at"] = completed_at
+    started_ms = _timestamp_ms(call.get("started_at"))
+    first_ms = _timestamp_ms(call.get("first_token_at"))
+    completed_ms = _timestamp_ms(completed_at)
+    call["first_token_ms"] = (
+        round(first_ms - started_ms, 3) if first_ms is not None and started_ms is not None else None
+    )
+    call["stream_duration_ms"] = (
+        round(completed_ms - first_ms, 3)
+        if completed_ms is not None and first_ms is not None
+        else None
+    )
+    call["duration_ms"] = (
+        round(completed_ms - started_ms, 3)
+        if completed_ms is not None and started_ms is not None
+        else None
+    )
+
+
+def _summarize_tools(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    executions: list[dict[str, Any]] = []
+    native: list[dict[str, Any]] = []
+    mcp: list[dict[str, Any]] = []
+    for event in events:
+        event_type = event.get("type")
+        if event_type == "tool_started":
+            native.append(
+                {
+                    "kind": "native",
+                    "tool_name": event.get("tool_name"),
+                    "started_at": event.get("ts"),
+                }
+            )
+        elif event_type == "tool_completed":
+            tool = _pop_matching(native, "tool_name", event.get("tool_name"))
+            tool.update(
+                completed_at=event.get("ts"),
+                duration_ms=event.get("duration_ms"),
+                success=event.get("outcome") == "success",
+                outcome=event.get("outcome"),
+            )
+            executions.append(tool)
+        elif event_type == "mcp_tool_call_started":
+            mcp.append(
+                {
+                    "kind": "mcp",
+                    "server_name": event.get("server_name"),
+                    "tool_name": _mcp_tool_name(event),
+                    "call_id": event.get("call_id"),
+                    "started_at": event.get("ts"),
+                }
+            )
+        elif event_type == "mcp_tool_call_completed":
+            tool = _pop_matching(mcp, "tool_name", _mcp_tool_name(event))
+            tool.update(
+                completed_at=event.get("ts"),
+                duration_ms=event.get("duration_ms"),
+                success=bool(event.get("success")),
+                is_timeout=bool(event.get("is_timeout")),
+                reconnect_attempted=bool(event.get("reconnect_attempted")),
+                auth_retry_attempted=bool(event.get("auth_retry_attempted")),
+            )
+            executions.append(tool)
+    for sequence, execution in enumerate(executions, 1):
+        execution["sequence"] = sequence
+    return executions
+
+
+def _pop_matching(
+    active: list[dict[str, Any]],
+    key: str,
+    value: Any,
+) -> dict[str, Any]:
+    for index in range(len(active) - 1, -1, -1):
+        if active[index].get(key) == value:
+            return active.pop(index)
+    return {key: value, "started_at": None}
+
+
+def _mcp_tool_name(event: dict[str, Any]) -> str:
+    server = str(event.get("server_name") or "")
+    tool = str(event.get("tool_name") or event.get("call_id") or "")
+    return f"{server}__{tool}" if server and not tool.startswith(f"{server}__") else tool
+
+
+def _terminal_usage(
+    updates: list[dict[str, Any]],
+    terminal_event: dict[str, Any],
+) -> tuple[dict[str, Any], str | None]:
+    for event in reversed(updates):
+        params = event.get("params") or {}
+        update = params.get("update") or {}
+        if update.get("sessionUpdate") == "turn_completed":
+            usage = update.get("usage")
+            return (
+                usage if isinstance(usage, dict) else {},
+                _string_or_none(params.get("sessionId")),
+            )
+    usage = terminal_event.get("usage")
+    return (
+        usage if isinstance(usage, dict) else {},
+        _string_or_none(terminal_event.get("sessionId")),
+    )
+
+
+def _normalize_usage(usage: dict[str, Any]) -> dict[str, Any]:
+    if "input_tokens" in usage:
+        return {
+            "input_tokens": usage.get("input_tokens"),
+            "cache_read_tokens": usage.get("cache_read_input_tokens"),
+            "output_tokens": usage.get("output_tokens"),
+            "reasoning_tokens": usage.get("reasoning_tokens"),
+            "total_tokens": usage.get("total_tokens"),
+            "model_calls": usage.get("model_calls"),
+            "api_duration_ms": usage.get("api_duration_ms"),
+            "model_usage": usage.get("modelUsage"),
+        }
+    full_input = usage.get("inputTokens")
+    cache_read = usage.get("cachedReadTokens")
+    input_tokens = (
+        max(0, full_input - cache_read)
+        if isinstance(full_input, int) and isinstance(cache_read, int)
+        else full_input
+    )
+    return {
+        "input_tokens": input_tokens,
+        "cache_read_tokens": cache_read,
+        "output_tokens": usage.get("outputTokens"),
+        "reasoning_tokens": usage.get("reasoningTokens"),
+        "total_tokens": usage.get("totalTokens"),
+        "model_calls": usage.get("modelCalls"),
+        "api_duration_ms": usage.get("apiDurationMs"),
+        "model_usage": usage.get("modelUsage"),
+    }
+
+
+def _timestamp_ms(value: Any) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).timestamp() * 1000
+    except ValueError:
+        return None
+
+
+def _string_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _json_lines(path: Path | None) -> Iterator[dict[str, Any]]:
+    if path is None:
+        return
+    try:
+        handle = path.open(encoding="utf-8", errors="replace")
+    except (FileNotFoundError, OSError):
+        return
+    with handle:
+        for line in handle:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                yield event
+
+
+def _write_jsonl_atomic(path: Path, records: list[dict[str, Any]]) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    temporary.replace(path)

--- a/ale_run/executors/_docker_entry.py
+++ b/ale_run/executors/_docker_entry.py
@@ -38,8 +38,12 @@ async def _run() -> dict:
     # mount and delete it immediately so it never persists in the host
     # log dir (work_dir is bind-mounted = host log dir for docker runs).
     # Fall back to a legacy in-spec env if present (older host writers).
-    from ale_run.executors._secrets import read_and_delete_secrets
+    from ale_run.executors._secrets import (
+        read_and_delete_secrets,
+        restore_config_secrets,
+    )
     env = read_and_delete_secrets(SPEC_PATH.parent) or (spec.get("env") or {})
+    config_kwargs, env = restore_config_secrets(spec["config_kwargs"], env)
     for k, v in env.items():
         os.environ[str(k)] = str(v)
 
@@ -62,7 +66,7 @@ async def _run() -> dict:
     cfg_cls = getattr(cfg_mod, spec["config_class"])
     dep_cls = getattr(dep_mod, spec["deployer_class"])
 
-    cfg = cfg_cls(**spec["config_kwargs"])
+    cfg = cfg_cls(**config_kwargs)
     sandbox = SandboxHandle(**spec["sandbox_kwargs"])
     executor = LocalExecutor(
         config=cfg,

--- a/ale_run/executors/_sandbox_entry.py
+++ b/ale_run/executors/_sandbox_entry.py
@@ -49,6 +49,8 @@ def run(spec: dict, env: dict | None = None) -> dict:
     # compatibility, but the writer no longer puts secrets in the spec.
     if env is None:
         env = spec.get("env") or {}
+    from ale_run.executors._secrets import restore_config_secrets
+    config_kwargs, env = restore_config_secrets(spec["config_kwargs"], env)
     for k, v in env.items():
         os.environ[str(k)] = str(v)
 
@@ -66,7 +68,7 @@ def run(spec: dict, env: dict | None = None) -> dict:
         cfg_cls = getattr(cfg_mod, spec["config_class"])
         dep_cls = getattr(dep_mod, spec["deployer_class"])
 
-        cfg = cfg_cls(**spec["config_kwargs"])
+        cfg = cfg_cls(**config_kwargs)
         sandbox = SandboxHandle(**spec["sandbox_kwargs"])
         # We are running INSIDE the sandbox: cua-server is co-located on
         # loopback at the image's declared port. The handle's ``endpoint`` was

--- a/ale_run/executors/_secrets.py
+++ b/ale_run/executors/_secrets.py
@@ -11,12 +11,15 @@ process environment, then deletes immediately. The gather step also
 excludes this filename by name as defense-in-depth, so even a racing
 or failed delete cannot leak it to host logs.
 """
+
 from __future__ import annotations
 
 import json
 import os
 import stat
+from dataclasses import fields
 from pathlib import Path
+from typing import Any
 
 # Basename of the transient secrets sidecar. Lives next to ``_spec.json``
 # in the deployer work_dir; read-once, then deleted by the entry.
@@ -25,6 +28,56 @@ SECRETS_FILE = "_secrets.json"
 # Control files that carry secrets and must never reach host logs. The
 # gather paths exclude these by basename as a belt-and-suspenders guard.
 SECRET_GATHER_EXCLUDES = frozenset({SECRETS_FILE, "_env"})
+
+# Config values resolved from `${env:...}` are ordinary dataclass fields by the
+# time an executor sees them. Keep those values in the same read-once sidecar
+# as process env instead of serializing them into the gathered `_spec.json`.
+_CONFIG_SECRET_PREFIX = "_ALE_CONFIG_SECRET_"
+
+
+def _is_config_secret_field(name: str, metadata: Any) -> bool:
+    return bool(metadata.get("secret")) or name == "api_key" or name.endswith("_api_key")
+
+
+def config_to_kwargs_and_secrets(
+    config: Any,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Serialize a dataclass config while extracting secret-valued fields."""
+    kwargs: dict[str, Any] = {}
+    secrets: dict[str, str] = {}
+    for config_field in fields(config):
+        value = getattr(config, config_field.name)
+        if not isinstance(
+            value,
+            (str, int, float, bool, type(None), list, dict, tuple),
+        ):
+            continue
+        if (
+            isinstance(value, str)
+            and value
+            and _is_config_secret_field(config_field.name, config_field.metadata)
+        ):
+            secret_name = f"{_CONFIG_SECRET_PREFIX}{config_field.name.upper()}"
+            kwargs[config_field.name] = None
+            secrets[secret_name] = value
+        else:
+            kwargs[config_field.name] = value
+    return kwargs, secrets
+
+
+def restore_config_secrets(
+    config_kwargs: dict[str, Any],
+    env: dict[str, str],
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Restore extracted config fields and remove private sidecar keys."""
+    restored = dict(config_kwargs)
+    clean_env = dict(env)
+    for key in tuple(clean_env):
+        if not key.startswith(_CONFIG_SECRET_PREFIX):
+            continue
+        field_name = key.removeprefix(_CONFIG_SECRET_PREFIX).lower()
+        restored[field_name] = clean_env.pop(key)
+    return restored, clean_env
 
 
 def write_secrets(work_dir: Path, env: dict[str, str]) -> Path:

--- a/ale_run/executors/docker.py
+++ b/ale_run/executors/docker.py
@@ -46,7 +46,12 @@ from ..base_interface import (
     RangeResult,
     SandboxHandle,
 )
-from ._secrets import SECRET_GATHER_EXCLUDES, SECRETS_FILE, write_secrets
+from ._secrets import (
+    SECRET_GATHER_EXCLUDES,
+    SECRETS_FILE,
+    config_to_kwargs_and_secrets,
+    write_secrets,
+)
 
 if TYPE_CHECKING:
     from ..base_interface import AgentRunResult, BaseAgentDeployer
@@ -124,13 +129,14 @@ class DockerExecutor(BaseExecutor):
         #    work_dir IS the host log dir for docker runs, so _spec.json is a
         #    host log file and must stay keyless. The env goes in a separate
         #    _secrets.json that the entry reads once and deletes.
+        config_kwargs, config_secrets = config_to_kwargs_and_secrets(self.config)
         spec = {
             "ale_src_root": "/ale_src",  # container view
             "deployer_module": deployer_cls.__module__,
             "deployer_class": deployer_cls.__name__,
             "config_module": self.config.__class__.__module__,
             "config_class": self.config.__class__.__name__,
-            "config_kwargs": _config_to_kwargs(self.config),
+            "config_kwargs": config_kwargs,
             "sandbox_kwargs": _sandbox_to_kwargs(self.sandbox),
             "work_dir": "/work",
             "secrets_file": SECRETS_FILE,
@@ -142,7 +148,10 @@ class DockerExecutor(BaseExecutor):
         # 1b. Write the read-once secrets sidecar into the bind mount. The
         #     in-container entry reads it then deletes it, so it does not
         #     persist in the host log dir. chmod 600 while it lives.
-        write_secrets(host_work, dict(self.env or {}))
+        write_secrets(
+            host_work,
+            {**dict(self.env or {}), **config_secrets},
+        )
 
         # 2. Write env-file (keeps api keys off cmdline + docker inspect).
         #    Lives in a private tempdir OUTSIDE the bind-mounted work_dir so
@@ -359,17 +368,6 @@ def _image_present(tag: str) -> bool:
         return r.returncode == 0
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
-
-
-def _config_to_kwargs(cfg) -> dict:
-    import dataclasses
-
-    out = {}
-    for f in dataclasses.fields(cfg):
-        val = getattr(cfg, f.name)
-        if isinstance(val, (str, int, float, bool, type(None), list, dict, tuple)):
-            out[f.name] = val
-    return out
 
 
 def _sandbox_to_kwargs(sb: SandboxHandle) -> dict:

--- a/ale_run/executors/sandbox.py
+++ b/ale_run/executors/sandbox.py
@@ -43,7 +43,11 @@ from ..base_interface import (
     RangeResult,
     SandboxHandle,
 )
-from ._secrets import SECRET_GATHER_EXCLUDES, SECRETS_FILE
+from ._secrets import (
+    SECRET_GATHER_EXCLUDES,
+    SECRETS_FILE,
+    config_to_kwargs_and_secrets,
+)
 
 if TYPE_CHECKING:
     from ..base_interface import AgentRunResult, BaseAgentDeployer
@@ -168,12 +172,13 @@ class SandboxExecutor(BaseExecutor):
         #    _spec.json is gathered back to host .logs and must stay keyless.
         #    The env goes in a separate _secrets.json that the entry reads
         #    once and deletes (see _secrets.py).
+        config_kwargs, config_secrets = config_to_kwargs_and_secrets(self.config)
         spec = {
             "deployer_module": deployer_cls.__module__,
             "deployer_class": deployer_cls.__name__,
             "config_module": self.config.__class__.__module__,
             "config_class": self.config.__class__.__name__,
-            "config_kwargs": _config_to_kwargs(self.config),
+            "config_kwargs": config_kwargs,
             "sandbox_kwargs": _sandbox_to_kwargs(self.sandbox),
             "work_dir": self.work_dir,
             "secrets_file": SECRETS_FILE,
@@ -184,7 +189,10 @@ class SandboxExecutor(BaseExecutor):
 
         # 4b. Write the transient secrets sidecar (read-once + self-deleted
         #     by the entry). Never gathered to host logs.
-        await sb.write_file(secrets_path, json.dumps(dict(self.env or {})))
+        await sb.write_file(
+            secrets_path,
+            json.dumps({**dict(self.env or {}), **config_secrets}),
+        )
 
         # 5. Write launcher script + fire it (short RPC: returns in seconds)
         launcher_body = _build_launcher(
@@ -830,17 +838,6 @@ def _local_offset(dst: Path) -> int:
 def _host_ale_root() -> Path:
     """Host's ``ale_run/`` package root."""
     return Path(__file__).resolve().parents[1]
-
-
-def _config_to_kwargs(cfg: Any) -> dict[str, Any]:
-    import dataclasses
-
-    out: dict[str, Any] = {}
-    for f in dataclasses.fields(cfg):
-        val = getattr(cfg, f.name)
-        if isinstance(val, (str, int, float, bool, type(None), list, dict, tuple)):
-            out[f.name] = val
-    return out
 
 
 def _sandbox_to_kwargs(sb: SandboxHandle) -> dict[str, Any]:

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -33,6 +33,7 @@ _AGENT_FQNS: dict[str, str] = {
     "kimi_code": "ale_run.agents.kimi_code.deployer.KimiCodeDeployer",
     "ale_claw": "ale_run.agents.ale_claw.deployer.AleClawDeployer",
     "gemini_cli": "ale_run.agents.gemini_cli.deployer.GeminiCliDeployer",
+    "grok_build": "ale_run.agents.grok_build.deployer.GrokBuildDeployer",
     "grok_cli": "ale_run.agents.grok_cli.deployer.GrokCliDeployer",
     "cursor_cli": "ale_run.agents.cursor_cli.deployer.CursorCliDeployer",
     "droid": "ale_run.agents.droid.deployer.DroidDeployer",

--- a/ale_run/orchestration/lifecycle.py
+++ b/ale_run/orchestration/lifecycle.py
@@ -749,6 +749,7 @@ def _collect_env_passthrough() -> dict[str, str]:
         "CURSOR_API_KEY",
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",
+        "XAI_API_KEY",
         "GROK_API_KEY",
         "MOONSHOT_API_KEY",
         "FACTORY_API_KEY",

--- a/configs/agents/grok_build.yaml
+++ b/configs/agents/grok_build.yaml
@@ -1,0 +1,37 @@
+# xAI Grok Build using the official built-in model catalog.
+# Auth: export XAI_API_KEY before launching the experiment.
+
+harness: grok_build
+model: grok-4.5
+
+config:
+  api_key_env: XAI_API_KEY
+  base_url: null
+  # For a custom endpoint, set base_url plus one of:
+  # chat_completions | responses | messages. The resolved key remains process-only.
+  api_backend: responses
+
+  # Grok Build runs headlessly inside ALE's already-isolated VM.
+  always_approve: true
+  disable_auto_update: true
+  sandbox_profile: "off"
+
+  # Optional model/runtime controls.
+  context_window: null
+  max_completion_tokens: null
+  reasoning_effort: null
+  max_turns: null
+  disable_web_search: false
+  # exit_plan_mode requires an interactive approval client.
+  plan_mode: false
+  disabled_tools:
+    - ask_user_question
+    - enter_plan_mode
+    - exit_plan_mode
+
+  # CUA MCP startup and per-tool deadlines.
+  mcp_startup_timeout_s: 60
+  mcp_tool_timeout_s: 6000
+
+  # Official package, pinned for reproducible sandbox installs.
+  cli_version: "@xai-official/grok@0.2.112"

--- a/configs/agents/grok_build.yaml
+++ b/configs/agents/grok_build.yaml
@@ -6,29 +6,23 @@ model: grok-4.5
 
 config:
   api_key_env: XAI_API_KEY
-  base_url: null
-  # For a custom endpoint, set base_url plus one of:
-  # chat_completions | responses | messages. The resolved key remains process-only.
-  api_backend: responses
 
-  # Grok Build runs headlessly inside ALE's already-isolated VM.
-  always_approve: true
-  disable_auto_update: true
-  disable_web_search: false
+  # Optional custom endpoint. Omit these fields for direct xAI catalog routing.
+  # The resolved key remains process-only.
+  # base_url: https://api.example.com/v1
+  # api_backend: responses  # responses | chat_completions | messages
 
-  # The harness always uses `--sandbox off` and `--no-plan`, and always removes
-  # ask_user_question / enter_plan_mode / exit_plan_mode. Add other tool names
-  # here only when an experiment needs further restrictions.
+  # ALE invariants are not configurable: the harness always auto-approves,
+  # disables CLI updates, uses `--sandbox off` and `--no-plan`, and removes
+  # ask_user_question / enter_plan_mode / exit_plan_mode.
+  # Web search/fetch remain available by default. Add tool names only when an
+  # experiment needs further restrictions.
   # disabled_tools:
   #   - image_gen
 
   # Optional custom-endpoint metadata. Omitted values are not written to TOML.
   # context_window: 262144
   # max_completion_tokens: 32768
-
-  # CUA MCP startup and per-tool deadlines.
-  mcp_startup_timeout_s: 60
-  mcp_tool_timeout_s: 6000
 
   # Official package, pinned for reproducible sandbox installs.
   cli_version: "@xai-official/grok@0.2.112"

--- a/configs/agents/grok_build.yaml
+++ b/configs/agents/grok_build.yaml
@@ -7,10 +7,28 @@ model: grok-4.5
 config:
   api_key_env: XAI_API_KEY
 
-  # Optional custom endpoint. Omit these fields for direct xAI catalog routing.
+  # Optional custom endpoint. Omit both fields for direct xAI catalog routing.
+  # All three values below are natively supported by Grok Build. Choose whichever
+  # protocol base_url exposes; base_url must be its API root, so Grok can call
+  # <base_url>/responses, /chat/completions, or /messages.
   # The resolved key remains process-only.
   # base_url: https://api.example.com/v1
-  # api_backend: responses  # responses | chat_completions | messages
+  # api_backend: responses
+  # Supported values:
+  #   responses        -> OpenAI Responses API
+  #   chat_completions -> OpenAI Chat Completions API
+  #   messages         -> Anthropic Messages API
+
+  # Explicitly pin reasoning depth instead of relying on CLI/model defaults.
+  # Grok Build accepts none|minimal|low|medium|high|xhigh|max or a model-specific
+  # menu id; the selected model/endpoint must support the chosen value.
+  # The built-in grok-4.5 catalog supports high|medium|low and defaults to high.
+  reasoning_effort: high
+
+  # Capture Grok Build's native external OpenTelemetry stream in the run dir.
+  # SpaceXAI product analytics and trace upload remain disabled; prompt text,
+  # code paths, and tool parameters are not enabled in the external OTEL stream.
+  otel_enabled: true
 
   # ALE invariants are not configurable: the harness always auto-approves,
   # disables CLI updates, uses `--sandbox off` and `--no-plan`, and removes

--- a/configs/agents/grok_build.yaml
+++ b/configs/agents/grok_build.yaml
@@ -14,20 +14,17 @@ config:
   # Grok Build runs headlessly inside ALE's already-isolated VM.
   always_approve: true
   disable_auto_update: true
-  sandbox_profile: "off"
-
-  # Optional model/runtime controls.
-  context_window: null
-  max_completion_tokens: null
-  reasoning_effort: null
-  max_turns: null
   disable_web_search: false
-  # exit_plan_mode requires an interactive approval client.
-  plan_mode: false
-  disabled_tools:
-    - ask_user_question
-    - enter_plan_mode
-    - exit_plan_mode
+
+  # The harness always uses `--sandbox off` and `--no-plan`, and always removes
+  # ask_user_question / enter_plan_mode / exit_plan_mode. Add other tool names
+  # here only when an experiment needs further restrictions.
+  # disabled_tools:
+  #   - image_gen
+
+  # Optional custom-endpoint metadata. Omitted values are not written to TOML.
+  # context_window: 262144
+  # max_completion_tokens: 32768
 
   # CUA MCP startup and per-tool deadlines.
   mcp_startup_timeout_s: 60

--- a/secret/.env.example
+++ b/secret/.env.example
@@ -16,6 +16,7 @@
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
 OPENAI_API_KEY=
+XAI_API_KEY=
 MOONSHOT_API_KEY=
 
 # Optional — only needed if you re-enable ale_claw's `web_search` tool.

--- a/tests/ale_run/test_baked_in_sandbox.py
+++ b/tests/ale_run/test_baked_in_sandbox.py
@@ -127,6 +127,7 @@ def test_reference_password_is_not_forwarded_to_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "agent-key")
+    monkeypatch.setenv("XAI_API_KEY", "xai-key")
     monkeypatch.setenv("MOONSHOT_API_KEY", "moonshot-key")
     monkeypatch.setenv(
         baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV,
@@ -136,6 +137,7 @@ def test_reference_password_is_not_forwarded_to_agent(
     env = _collect_env_passthrough()
 
     assert env["OPENAI_API_KEY"] == "agent-key"
+    assert env["XAI_API_KEY"] == "xai-key"
     assert env["MOONSHOT_API_KEY"] == "moonshot-key"
     assert baked_in_sandbox.REFERENCE_ARCHIVE_PASSWORD_ENV not in env
 

--- a/tests/ale_run/test_executor_secrets.py
+++ b/tests/ale_run/test_executor_secrets.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ale_run.executors._secrets import (
+    config_to_kwargs_and_secrets,
+    restore_config_secrets,
+)
+
+
+@dataclass
+class _Config:
+    model: str = "model"
+    api_key: str | None = "primary-secret"
+    vision_api_key: str | None = "vision-secret"
+    api_key_env: str = "MODEL_API_KEY"
+    access_token: str = "ordinary-value"
+    custom_credential: str = field(
+        default="metadata-secret",
+        metadata={"secret": True},
+    )
+
+
+def test_config_secrets_are_kept_out_of_serialized_kwargs() -> None:
+    kwargs, secrets = config_to_kwargs_and_secrets(_Config())
+
+    assert kwargs == {
+        "model": "model",
+        "api_key": None,
+        "vision_api_key": None,
+        "api_key_env": "MODEL_API_KEY",
+        "access_token": "ordinary-value",
+        "custom_credential": None,
+    }
+    assert set(secrets.values()) == {
+        "primary-secret",
+        "vision-secret",
+        "metadata-secret",
+    }
+    assert all(secret not in repr(kwargs) for secret in secrets.values())
+
+
+def test_config_secrets_round_trip_without_polluting_executor_env() -> None:
+    kwargs, secrets = config_to_kwargs_and_secrets(_Config())
+    restored, clean_env = restore_config_secrets(
+        kwargs,
+        {"OPENAI_API_KEY": "env-secret", **secrets},
+    )
+
+    assert restored["api_key"] == "primary-secret"
+    assert restored["vision_api_key"] == "vision-secret"
+    assert restored["custom_credential"] == "metadata-secret"
+    assert clean_env == {"OPENAI_API_KEY": "env-secret"}

--- a/tests/ale_run/test_grok_build.py
+++ b/tests/ale_run/test_grok_build.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+from ale_run.agents.grok_build.config import GrokBuildConfig
+from ale_run.agents.grok_build.deployer import (
+    GrokBuildDeployer,
+    _expected_version,
+    _grok_cwd,
+)
+from ale_run.base_interface import AgentRunResult, TrajectoryBuilder
+from ale_run.orchestration.factory import AGENT_REGISTRY
+
+
+def _executor(
+    tmp_path: Path,
+    config: GrokBuildConfig,
+    *,
+    is_linux: bool = True,
+) -> SimpleNamespace:
+    sandbox = SimpleNamespace(
+        is_linux=is_linux,
+        mcp_server_dir="/opt/cua_mcp_server",
+    )
+    return SimpleNamespace(
+        config=config,
+        env={config.api_key_env: "test-key"},
+        work_dir=str(tmp_path),
+        sandbox=sandbox,
+        cua_bridge_url=lambda: "http://127.0.0.1:5000",
+    )
+
+
+def _builder() -> TrajectoryBuilder:
+    return TrajectoryBuilder(
+        agent_name="grok-build",
+        model="grok-4.5",
+        task_path="demo/seecheck",
+        variant_index=0,
+    )
+
+
+def test_grok_build_is_registered() -> None:
+    assert AGENT_REGISTRY["grok_build"] is GrokBuildDeployer
+
+
+def test_expected_version_parses_scoped_npm_spec() -> None:
+    assert _expected_version("@xai-official/grok@0.2.112") == "0.2.112"
+    assert _expected_version("@xai-official/grok") is None
+
+
+def test_headless_plan_mode_is_disabled_by_default() -> None:
+    assert GrokBuildConfig().plan_mode is False
+
+
+def test_default_model_matches_official_cli_catalog() -> None:
+    assert GrokBuildConfig().model == "grok-4.5"
+
+
+def test_primary_session_exports_are_hot_artifacts() -> None:
+    assert {
+        "session_chat_history.jsonl",
+        "session_updates.jsonl",
+        "session_events.jsonl",
+        "session_summary.json",
+        "session_media.jsonl",
+    }.issubset(GrokBuildDeployer.hot_artifacts)
+
+
+def test_build_env_isolates_home_and_keeps_custom_key_ephemeral(tmp_path: Path) -> None:
+    config = GrokBuildConfig(
+        model="kimi-k2.5",
+        api_key_env="MOONSHOT_API_KEY",
+        base_url="https://api.moonshot.ai/v1",
+        api_backend="chat_completions",
+    )
+    deployer = GrokBuildDeployer(_executor(tmp_path, config))
+
+    env = deployer._build_env(config, work_dir=tmp_path)
+
+    assert env["GROK_HOME"] == str(tmp_path / "grok-home")
+    assert env["GROK_LOG_FILE"] == os.devnull
+    assert env["ALE_GROK_BUILD_API_KEY"] == "test-key"
+    assert env["GROK_DISABLE_AUTOUPDATER"] == "1"
+    assert env["GROK_SANDBOX"] == "off"
+    assert env["GROK_CURSOR_MCPS_ENABLED"] == "0"
+    assert env["GROK_CLAUDE_MCPS_ENABLED"] == "0"
+    assert "grok.log" not in GrokBuildDeployer.hot_artifacts
+
+
+def test_custom_model_key_does_not_replace_xai_imagine_key(tmp_path: Path) -> None:
+    config = GrokBuildConfig(
+        model="kimi-k2.5",
+        api_key_env="MOONSHOT_API_KEY",
+        base_url="https://api.moonshot.ai/v1",
+        api_backend="chat_completions",
+    )
+    executor = _executor(tmp_path, config)
+    executor.env["XAI_API_KEY"] = "xai-imagine-key"
+    deployer = GrokBuildDeployer(executor)
+
+    env = deployer._build_env(config, work_dir=tmp_path)
+
+    assert env["ALE_GROK_BUILD_API_KEY"] == "test-key"
+    assert env["XAI_API_KEY"] == "xai-imagine-key"
+
+
+def test_build_env_maps_direct_key_to_xai(tmp_path: Path) -> None:
+    config = GrokBuildConfig()
+    deployer = GrokBuildDeployer(_executor(tmp_path, config))
+
+    env = deployer._build_env(config, work_dir=tmp_path)
+
+    assert env["XAI_API_KEY"] == "test-key"
+    assert "ALE_GROK_BUILD_API_KEY" not in env
+
+
+def test_write_config_registers_cua_and_custom_model_without_secret(
+    tmp_path: Path,
+) -> None:
+    config = GrokBuildConfig(
+        model="kimi-k2.5",
+        api_key="must-not-be-written",
+        base_url="https://api.moonshot.ai/v1",
+        api_backend="chat_completions",
+        context_window=262144,
+        max_completion_tokens=8192,
+    )
+    executor = _executor(tmp_path, config)
+    deployer = GrokBuildDeployer(executor)
+    deployer._node_path = "/usr/bin/node"
+    (tmp_path / "grok-home").mkdir()
+
+    deployer._write_config(config, work_dir=tmp_path)
+
+    rendered = (tmp_path / "grok-home" / "config.toml").read_text(encoding="utf-8")
+    assert '[model."ale-custom"]' in rendered
+    assert 'model = "kimi-k2.5"' in rendered
+    assert 'api_backend = "chat_completions"' in rendered
+    assert 'env_key = "ALE_GROK_BUILD_API_KEY"' in rendered
+    assert "context_window = 262144" in rendered
+    assert "[mcp_servers.cua]" in rendered
+    assert 'args = ["/opt/cua_mcp_server/src/index.js"]' in rendered
+    assert 'CUA_SERVER_URL = "http://127.0.0.1:5000"' in rendered
+    assert "must-not-be-written" not in rendered
+
+
+def test_build_argv_uses_supported_headless_flags(tmp_path: Path) -> None:
+    config = GrokBuildConfig(
+        model="kimi-k2.5",
+        base_url="https://api.moonshot.ai/v1",
+        reasoning_effort="high",
+        max_turns=42,
+        disable_web_search=True,
+        plan_mode=False,
+    )
+    deployer = GrokBuildDeployer(_executor(tmp_path, config))
+    deployer._grok_path = "/opt/grok"
+    prompt_file = tmp_path / "prompt.txt"
+
+    argv = deployer._build_argv(
+        config,
+        grok_cwd=tmp_path,
+        prompt_file=prompt_file,
+    )
+
+    assert argv[:3] == ["/opt/grok", "--prompt-file", str(prompt_file)]
+    assert argv[argv.index("--cwd") + 1] == str(tmp_path)
+    assert argv[argv.index("--model") + 1] == "ale-custom"
+    assert argv[argv.index("--output-format") + 1] == "streaming-json"
+    assert "--always-approve" in argv
+    assert "--no-auto-update" in argv
+    assert "--disable-web-search" in argv
+    assert "--no-plan" in argv
+    assert argv[argv.index("--disallowed-tools") + 1] == (
+        "ask_user_question,enter_plan_mode,exit_plan_mode"
+    )
+    assert argv[argv.index("--reasoning-effort") + 1] == "high"
+    assert argv[argv.index("--max-turns") + 1] == "42"
+
+
+def test_windows_grok_cwd_is_short_stable_and_linux_uses_work_dir(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    work_dir = tmp_path / ("long-run-id-" * 12)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    windows_cwd = _grok_cwd(work_dir, is_linux=False)
+
+    assert windows_cwd == _grok_cwd(work_dir, is_linux=False)
+    assert windows_cwd.parent == Path.home() / ".ale-grok-build" / "cwd"
+    assert len(windows_cwd.name) == 12
+    assert len(str(windows_cwd)) < len(str(work_dir))
+    assert _grok_cwd(work_dir, is_linux=True) == work_dir
+
+
+def test_parse_session_preserves_tools_images_and_authoritative_usage(
+    tmp_path: Path,
+) -> None:
+    session_id = "019f9bd7-3d6a-7132-9b65-af4af83b7606"
+    session_dir = tmp_path / "grok-home" / "sessions" / "%2Fwork" / session_id
+    session_dir.mkdir(parents=True)
+    image_data = base64.b64encode(b"png-bytes").decode("ascii")
+    transcript_events = [
+        {"type": "thought", "data": "ignored because chat history is richer"},
+        {
+            "type": "end",
+            "stopReason": "EndTurn",
+            "sessionId": session_id,
+            "requestId": "request-1",
+            "usage": {
+                "input_tokens": 795,
+                "cache_read_input_tokens": 33792,
+                "output_tokens": 175,
+                "reasoning_tokens": 121,
+                "total_tokens": 34762,
+            },
+            "num_turns": 3,
+            "modelUsage": {
+                "kimi-k2.5": {
+                    "inputTokens": 795,
+                    "outputTokens": 175,
+                    "cacheReadInputTokens": 33792,
+                    "modelCalls": 3,
+                }
+            },
+            "total_cost_usd": 0.0123,
+        },
+    ]
+    (tmp_path / "transcript.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in transcript_events),
+        encoding="utf-8",
+    )
+    chat_events = [
+        {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "Inspect the desktop."}],
+        },
+        {
+            "type": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "use_tool_1",
+                    "name": "use_tool",
+                    "arguments": json.dumps(
+                        {
+                            "tool_name": "cua__screenshot",
+                            "tool_input": {},
+                        }
+                    ),
+                }
+            ],
+        },
+        {
+            "type": "tool_result",
+            "tool_call_id": "use_tool_1",
+            "content": f"Screenshot captured\ndata:image/png;base64,{image_data}",
+        },
+        {
+            "type": "assistant",
+            "content": "The code is visible.",
+            "model_id": "kimi-k2.5",
+        },
+    ]
+    (session_dir / "chat_history.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in chat_events),
+        encoding="utf-8",
+    )
+    update_events = [
+        {
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "use_tool_1",
+                    "status": "completed",
+                },
+            },
+        }
+    ]
+    (session_dir / "updates.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in update_events),
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    GrokBuildDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=GrokBuildConfig(),
+        run_result=AgentRunResult(status="completed", exit_code=0),
+        builder=builder,
+    )
+    trajectory = builder.finalize(reward=1.0)
+
+    agent_step, environment_step, final_step = trajectory.steps
+    assert agent_step.reasoning == "Inspect the desktop."
+    assert agent_step.tool_calls[0].name == "cua__screenshot"
+    assert agent_step.tool_calls[0].arguments == {}
+    result = environment_step.observation.results[0]
+    assert result.content[0].text == "Screenshot captured\n"
+    assert result.content[1].image.type == "base64"
+    assert result.content[1].image.media_type == "image/png"
+    assert result.content[1].image.data == image_data
+    assert final_step.message == "The code is visible."
+    assert trajectory.final_metrics.total_input_tokens == 795
+    assert trajectory.final_metrics.total_cache_read_tokens == 33792
+    assert trajectory.final_metrics.total_output_tokens == 175
+    assert trajectory.final_metrics.total_cost_usd == 0.0123
+    assert trajectory.extra["grok_build"]["session_id"] == session_id
+    assert trajectory.extra["grok_build"]["num_turns"] == 3
+
+
+def test_parse_stream_fallback_and_error(tmp_path: Path) -> None:
+    transcript_events = [
+        {"type": "thought", "data": "Checking"},
+        {"type": "thought", "data": " files."},
+        {"type": "text", "data": "Done"},
+        {"type": "error", "message": "late warning"},
+    ]
+    (tmp_path / "transcript.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in transcript_events),
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    GrokBuildDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=GrokBuildConfig(),
+        run_result=AgentRunResult(status="failed", exit_code=1),
+        builder=builder,
+    )
+
+    assert builder.trajectory.steps[0].reasoning == "Checking files."
+    assert builder.trajectory.steps[0].message == "Done"
+    assert builder.trajectory.steps[1].message == "late warning"
+    assert builder.trajectory.steps[1].extra["grok_build_error"] is True
+
+
+def test_parse_session_recovers_image_from_mcp_spill(tmp_path: Path) -> None:
+    session_id = "session-with-spill"
+    session_dir = tmp_path / "grok-home" / "sessions" / "%2Fwork" / session_id
+    (session_dir / "mcp").mkdir(parents=True)
+    image_data = base64.b64encode(b"spilled-png").decode("ascii")
+    (tmp_path / "transcript.jsonl").write_text(
+        json.dumps({"type": "end", "sessionId": session_id}),
+        encoding="utf-8",
+    )
+    (session_dir / "chat_history.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "tool_result",
+                "tool_call_id": "use_tool_7",
+                "content": "[MCP output truncated; full output written separately]",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (session_dir / "mcp" / "use_tool_7.txt").write_text(
+        f"Screenshot captured\ndata:image/png;base64,{image_data}",
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    GrokBuildDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=GrokBuildConfig(),
+        run_result=AgentRunResult(status="completed", exit_code=0),
+        builder=builder,
+    )
+
+    content = builder.trajectory.steps[0].observation.results[0].content
+    assert content[0].text == "[MCP output truncated; full output written separately]"
+    assert content[1].image.data == image_data
+
+
+def test_exported_session_recovers_trajectory_when_session_tree_is_missing(
+    tmp_path: Path,
+) -> None:
+    session_id = "session-export"
+    session_dir = tmp_path / "grok-home" / "sessions" / "%2Fwork" / session_id
+    (session_dir / "mcp").mkdir(parents=True)
+    image_data = base64.b64encode(b"exported-png").decode("ascii")
+    (tmp_path / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "end",
+                "sessionId": session_id,
+                "usage": {
+                    "input_tokens": 10,
+                    "cache_read_input_tokens": 20,
+                    "output_tokens": 5,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (session_dir / "chat_history.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "use_tool_9",
+                                "name": "use_tool",
+                                "arguments": json.dumps(
+                                    {
+                                        "tool_name": "cua__screenshot",
+                                        "tool_input": {},
+                                    }
+                                ),
+                            }
+                        ],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "tool_result",
+                        "tool_call_id": "use_tool_9",
+                        "content": "[MCP output written separately]",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (session_dir / "updates.jsonl").write_text("", encoding="utf-8")
+    (session_dir / "events.jsonl").write_text(
+        json.dumps({"type": "turn_ended", "ts": "2026-07-26T01:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    (session_dir / "summary.json").write_text("{}\n", encoding="utf-8")
+    (session_dir / "mcp" / "use_tool_9.txt").write_text(
+        f"Screenshot captured\ndata:image/png;base64,{image_data}",
+        encoding="utf-8",
+    )
+
+    GrokBuildDeployer._export_session_artifacts(
+        tmp_path,
+        tmp_path / "transcript.jsonl",
+    )
+    shutil.rmtree(tmp_path / "grok-home")
+
+    builder = _builder()
+    GrokBuildDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=GrokBuildConfig(),
+        run_result=AgentRunResult(status="completed", exit_code=0),
+        builder=builder,
+    )
+
+    assert (tmp_path / "session_chat_history.jsonl").is_file()
+    assert (tmp_path / "session_events.jsonl").is_file()
+    assert (tmp_path / "session_media.jsonl").is_file()
+    assert (tmp_path / "telemetry_summary.json").is_file()
+    assert builder.trajectory.steps[0].tool_calls[0].name == "cua__screenshot"
+    image = builder.trajectory.steps[1].observation.results[0].content[1].image
+    assert image.data == image_data
+    assert builder.trajectory.extra["grok_build"]["session_dir"] is None
+    assert builder.trajectory.extra["grok_build"]["events_path"].endswith("session_events.jsonl")
+
+
+def test_parse_missing_transcript_emits_system_step(tmp_path: Path) -> None:
+    builder = _builder()
+
+    GrokBuildDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=GrokBuildConfig(),
+        run_result=AgentRunResult(status="failed", exit_code=1),
+        builder=builder,
+    )
+
+    assert builder.trajectory.steps[0].source == "system"
+    assert builder.trajectory.steps[0].extra["reason"] == "no_transcript"

--- a/tests/ale_run/test_grok_build.py
+++ b/tests/ale_run/test_grok_build.py
@@ -4,6 +4,7 @@ import base64
 import json
 import os
 import shutil
+from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -56,6 +57,21 @@ def test_expected_version_parses_scoped_npm_spec() -> None:
 
 def test_default_model_matches_official_cli_catalog() -> None:
     assert GrokBuildConfig().model == "grok-4.5"
+
+
+def test_headless_invariants_are_not_public_config_fields() -> None:
+    config_fields = {field.name for field in fields(GrokBuildConfig)}
+    assert config_fields.isdisjoint(
+        {
+            "always_approve",
+            "disable_auto_update",
+            "disable_web_search",
+            "mcp_startup_timeout_s",
+            "mcp_tool_timeout_s",
+            "plan_mode",
+            "sandbox_profile",
+        }
+    )
 
 
 def test_primary_session_exports_are_hot_artifacts() -> None:
@@ -140,9 +156,12 @@ def test_write_config_registers_cua_and_custom_model_without_secret(
     assert 'api_backend = "chat_completions"' in rendered
     assert 'env_key = "ALE_GROK_BUILD_API_KEY"' in rendered
     assert "context_window = 262144" in rendered
+    assert "auto_update = false" in rendered
     assert "[mcp_servers.cua]" in rendered
     assert 'args = ["/opt/cua_mcp_server/src/index.js"]' in rendered
     assert 'CUA_SERVER_URL = "http://127.0.0.1:5000"' in rendered
+    assert "startup_timeout_sec" not in rendered
+    assert "tool_timeout_sec" not in rendered
     assert "must-not-be-written" not in rendered
 
 
@@ -152,7 +171,6 @@ def test_build_argv_uses_supported_headless_flags(tmp_path: Path) -> None:
         base_url="https://api.moonshot.ai/v1",
         reasoning_effort="high",
         max_turns=42,
-        disable_web_search=True,
         disabled_tools=("image_gen", "ask_user_question"),
     )
     deployer = GrokBuildDeployer(_executor(tmp_path, config))
@@ -171,7 +189,7 @@ def test_build_argv_uses_supported_headless_flags(tmp_path: Path) -> None:
     assert argv[argv.index("--output-format") + 1] == "streaming-json"
     assert "--always-approve" in argv
     assert "--no-auto-update" in argv
-    assert "--disable-web-search" in argv
+    assert "--disable-web-search" not in argv
     assert "--no-plan" in argv
     assert argv[argv.index("--disallowed-tools") + 1] == (
         "ask_user_question,enter_plan_mode,exit_plan_mode,image_gen"

--- a/tests/ale_run/test_grok_build.py
+++ b/tests/ale_run/test_grok_build.py
@@ -8,6 +8,8 @@ from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from ale_run.agents.grok_build.config import GrokBuildConfig
 from ale_run.agents.grok_build.deployer import (
     GrokBuildDeployer,
@@ -56,7 +58,10 @@ def test_expected_version_parses_scoped_npm_spec() -> None:
 
 
 def test_default_model_matches_official_cli_catalog() -> None:
-    assert GrokBuildConfig().model == "grok-4.5"
+    config = GrokBuildConfig()
+    assert config.model == "grok-4.5"
+    assert config.reasoning_effort == "high"
+    assert config.otel_enabled is True
 
 
 def test_headless_invariants_are_not_public_config_fields() -> None:
@@ -76,6 +81,7 @@ def test_headless_invariants_are_not_public_config_fields() -> None:
 
 def test_primary_session_exports_are_hot_artifacts() -> None:
     assert {
+        "otel_requests.jsonl",
         "session_chat_history.jsonl",
         "session_updates.jsonl",
         "session_events.jsonl",
@@ -102,7 +108,31 @@ def test_build_env_isolates_home_and_keeps_custom_key_ephemeral(tmp_path: Path) 
     assert env["GROK_SANDBOX"] == "off"
     assert env["GROK_CURSOR_MCPS_ENABLED"] == "0"
     assert env["GROK_CLAUDE_MCPS_ENABLED"] == "0"
+    assert env["GROK_TELEMETRY_ENABLED"] == "0"
+    assert env["GROK_TELEMETRY_TRACE_UPLOAD"] == "0"
+    assert env["GROK_EXTERNAL_OTEL"] == "0"
+    assert env["OTEL_LOGS_EXPORTER"] == "none"
     assert "grok.log" not in GrokBuildDeployer.hot_artifacts
+
+
+def test_build_env_routes_external_otel_to_run_local_collector(tmp_path: Path) -> None:
+    config = GrokBuildConfig()
+    deployer = GrokBuildDeployer(_executor(tmp_path, config))
+
+    env = deployer._build_env(
+        config,
+        work_dir=tmp_path,
+        otel_endpoint="http://127.0.0.1:4318",
+    )
+
+    assert env["GROK_EXTERNAL_OTEL"] == "1"
+    assert env["OTEL_LOGS_EXPORTER"] == "otlp"
+    assert env["OTEL_METRICS_EXPORTER"] == "otlp"
+    assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+    assert env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] == "http://127.0.0.1:4318/v1/logs"
+    assert env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] == ("http://127.0.0.1:4318/v1/metrics")
+    assert env["OTEL_LOG_USER_PROMPTS"] == "0"
+    assert env["OTEL_LOG_TOOL_DETAILS"] == "0"
 
 
 def test_custom_model_key_does_not_replace_xai_imagine_key(tmp_path: Path) -> None:
@@ -156,6 +186,12 @@ def test_write_config_registers_cua_and_custom_model_without_secret(
     assert 'api_backend = "chat_completions"' in rendered
     assert 'env_key = "ALE_GROK_BUILD_API_KEY"' in rendered
     assert "context_window = 262144" in rendered
+    assert "supports_reasoning_effort = true" in rendered
+    assert 'reasoning_effort = "high"' in rendered
+    assert "[features]" in rendered
+    assert "telemetry = false" in rendered
+    assert "[telemetry]" in rendered
+    assert "trace_upload = false" in rendered
     assert "auto_update = false" in rendered
     assert "[mcp_servers.cua]" in rendered
     assert 'args = ["/opt/cua_mcp_server/src/index.js"]' in rendered
@@ -163,6 +199,27 @@ def test_write_config_registers_cua_and_custom_model_without_secret(
     assert "startup_timeout_sec" not in rendered
     assert "tool_timeout_sec" not in rendered
     assert "must-not-be-written" not in rendered
+
+
+@pytest.mark.parametrize("api_backend", ["responses", "chat_completions", "messages"])
+def test_write_config_supports_every_grok_api_backend(
+    tmp_path: Path,
+    api_backend: str,
+) -> None:
+    config = GrokBuildConfig(
+        model="custom-model",
+        base_url="https://provider.example/v1",
+        api_backend=api_backend,  # type: ignore[arg-type]
+    )
+    deployer = GrokBuildDeployer(_executor(tmp_path, config))
+    deployer._node_path = "/usr/bin/node"
+    (tmp_path / "grok-home").mkdir()
+
+    deployer._write_config(config, work_dir=tmp_path)
+
+    rendered = (tmp_path / "grok-home" / "config.toml").read_text(encoding="utf-8")
+    assert 'base_url = "https://provider.example/v1"' in rendered
+    assert f'api_backend = "{api_backend}"' in rendered
 
 
 def test_build_argv_uses_supported_headless_flags(tmp_path: Path) -> None:
@@ -477,7 +534,7 @@ def test_exported_session_recovers_trajectory_when_session_tree_is_missing(
     assert (tmp_path / "session_chat_history.jsonl").is_file()
     assert (tmp_path / "session_events.jsonl").is_file()
     assert (tmp_path / "session_media.jsonl").is_file()
-    assert (tmp_path / "telemetry_summary.json").is_file()
+    assert (tmp_path / "native_telemetry_summary.json").is_file()
     assert builder.trajectory.steps[0].tool_calls[0].name == "cua__screenshot"
     image = builder.trajectory.steps[1].observation.results[0].content[1].image
     assert image.data == image_data

--- a/tests/ale_run/test_grok_build.py
+++ b/tests/ale_run/test_grok_build.py
@@ -54,10 +54,6 @@ def test_expected_version_parses_scoped_npm_spec() -> None:
     assert _expected_version("@xai-official/grok") is None
 
 
-def test_headless_plan_mode_is_disabled_by_default() -> None:
-    assert GrokBuildConfig().plan_mode is False
-
-
 def test_default_model_matches_official_cli_catalog() -> None:
     assert GrokBuildConfig().model == "grok-4.5"
 
@@ -157,7 +153,7 @@ def test_build_argv_uses_supported_headless_flags(tmp_path: Path) -> None:
         reasoning_effort="high",
         max_turns=42,
         disable_web_search=True,
-        plan_mode=False,
+        disabled_tools=("image_gen", "ask_user_question"),
     )
     deployer = GrokBuildDeployer(_executor(tmp_path, config))
     deployer._grok_path = "/opt/grok"
@@ -178,7 +174,7 @@ def test_build_argv_uses_supported_headless_flags(tmp_path: Path) -> None:
     assert "--disable-web-search" in argv
     assert "--no-plan" in argv
     assert argv[argv.index("--disallowed-tools") + 1] == (
-        "ask_user_question,enter_plan_mode,exit_plan_mode"
+        "ask_user_question,enter_plan_mode,exit_plan_mode,image_gen"
     )
     assert argv[argv.index("--reasoning-effort") + 1] == "high"
     assert argv[argv.index("--max-turns") + 1] == "42"

--- a/tests/ale_run/test_grok_build_telemetry.py
+++ b/tests/ale_run/test_grok_build_telemetry.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
 import json
+import urllib.request
 from pathlib import Path
 
-from ale_run.agents.grok_build.telemetry import recover_telemetry_artifacts
+from google.protobuf.json_format import ParseDict
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+)
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+    ExportMetricsServiceRequest,
+)
+
+from ale_run.agents.grok_build.otel import (
+    GrokBuildOtelCollector,
+    recover_otel_artifacts,
+)
+from ale_run.agents.grok_build.telemetry import recover_native_telemetry_artifacts
 
 
 def _write_jsonl(path: Path, records: list[dict]) -> None:
@@ -86,7 +99,7 @@ def test_native_telemetry_captures_llm_and_tool_timings(tmp_path: Path) -> None:
     )
 
     assert (
-        recover_telemetry_artifacts(
+        recover_native_telemetry_artifacts(
             tmp_path,
             events_file=events,
             updates_file=updates,
@@ -95,9 +108,9 @@ def test_native_telemetry_captures_llm_and_tool_timings(tmp_path: Path) -> None:
     )
 
     normalized = [
-        json.loads(line) for line in (tmp_path / "telemetry.jsonl").read_text().splitlines()
+        json.loads(line) for line in (tmp_path / "native_telemetry.jsonl").read_text().splitlines()
     ]
-    summary = json.loads((tmp_path / "telemetry_summary.json").read_text())
+    summary = json.loads((tmp_path / "native_telemetry_summary.json").read_text())
     assert len(normalized) == 7
     assert summary["session_id"] == "session-1"
     assert summary["usage"]["input_tokens"] == 200
@@ -112,7 +125,7 @@ def test_native_telemetry_captures_llm_and_tool_timings(tmp_path: Path) -> None:
 
 
 def test_missing_native_logs_still_produces_recoverable_summary(tmp_path: Path) -> None:
-    count = recover_telemetry_artifacts(
+    count = recover_native_telemetry_artifacts(
         tmp_path,
         events_file=None,
         updates_file=None,
@@ -126,8 +139,168 @@ def test_missing_native_logs_still_produces_recoverable_summary(tmp_path: Path) 
         },
     )
 
-    summary = json.loads((tmp_path / "telemetry_summary.json").read_text())
+    summary = json.loads((tmp_path / "native_telemetry_summary.json").read_text())
     assert count == 0
     assert summary["session_id"] == "session-fallback"
     assert summary["usage"]["input_tokens"] == 10
     assert summary["event_count"] == 0
+
+
+def _attribute(key: str, value: object) -> dict:
+    if isinstance(value, bool):
+        encoded = {"boolValue": value}
+    elif isinstance(value, int):
+        encoded = {"intValue": str(value)}
+    else:
+        encoded = {"stringValue": str(value)}
+    return {"key": key, "value": encoded}
+
+
+def _log_record(name: str, sequence: int, **attributes: object) -> dict:
+    return {
+        "timeUnixNano": str(1_800_000_000_000_000_000 + sequence),
+        "eventName": name,
+        "attributes": [
+            _attribute("event.sequence", sequence),
+            *[_attribute(key, value) for key, value in attributes.items()],
+        ],
+    }
+
+
+def _post_protobuf(url: str, message: object) -> None:
+    request = urllib.request.Request(
+        url,
+        data=message.SerializeToString(),  # type: ignore[attr-defined]
+        headers={"Content-Type": "application/x-protobuf"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        assert response.status == 200
+
+
+def test_external_otel_collector_captures_protobuf_logs_and_metrics(
+    tmp_path: Path,
+) -> None:
+    logs = ParseDict(
+        {
+            "resourceLogs": [
+                {
+                    "resource": {
+                        "attributes": [
+                            _attribute("service.name", "grok-cli"),
+                            _attribute("grok_code.schema.version", "v1"),
+                        ]
+                    },
+                    "scopeLogs": [
+                        {
+                            "scope": {"name": "ai.xai.grok_code"},
+                            "logRecords": [
+                                _log_record(
+                                    "grok_code.api_request",
+                                    1,
+                                    model="grok-4.5",
+                                    duration_ms=800,
+                                    input_tokens=100,
+                                    output_tokens=20,
+                                ),
+                                _log_record(
+                                    "grok_code.tool_result",
+                                    2,
+                                    tool_name="web_search",
+                                    duration_ms=250,
+                                    success=True,
+                                    outcome="completed",
+                                ),
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+        ExportLogsServiceRequest(),
+    )
+    metrics = ParseDict(
+        {
+            "resourceMetrics": [
+                {
+                    "scopeMetrics": [
+                        {
+                            "scope": {"name": "ai.xai.grok_code"},
+                            "metrics": [
+                                {
+                                    "name": "grok_code.token.usage",
+                                    "unit": "{token}",
+                                    "sum": {
+                                        "aggregationTemporality": 1,
+                                        "isMonotonic": True,
+                                        "dataPoints": [
+                                            {
+                                                "asInt": "100",
+                                                "attributes": [
+                                                    _attribute("type", "input"),
+                                                    _attribute("model", "grok-4.5"),
+                                                ],
+                                            },
+                                            {
+                                                "asInt": "20",
+                                                "attributes": [
+                                                    _attribute("type", "output"),
+                                                    _attribute("model", "grok-4.5"),
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ]
+        },
+        ExportMetricsServiceRequest(),
+    )
+    collector = GrokBuildOtelCollector(tmp_path)
+    collector.start()
+    _post_protobuf(collector.endpoint + "/v1/logs", logs)
+    _post_protobuf(collector.endpoint + "/v1/metrics", metrics)
+    collector.stop()
+
+    raw = [json.loads(line) for line in collector.raw_path.read_text().splitlines()]
+    assert {record["signal"] for record in raw} == {"logs", "metrics"}
+    events = [json.loads(line) for line in collector.events_path.read_text().splitlines()]
+    assert [event["attributes"]["event.name"] for event in events] == [
+        "grok_code.api_request",
+        "grok_code.tool_result",
+    ]
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["api_calls"][0]["duration_ms"] == 800
+    assert summary["tool_executions"][0]["tool_name"] == "web_search"
+    assert summary["metric_totals"]["tokens_by_type"] == {
+        "input": 100,
+        "output": 20,
+    }
+
+
+def test_external_otel_wal_recovers_derived_files(tmp_path: Path) -> None:
+    logs = ParseDict(
+        {
+            "resourceLogs": [
+                {
+                    "scopeLogs": [
+                        {
+                            "logRecords": [
+                                _log_record("grok_code.session_start", 1, model="grok-4.5")
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        ExportLogsServiceRequest(),
+    )
+    collector = GrokBuildOtelCollector(tmp_path)
+    collector._store_request("logs", {}, logs.SerializeToString())
+
+    assert recover_otel_artifacts(tmp_path) == 1
+    summary = json.loads(collector.summary_path.read_text())
+    assert summary["events_by_name"] == {"grok_code.session_start": 1}

--- a/tests/ale_run/test_grok_build_telemetry.py
+++ b/tests/ale_run/test_grok_build_telemetry.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ale_run.agents.grok_build.telemetry import recover_telemetry_artifacts
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def test_native_telemetry_captures_llm_and_tool_timings(tmp_path: Path) -> None:
+    events = tmp_path / "session_events.jsonl"
+    updates = tmp_path / "session_updates.jsonl"
+    _write_jsonl(
+        events,
+        [
+            {
+                "ts": "2026-07-26T01:00:00.000Z",
+                "type": "turn_started",
+                "model_id": "kimi-k2.5",
+            },
+            {
+                "ts": "2026-07-26T01:00:00.100Z",
+                "type": "loop_started",
+                "loop_index": 0,
+            },
+            {"ts": "2026-07-26T01:00:00.600Z", "type": "first_token"},
+            {
+                "ts": "2026-07-26T01:00:01.000Z",
+                "type": "tool_started",
+                "tool_name": "use_tool",
+            },
+            {
+                "ts": "2026-07-26T01:00:01.010Z",
+                "type": "mcp_tool_call_started",
+                "server_name": "cua",
+                "tool_name": "screenshot",
+                "call_id": "cua__screenshot",
+            },
+            {
+                "ts": "2026-07-26T01:00:01.260Z",
+                "type": "mcp_tool_call_completed",
+                "server_name": "cua",
+                "tool_name": "screenshot",
+                "call_id": "cua__screenshot",
+                "duration_ms": 250,
+                "success": True,
+                "is_timeout": False,
+            },
+            {
+                "ts": "2026-07-26T01:00:01.300Z",
+                "type": "tool_completed",
+                "tool_name": "use_tool",
+                "duration_ms": 300,
+                "outcome": "success",
+            },
+        ],
+    )
+    _write_jsonl(
+        updates,
+        [
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "session-1",
+                    "update": {
+                        "sessionUpdate": "turn_completed",
+                        "usage": {
+                            "inputTokens": 900,
+                            "cachedReadTokens": 700,
+                            "outputTokens": 50,
+                            "reasoningTokens": 20,
+                            "totalTokens": 950,
+                            "modelCalls": 1,
+                            "apiDurationMs": 800,
+                        },
+                    },
+                },
+            }
+        ],
+    )
+
+    assert (
+        recover_telemetry_artifacts(
+            tmp_path,
+            events_file=events,
+            updates_file=updates,
+        )
+        == 7
+    )
+
+    normalized = [
+        json.loads(line) for line in (tmp_path / "telemetry.jsonl").read_text().splitlines()
+    ]
+    summary = json.loads((tmp_path / "telemetry_summary.json").read_text())
+    assert len(normalized) == 7
+    assert summary["session_id"] == "session-1"
+    assert summary["usage"]["input_tokens"] == 200
+    assert summary["usage"]["cache_read_tokens"] == 700
+    assert summary["usage"]["api_duration_ms"] == 800
+    assert summary["llm_calls"][0]["first_token_ms"] == 500
+    assert summary["llm_calls"][0]["duration_ms"] == 900
+    assert summary["tool_executions"][0]["tool_name"] == "cua__screenshot"
+    assert summary["tool_executions"][0]["duration_ms"] == 250
+    assert summary["tool_executions"][1]["tool_name"] == "use_tool"
+    assert summary["tool_executions"][1]["success"] is True
+
+
+def test_missing_native_logs_still_produces_recoverable_summary(tmp_path: Path) -> None:
+    count = recover_telemetry_artifacts(
+        tmp_path,
+        events_file=None,
+        updates_file=None,
+        terminal_event={
+            "sessionId": "session-fallback",
+            "usage": {
+                "input_tokens": 10,
+                "cache_read_input_tokens": 20,
+                "output_tokens": 5,
+            },
+        },
+    )
+
+    summary = json.loads((tmp_path / "telemetry_summary.json").read_text())
+    assert count == 0
+    assert summary["session_id"] == "session-fallback"
+    assert summary["usage"]["input_tokens"] == 10
+    assert summary["event_count"] == 0


### PR DESCRIPTION
## Summary

- add an ALE harness for xAI's official Grok Build CLI without modifying or vendoring upstream
- pin and verify `@xai-official/grok@0.2.112` in Linux and Windows sandboxes
- run the official `grok-4.5` catalog model directly with `XAI_API_KEY`
- support custom endpoints through every Grok Build backend: `responses`, `chat_completions`, and `messages`
- expose ALE's CUA MCP bridge and produce standard trajectories, screenshots, usage, cost, and output artifacts
- capture Grok Build's native external OpenTelemetry logs and metrics with a run-local OTLP receiver

This is separate from the existing `grok_cli` harness, which integrates the older `superagent-ai/grok-cli` package.

## Runtime invariants

The preset is `configs/agents/grok_build.yaml`:

- model: `grok-4.5`
- credential: `XAI_API_KEY`
- CLI: `@xai-official/grok@0.2.112`
- reasoning effort: `high`
- output: `streaming-json`
- sandbox: `--sandbox off`, because the ALE VM is the isolation boundary
- approval: `--always-approve`
- plan mode: `--no-plan`
- auto-update: `--no-auto-update`

These are fixed harness behavior rather than experiment knobs. The harness also removes `ask_user_question`, `enter_plan_mode`, and `exit_plan_mode`, because ALE has no interactive approval client.

Grok's built-in `web_search` and `web_fetch` remain available. `search_tool` is a different tool: it searches connected MCP tool schemas.

On Windows, Grok's project cwd uses a short per-run hash under `~/.ale-grok-build/cwd/`. Grok percent-encodes the cwd inside its session tree, so using ALE's full run ID can exceed the legacy Windows path limit.

## API backends and reasoning

All three custom-model backends are native Grok Build capabilities:

- `responses` calls `<base_url>/responses`
- `chat_completions` calls `<base_url>/chat/completions`
- `messages` calls `<base_url>/messages`

`base_url` must be the API root for the selected wire protocol. The harness does not translate between protocols.

`reasoning_effort` is passed through `--reasoning-effort`. The pinned Grok Build release accepts canonical effort levels plus model-specific menu IDs; its built-in `grok-4.5` catalog advertises `high`, `medium`, and `low`, and ALE explicitly pins `high`.

## Credentials

Generated TOML stores only an environment variable name, never the credential value. Custom-model credentials are passed through the private process variable named by the model's `env_key`.

This PR also closes an ALE executor credential gap: resolved `api_key`, `*_api_key`, and explicitly secret-marked fields are extracted into the existing read-once `_secrets.json` sidecar, restored inside the executor entry point, and deleted before gathered `_spec.json` artifacts are written.

Custom model authentication does not replace authentication for Grok Build's built-in xAI Imagine tools. `image_gen`, `image_edit`, `image_to_video`, and `reference_to_video` still require an authorized `XAI_API_KEY`.

## OpenTelemetry

Grok Build has a native external OTEL stream independent of its SpaceXAI product analytics. The harness:

- disables product telemetry, Mixpanel, trace upload, and auto-update
- enables external OTEL with the required double opt-in
- starts a run-local OTLP/HTTP protobuf receiver before launching Grok
- captures both `/v1/logs` and `/v1/metrics`
- keeps prompt and tool-detail content gates disabled
- strips inherited OTLP authorization headers

Artifacts:

- `otel_requests.jsonl`: complete chunked raw OTLP write-ahead log, incrementally mirrored from the sandbox
- `telemetry.jsonl`: flattened `grok_code.*` log events
- `telemetry_metrics.jsonl`: flattened session, turn, tool, error, and token metrics
- `telemetry_summary.json`: API calls/errors, tool decisions/results, MCP connections, event counts, and metric totals

The raw WAL is authoritative and can rebuild derived files after interruption. Richer run-local Grok session events remain separate as `native_telemetry.jsonl` and `native_telemetry_summary.json`.

## Artifact reliability

Grok Build does not emit tool calls on streaming stdout, so the parser combines:

- `transcript.jsonl`
- session `chat_history.jsonl`
- `updates.jsonl`
- `events.jsonl`
- MCP spill files

The primary session is also exported to fixed top-level hot artifacts. This lets ALE's bounded final reconciliation recover trajectories and media even when nested Windows paths cannot all be gathered.

## Validation

### Automated

- `120 passed` across `tests/ale_run`
- `37 passed` across incremental-tail and QEMU-provider tests
- focused Ruff lint passed
- focused Ruff format check passed
- `uv lock --check` passed
- `git diff --check` passed
- staged diff scan found no configured credential values

### Direct xAI OTEL smoke

The pinned native CLI completed a direct `grok-4.5` request with `XAI_API_KEY` while exporting OTLP/HTTP protobuf:

- process exit: `0`
- raw OTLP requests: `4`
- log events: `6`
- events included session start, auth, model switch, API request, user prompt, and turn completion
- OTEL input/output/reasoning usage matched Grok's terminal usage

### Local QEMU: direct xAI with OTEL

Official `grok-4.5`, `reasoning_effort: high`, and external OTEL enabled:

- Linux `demo/seecheck`: score `1.0`
  - 31 OTEL events
  - 9 API calls, 0 API errors
  - 8 tool decisions/results
  - MCP connected with all 14 CUA tools
  - 545 reasoning tokens recorded
- Windows `demo/seecheck_win`: score `1.0`
  - 52 OTEL events
  - 16 API calls, 0 API errors
  - 15 tool decisions/results
  - MCP connected with all 14 CUA tools
  - 564 reasoning tokens recorded

Both runs persisted the raw WAL, flattened events, metrics, summaries, native session telemetry, standard trajectories, and output artifacts.

### Tool smoke coverage

Direct xAI Windows `demo/tool_smoke_win` scored `0.886` (`31/35`):

- all 14 CUA tools passed
- native file, shell, subagent, scheduler, monitor, and workflow tools passed
- `web_search` passed
- the four xAI Imagine tools returned `403 permission-denied`; the test key could call `grok-4.5` but was not authorized for image/video endpoints

Custom Moonshot `kimi-k2.5` through `api_backend: chat_completions`:

- Linux `demo/seecheck`: `1.0`
- Windows `demo/seecheck_win`: `1.0`
- Linux `demo/tool_smoke`: `0.857`
- Windows `demo/tool_smoke_win`: `0.882`
- all 14 Windows CUA tools passed

## Comparison with #52

This follows the merged Kimi Code harness conventions from #52:

- official pinned CLI installation and version verification
- isolated per-run home and configuration
- process-only credentials
- CUA MCP registration
- standard trajectory, usage, screenshot, and output artifacts
- raw OTLP WAL plus recoverable derived telemetry
- hot artifact recovery
- Linux QEMU integration coverage

It additionally covers Windows QEMU, Grok's three native custom endpoint protocols, explicit reasoning effort, native Grok external OTEL logs and metrics, and Windows path-length/session-export handling.

## Upstream references

- https://docs.x.ai/build/overview
- https://docs.x.ai/build/cli/headless-scripting
- https://docs.x.ai/build/features/mcp-servers
- https://docs.x.ai/build/settings/reference
- https://docs.x.ai/build/cli/reference
- https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/24-monitoring-usage.md
- https://www.npmjs.com/package/@xai-official/grok
- https://github.com/rdi-berkeley/agents-last-exam/pull/52
