### PR TITLE
Parse failed MPC verifier results

### DIFF
--- a/tasks/engineering/mpc_control_building_v1/main.py
+++ b/tasks/engineering/mpc_control_building_v1/main.py
@@ -155,11 +155,12 @@ async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
         _read_script("verify_outputs.py"),
     )
     result = await session.run_command(
-        f'UV_CACHE_DIR=/tmp/uv-cache uv run --with pandas --with numpy '
+        f"UV_CACHE_DIR=/tmp/uv-cache uv run --with pandas --with numpy "
         f'python "{EVAL_TMP_DIR}/verify_outputs.py" '
         f'--output-dir "{meta["remote_output_dir"]}" '
         f'--input-dir "{meta["input_dir"]}" '
-        f'--reference-dir "{meta["reference_dir"]}"'
+        f'--reference-dir "{meta["reference_dir"]}"',
+        check=False,
     )
     stdout = result.get("output", result.get("stdout", ""))
     try:


### PR DESCRIPTION
## What changed

Run the `engineering/mpc_control_building_v1` verifier with `check=False` so its JSON result is parsed for both passing and failing candidates.

## Why

`verify_outputs.py` intentionally exits with status 1 when a candidate fails and emits a valid JSON report containing `passed: false` and `score: 0.0`. The evaluator previously used the session default `check=True`, which raised before that report could be parsed. Valid failed candidates therefore appeared as evaluator infrastructure errors instead of zero-score results.

## Impact

Passing candidates behave unchanged. Failed candidates now complete normally with the score reported by the verifier.

## Validation

- `uv run ruff check tasks/engineering/mpc_control_building_v1/main.py`
- `uv run ruff format --check tasks/engineering/mpc_control_building_v1/main.py`
- In-process evaluator check with a session returning exit 1 and valid failed-candidate JSON; the evaluator returned `[0.0]`.
