### PR TITLE
Fix ALE CLI reference publication and evaluator failures

### DIFF
--- a/tasks/engineering/mpc_control_building_v1/main.py
+++ b/tasks/engineering/mpc_control_building_v1/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 from pathlib import Path
 
@@ -26,6 +27,33 @@ EVAL_TMP_DIR = f"/tmp/agenthle_eval/{TASK_NAME}"
 
 def _read_script(name: str) -> str:
     return (SCRIPTS_DIR / name).read_text(encoding="utf-8")
+
+
+def _parse_verifier_result(result: dict) -> float:
+    stdout = result.get("output", result.get("stdout", ""))
+    return_code = result.get("return_code", result.get("returncode"))
+    stderr = str(result.get("stderr", ""))
+    try:
+        data = json.loads(stdout)
+        if not isinstance(data, dict):
+            raise TypeError("verifier result must be a JSON object")
+        passed = data.get("passed")
+        if not isinstance(passed, bool):
+            raise TypeError("verifier result must contain a boolean passed field")
+        if return_code not in (0, 1) or passed != (return_code == 0):
+            raise ValueError(
+                f"verifier status mismatch: return_code={return_code!r}, passed={passed!r}"
+            )
+        score = float(data["score"])
+        if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+            raise ValueError(f"verifier score is outside [0, 1]: {score!r}")
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "MPC verifier failed to produce a valid result: "
+            f"return_code={return_code!r}, stderr={stderr[:1000]!r}"
+        ) from exc
+    logger.info("MPC control building eval result: %s", data)
+    return score
 
 
 class MPCControlBuildingConfig(LinuxTaskConfig):
@@ -155,17 +183,11 @@ async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
         _read_script("verify_outputs.py"),
     )
     result = await session.run_command(
-        f'UV_CACHE_DIR=/tmp/uv-cache uv run --with pandas --with numpy '
+        f"UV_CACHE_DIR=/tmp/uv-cache uv run --with pandas --with numpy "
         f'python "{EVAL_TMP_DIR}/verify_outputs.py" '
         f'--output-dir "{meta["remote_output_dir"]}" '
         f'--input-dir "{meta["input_dir"]}" '
-        f'--reference-dir "{meta["reference_dir"]}"'
+        f'--reference-dir "{meta["reference_dir"]}"',
+        check=False,
     )
-    stdout = result.get("output", result.get("stdout", ""))
-    try:
-        data = json.loads(stdout)
-    except (TypeError, json.JSONDecodeError):
-        logger.error("verify_outputs.py did not produce JSON: %s", stdout)
-        return [0.0]
-    logger.info("MPC control building eval result: %s", data)
-    return [float(data.get("score", 0.0))]
+    return [_parse_verifier_result(result)]

--- a/tasks/life_sciences/WGS_Variant_Calling/EVALUATOR_DATA.md
+++ b/tasks/life_sciences/WGS_Variant_Calling/EVALUATOR_DATA.md
@@ -8,4 +8,8 @@ Set `WGS_VARIANT_CALLING_EVAL_DATA_DIR` to an evaluator-local directory containi
 - `eval_region_confident.bed`
 
 This directory must not be staged on the agent VM or stored in a public repository. The evaluator
-downloads only the submitted VCF and compares it against these local files.
+downloads only the submitted VCF and compares it against these local files. For ALE CLI runs that
+do not provision this directory, the same four files may be staged from the gated task reference
+after the solve phase and materialized into a temporary evaluator directory by `evaluate()`.
+
+Missing evaluator data is an evaluator failure, not a valid partial score.

--- a/tasks/life_sciences/WGS_Variant_Calling/main.py
+++ b/tasks/life_sciences/WGS_Variant_Calling/main.py
@@ -5,6 +5,7 @@ import os
 import posixpath
 import re
 import shlex
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -250,31 +251,56 @@ async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
     except Exception as exc:
         logger.info("Checkpoint 3 FAILED: %s", exc)
 
-    try:
-        if not vcf_bytes:
-            raise ValueError("submitted VCF is missing")
-        evaluator_data_dir = Path(
-            os.environ.get(
-                "WGS_VARIANT_CALLING_EVAL_DATA_DIR",
-                Path(__file__).resolve().parents[3]
-                / "secret"
-                / "eval_data"
-                / "WGS_Variant_Calling",
-            )
+    if not vcf_bytes:
+        logger.info("Checkpoint 4 FAILED: submitted VCF is missing")
+        return [score]
+
+    evaluator_data_dir = Path(
+        os.environ.get(
+            "WGS_VARIANT_CALLING_EVAL_DATA_DIR",
+            Path(__file__).resolve().parents[3]
+            / "secret"
+            / "eval_data"
+            / "WGS_Variant_Calling",
         )
+    )
+    required_evaluator_files = (
+        "chr17.fa",
+        "truth_chr17.vcf.gz",
+        "truth_chr17.vcf.gz.tbi",
+        "eval_region_confident.bed",
+    )
+
+    if all((evaluator_data_dir / name).is_file() for name in required_evaluator_files):
         report = score_vcf_bytes(vcf_bytes, evaluator_data_dir)
-        for value, threshold in [
-            (report.snp.f1, task_cfg.metadata["min_snp_f1"]),
-            (report.snp.precision, task_cfg.metadata["min_snp_precision"]),
-            (report.snp.recall, task_cfg.metadata["min_snp_recall"]),
-            (report.indel.f1, task_cfg.metadata["min_indel_f1"]),
-            (report.indel.precision, task_cfg.metadata["min_indel_precision"]),
-            (report.indel.recall, task_cfg.metadata["min_indel_recall"]),
-        ]:
-            if value >= threshold:
-                score += 0.10
-        logger.info("Checkpoint 4 independently recomputed metrics=%s", report)
-    except Exception as exc:
-        logger.info("Checkpoint 4 FAILED: %s", exc)
+    else:
+        reference_dir = task_cfg.metadata["reference_dir"]
+        try:
+            with tempfile.TemporaryDirectory(prefix="wgs-evaluator-") as temp_dir:
+                staged_evaluator_dir = Path(temp_dir)
+                for name in required_evaluator_files:
+                    payload = await session.read_bytes(f"{reference_dir}/{name}")
+                    if not payload:
+                        raise FileNotFoundError(
+                            f"staged evaluator reference is missing or empty: {name}"
+                        )
+                    (staged_evaluator_dir / name).write_bytes(payload)
+                report = score_vcf_bytes(vcf_bytes, staged_evaluator_dir)
+        except Exception as exc:
+            raise RuntimeError(
+                "WGS evaluator data is unavailable both locally and in the staged reference"
+            ) from exc
+
+    for value, threshold in [
+        (report.snp.f1, task_cfg.metadata["min_snp_f1"]),
+        (report.snp.precision, task_cfg.metadata["min_snp_precision"]),
+        (report.snp.recall, task_cfg.metadata["min_snp_recall"]),
+        (report.indel.f1, task_cfg.metadata["min_indel_f1"]),
+        (report.indel.precision, task_cfg.metadata["min_indel_precision"]),
+        (report.indel.recall, task_cfg.metadata["min_indel_recall"]),
+    ]:
+        if value >= threshold:
+            score += 0.10
+    logger.info("Checkpoint 4 independently recomputed metrics=%s", report)
 
     return [score]

--- a/tasks/published_tasks.json
+++ b/tasks/published_tasks.json
@@ -147,7 +147,7 @@
     },
     "computing_math/os_log_permission_guard_v1": {
       "variants": [
-        "_package"
+        "base"
       ]
     },
     "computing_math/k8s_migration_1": {
@@ -537,7 +537,7 @@
     },
     "health_medicine/wsi_tumor_localization_1": {
       "variants": [
-        "bounding_box"
+        "center_point"
       ]
     },
     "health_medicine/healthcare_bias_audit_27a_public_replication_v1": {

--- a/tests/tasks/test_clustered_cyclic_code_circuit_level_simulation.py
+++ b/tests/tasks/test_clustered_cyclic_code_circuit_level_simulation.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import csv
+from io import StringIO
+from pathlib import Path
+
+from tasks.computing_math.clustered_cyclic_code_circuit_level_simulation.scripts.score_logical_error_rates import (
+    SUPPRESSION_LADDER,
+    score_logical_error_rates_bytes,
+)
+
+
+REFERENCE_PATH = Path(
+    "/mnt/data/agenthle/computing_math/clustered_cyclic_code_circuit_level_simulation/"
+    "base/reference/logical_error_rates_3codes.csv"
+)
+
+
+def test_published_reference_scores_one_against_itself() -> None:
+    reference = REFERENCE_PATH.read_bytes()
+    result = score_logical_error_rates_bytes(
+        agent_bytes=reference,
+        reference_bytes=reference,
+    )
+
+    assert SUPPRESSION_LADDER == ["[24,8,3]", "[40,8,5]", "[56,8,7]"]
+    assert result.score == 1.0
+    assert result.passed
+
+    rows = list(csv.DictReader(StringIO(reference.decode("utf-8"))))
+    assert {row["code"] for row in rows} == set(SUPPRESSION_LADDER)

--- a/tests/tasks/test_mpc_control_building.py
+++ b/tests/tasks/test_mpc_control_building.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tasks.engineering.mpc_control_building_v1.main import _parse_verifier_result
+
+
+def test_failed_verifier_json_is_scored_as_candidate_failure() -> None:
+    result = {
+        "stdout": json.dumps(
+            {
+                "score": 0.0,
+                "passed": False,
+                "reason": "missing required output file",
+            }
+        ),
+        "stderr": "",
+        "return_code": 1,
+    }
+
+    assert _parse_verifier_result(result) == 0.0
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"stdout": "", "stderr": "uv failed", "return_code": 1},
+        {
+            "stdout": json.dumps({"score": 0.0, "passed": False}),
+            "stderr": "verifier crashed after printing",
+            "return_code": 2,
+        },
+        {
+            "stdout": json.dumps({"score": float("nan"), "passed": True}),
+            "stderr": "",
+            "return_code": 0,
+        },
+    ],
+)
+def test_evaluator_failures_are_not_scored_as_candidate_failures(result: dict) -> None:
+    with pytest.raises(RuntimeError, match="MPC verifier failed"):
+        _parse_verifier_result(result)

--- a/tests/tasks/test_wgs_variant_calling.py
+++ b/tests/tasks/test_wgs_variant_calling.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import gzip
 from types import SimpleNamespace
 
+import pytest
+
 from tasks.life_sciences.WGS_Variant_Calling.main import config, evaluate, start
 
 
@@ -24,6 +26,17 @@ class FakeSession:
         if path.endswith("duplication_metrics.txt"):
             return b"percent_duplication 0.01\n"
         raise AssertionError(path)
+
+
+class StagedReferenceSession(FakeSession):
+    def __init__(self, vcf_payload: bytes, evaluator_dir):
+        super().__init__(vcf_payload)
+        self.evaluator_dir = evaluator_dir
+
+    async def read_bytes(self, path: str) -> bytes:
+        if "/reference/" in path:
+            return (self.evaluator_dir / path.rsplit("/", 1)[-1]).read_bytes()
+        return await super().read_bytes(path)
 
 
 class StartSession:
@@ -57,6 +70,7 @@ def _write_evaluator_data(tmp_path, reference: str) -> None:
     (tmp_path / "chr17.fa").write_text(">chr17\n" + reference + "\n")
     (tmp_path / "eval_region_confident.bed").write_text(f"chr17\t0\t{len(reference)}\n")
     (tmp_path / "truth_chr17.vcf.gz").write_bytes(_vcf_payload(reference, include_variants=True))
+    (tmp_path / "truth_chr17.vcf.gz.tbi").write_bytes(gzip.compress(b"TBI\x01test-index"))
 
 
 async def test_evaluator_recomputes_metrics_from_submitted_vcf(tmp_path, monkeypatch):
@@ -85,6 +99,40 @@ async def test_perfect_self_report_cannot_replace_variant_calls(tmp_path, monkey
     )
 
     assert score == [0.4]
+
+
+async def test_missing_evaluator_bundle_is_not_scored_as_partial_success(tmp_path, monkeypatch):
+    reference = ("ACGTTGCAAG" * 20)[:200]
+    missing_dir = tmp_path / "missing"
+    monkeypatch.setenv("WGS_VARIANT_CALLING_EVAL_DATA_DIR", str(missing_dir))
+    task_cfg = SimpleNamespace(metadata=config.to_metadata())
+
+    with pytest.raises(RuntimeError, match="evaluator data is unavailable"):
+        await evaluate(
+            task_cfg,
+            FakeSession(_vcf_payload(reference, include_variants=True)),
+        )
+
+
+async def test_staged_gated_reference_is_used_when_local_bundle_is_absent(
+    tmp_path, monkeypatch
+):
+    reference = ("ACGTTGCAAG" * 20)[:200]
+    evaluator_dir = tmp_path / "reference"
+    evaluator_dir.mkdir()
+    _write_evaluator_data(evaluator_dir, reference)
+    monkeypatch.setenv("WGS_VARIANT_CALLING_EVAL_DATA_DIR", str(tmp_path / "missing"))
+    task_cfg = SimpleNamespace(metadata=config.to_metadata())
+
+    score = await evaluate(
+        task_cfg,
+        StagedReferenceSession(
+            _vcf_payload(reference, include_variants=True),
+            evaluator_dir,
+        ),
+    )
+
+    assert score == [0.9999999999999999]
 
 
 async def test_start_clears_stale_output():


### PR DESCRIPTION
## Summary

- publish the runtime-selected OS log `base` and WSI `center_point` variants
- let WGS scoring use evaluator-local truth or the gated reference staged after solve, and fail closed when neither is available
- add a clustered-cyclic reference self-score regression for the corrected suppression ladder
- accept structured MPC candidate failures from a non-zero verifier exit while surfacing malformed/crashed verifier runs as evaluator errors

## Validation

- `pytest -q tests/tasks/test_mpc_control_building.py tests/tasks/test_wgs_variant_calling.py tests/tasks/test_clustered_cyclic_code_circuit_level_simulation.py`
- 10 passed in public, private, and the local-test worktree
- corrected references independently self-score 1.0

The MPC change supersedes #65 with explicit status/schema/finite-score validation and evaluator-fault regression coverage.