### PR TITLE
fix(config): do not require ${env:VAR} refs that appear only in comments

### DIFF
--- a/ale_run/orchestration/config_loader.py
+++ b/ale_run/orchestration/config_loader.py
@@ -26,7 +26,8 @@ Shape:
 Other behavior:
 
 * ``${env:VAR}`` substitution at parse time (KeyError if VAR unset) — applied
-  to the experiment yaml AND every referenced config file.
+  to the experiment yaml AND every referenced config file. Refs that appear
+  only in a comment are dropped by the parser and never required.
 * All relative paths resolve against the main yaml's directory.
 * Unknown / missing keys raise loudly.
 """
@@ -110,6 +111,7 @@ def load_experiment(path: str | Path) -> ExperimentSpec:
     raw = yaml.safe_load(_substitute_env(text)) or {}
     if not isinstance(raw, dict):
         raise TypeError(f"experiment yaml root must be a mapping, got {type(raw).__name__}")
+    _require_env_resolved(raw, main_path)
     return _build_experiment(raw, base_dir=base_dir)
 
 
@@ -161,19 +163,26 @@ def _load_dotenv(path: Path, *, override: bool = False) -> None:
 def _read_yaml(path: Path) -> Any:
     text = path.read_text()
     text = _substitute_env(text)
-    return yaml.safe_load(text) or {}
+    data = yaml.safe_load(text) or {}
+    _require_env_resolved(data, path)
+    return data
 
 
 def _substitute_env(text: str) -> str:
-    def repl(m: re.Match[str]) -> str:
+    """Expand ``${env:VAR}``; unset refs are left for :func:`_require_env_resolved`."""
+    return _ENV_RE.sub(lambda m: os.environ.get(m.group(1), m.group(0)), text)
+
+
+def _require_env_resolved(data: Any, path: Path) -> None:
+    """Raise if a ``${env:VAR}`` ref survived into the *parsed* document.
+
+    Substitution runs on raw text — it has to, so a substituted value keeps its
+    yaml type — which means it also sees comments. Checking after the parse is
+    what keeps a commented ``${env:...}`` example from becoming a requirement.
+    """
+    if (m := _ENV_RE.search(yaml.safe_dump(data))) is not None:
         var = m.group(1)
-        val = os.environ.get(var)
-        if val is None:
-            raise KeyError(
-                f"yaml references ${{env:{var}}} but {var} is not set"
-            )
-        return val
-    return _ENV_RE.sub(repl, text)
+        raise KeyError(f"yaml {path} references ${{env:{var}}} but {var} is not set")
 
 
 def _resolve_path(p: str | Path, base_dir: Path) -> Path:

--- a/tests/ale_run/test_config_env_substitution.py
+++ b/tests/ale_run/test_config_env_substitution.py
@@ -1,0 +1,151 @@
+"""Env-substitution rules for the config loader.
+
+Regression guard: `${env:VAR}` refs live in the *documentation comments* of
+every shipped agent preset (`configs/agents/*.yaml`). Substitution runs over
+raw file text before parsing, so those comments must not be able to fail a
+load.
+"""
+from pathlib import Path
+
+import pytest
+
+from ale_run.orchestration.config_loader import load_experiment
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHIPPED_AGENT_CONFIGS = sorted((REPO_ROOT / "configs" / "agents").glob("*.yaml"))
+
+
+def _write_experiment(tmp_path: Path, agent: Path) -> Path:
+    # Same shape as tests/ale_run/test_auto_resume.py::_write_experiment.
+    (tmp_path / "environment.yaml").write_text(
+        "provider: static\nendpoint: http://127.0.0.1:5000\n",
+        encoding="utf-8",
+    )
+    experiment = tmp_path / "experiment.yaml"
+    experiment.write_text(
+        "name: env-substitution-test\n"
+        f"agent: {agent.as_posix()}\n"
+        "environment: environment.yaml\n"
+        "tasks:\n"
+        "  - path: demo/hello\n",
+        encoding="utf-8",
+    )
+    return experiment
+
+
+@pytest.mark.parametrize(
+    "agent_config", SHIPPED_AGENT_CONFIGS, ids=lambda p: p.stem
+)
+def test_shipped_agent_configs_load_with_no_env_set(tmp_path, agent_config):
+    """Every checked-in preset loads on a clean environment.
+
+    Nine presets document the custom-gateway hook with a commented
+    `api_key: ${env:...}` example. A commented ref is not a requirement.
+    """
+    spec = load_experiment(_write_experiment(tmp_path, agent_config))
+    assert spec.agents[0].config.get("api_key") is None
+
+
+def test_unset_ref_in_a_real_value_still_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("ALE_TEST_MISSING", raising=False)
+    agent = tmp_path / "agent.yaml"
+    agent.write_text(
+        "harness: dummy\nmodel: test\nconfig:\n  api_key: ${env:ALE_TEST_MISSING}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(KeyError, match="ALE_TEST_MISSING is not set"):
+        load_experiment(_write_experiment(tmp_path, agent))
+
+
+def test_set_ref_substitutes_and_preserves_yaml_typing(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALE_TEST_KEY", "sk-abc123")
+    monkeypatch.setenv("ALE_TEST_TURNS", "42")
+    agent = tmp_path / "agent.yaml"
+    agent.write_text(
+        "harness: dummy\nmodel: test\n"
+        "config:\n"
+        "  api_key: ${env:ALE_TEST_KEY}\n"
+        "  max_turns: ${env:ALE_TEST_TURNS}\n",
+        encoding="utf-8",
+    )
+    config = load_experiment(_write_experiment(tmp_path, agent)).agents[0].config
+    assert config["api_key"] == "sk-abc123"
+    assert config["max_turns"] == 42  # substituted before parse → still an int
+
+
+def test_hash_inside_a_quoted_scalar_survives(tmp_path, monkeypatch):
+    """A `#` in a quoted value is data, not a comment.
+
+    Pins the boundary against a future "just strip comments first" refactor,
+    which would truncate this value at the `#`.
+    """
+    monkeypatch.setenv("ALE_TEST_KEY", "sk-abc123")
+    agent = tmp_path / "agent.yaml"
+    agent.write_text(
+        "harness: dummy\nmodel: test\n"
+        'config:\n  note: "id #42 uses ${env:ALE_TEST_KEY} # not a comment"\n',
+        encoding="utf-8",
+    )
+    config = load_experiment(_write_experiment(tmp_path, agent)).agents[0].config
+    assert config["note"] == "id #42 uses sk-abc123 # not a comment"
+
+
+def test_hash_inside_a_block_scalar_survives(tmp_path, monkeypatch):
+    """Same boundary for a block scalar — the `prompt_suffix: |` shape."""
+    monkeypatch.setenv("ALE_TEST_KEY", "sk-abc123")
+    (tmp_path / "agent.yaml").write_text("harness: dummy\nmodel: test\n", encoding="utf-8")
+    (tmp_path / "environment.yaml").write_text(
+        "provider: static\nendpoint: http://127.0.0.1:5000\n", encoding="utf-8"
+    )
+    experiment = tmp_path / "experiment.yaml"
+    experiment.write_text(
+        "name: block-scalar-test\n"
+        "agent: agent.yaml\n"
+        "environment: environment.yaml\n"
+        "tasks:\n"
+        "  - path: demo/hello\n"
+        "prompt_suffix: |\n"
+        "  Write results to out.md # keep this hash\n"
+        "  Auth with ${env:ALE_TEST_KEY}\n",
+        encoding="utf-8",
+    )
+    spec = load_experiment(experiment)
+    assert "# keep this hash" in spec.prompt_suffix
+    assert "sk-abc123" in spec.prompt_suffix
+
+
+def test_ref_as_a_mapping_key_resolves(tmp_path, monkeypatch):
+    """`${env:VAR}` is legal in a key position, not just a value."""
+    monkeypatch.setenv("ALE_TEST_KEYNAME", "api_key")
+    agent = tmp_path / "agent.yaml"
+    agent.write_text(
+        "harness: dummy\nmodel: test\nconfig:\n  ${env:ALE_TEST_KEYNAME}: sk-from-key\n",
+        encoding="utf-8",
+    )
+    config = load_experiment(_write_experiment(tmp_path, agent)).agents[0].config
+    assert config["api_key"] == "sk-from-key"
+
+
+def test_unset_ref_as_a_mapping_key_still_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("ALE_TEST_KEYNAME", raising=False)
+    agent = tmp_path / "agent.yaml"
+    agent.write_text(
+        "harness: dummy\nmodel: test\nconfig:\n  ${env:ALE_TEST_KEYNAME}: v\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(KeyError, match="ALE_TEST_KEYNAME is not set"):
+        load_experiment(_write_experiment(tmp_path, agent))
+
+
+def test_commented_ref_does_not_leak_into_parsed_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALE_TEST_KEY", "sk-should-not-appear")
+    agent = tmp_path / "agent.yaml"
+    agent.write_text(
+        "harness: dummy\nmodel: test\n"
+        "config:\n"
+        "  # api_key: ${env:ALE_TEST_KEY}\n"
+        "  api_key: null\n",
+        encoding="utf-8",
+    )
+    config = load_experiment(_write_experiment(tmp_path, agent)).agents[0].config
+    assert config["api_key"] is None


### PR DESCRIPTION
### Summary

`_substitute_env()` expands `${env:VAR}` over the raw file text *before* the
YAML is parsed, and raises `KeyError` for any unset var. Comments are part of
that raw text, so a `${env:...}` written inside a **comment** becomes a hard
requirement.

9 of the 15 presets in `configs/agents/` document the custom-gateway hook with
exactly such a comment, so they fail to load on a clean checkout:

```
KeyError: 'yaml references ${env:SUPERNOVA_API_KEY} but SUPERNOVA_API_KEY is not set'
```

| preset | ref, in a comment | added by |
|---|---|---|
| `ale_claw.yaml` | `${env:SUPERNOVA_API_KEY}` | #53 |
| `claude_code.yaml`, `codex.yaml`, `droid.yaml`, `grok_cli.yaml`, `hermes.yaml`, `openclaw_cli.yaml`, `openhands_cli.yaml`, `terminus_2.yaml` | `${env:YOUR_KEY}` | #20 |

Neither var is referenced anywhere outside those comments, and neither is in
`secret/.env.example` — they are illustrative placeholders, not inputs.

Loading every shipped preset through `load_experiment()` on a clean env, before
and after this change:

```
before:   6 loaded,  9 failed, of 15 shipped presets
after:   15 loaded,  0 failed, of 15 shipped presets
```

### Fix

Substitution stays where it is — running it pre-parse is what preserves yaml
typing, so `max_turns: ${env:TURNS}` still parses as an `int`. What moves is
*enforcement*: `_substitute_env()` now leaves an unset ref in place, and the new
`_require_env_resolved()` raises if one survived into the **parsed** document,
where comments no longer exist.

The failure mode for a genuinely missing var is unchanged, apart from the
message now naming the offending file.

### Tests

`tests/ale_run/test_config_env_substitution.py`:

- every checked-in `configs/agents/*.yaml` loads with no env set — parametrized,
  so it also guards the next preset someone documents this way
- an unset ref in a real *value* still raises `KeyError`
- a set ref substitutes and keeps yaml typing (`int` stays `int`)
- a commented ref does not leak into the parsed config
- a `#` inside a quoted scalar, and inside a `prompt_suffix: |` block scalar,
  survives intact — those are data, not comments
- `${env:VAR}` in a *key* position resolves, and still raises when unset

The last two exist because the obvious alternative fixes break them: stripping
comments before substituting truncates any value containing `#`, and walking
only string values after the parse cannot substitute a key. Both are pinned.

Verified the new test fails without the fix (9 of the 15 parametrized cases).
`tests/ale_run/` is green — 142 passed. The full suite has 10 failures that are
identical with and without this patch (`/mnt/data/agenthle/...` fixtures that
aren't in the repo, plus some `tests/ale_claw` tool-list tests).

### Notes

- No behavior change for any config that loads today.
- Considered stripping comments before substituting — rejected, it needs a
  yaml-aware scanner to avoid mangling `#` inside quoted strings.
- Considered lowercasing the placeholders in the comments, since `_ENV_RE` only
  matches `[A-Z_][A-Z0-9_]*`. That fixes the nine files but leaves the trap
  armed for the tenth.

Found while bringing up the local QEMU provider on a workstation.
