### PR TITLE
Disable network for five offline tasks

### DIFF
--- a/tasks/computing_math/go_game_reconstruction_1/task_card.json
+++ b/tasks/computing_math/go_game_reconstruction_1/task_card.json
@@ -41,7 +41,10 @@
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free-ubuntu",
-    "timeout": 7200
+    "timeout": 7200,
+    "network": {
+      "mode": "off"
+    }
   },
   "taxonomy": {
     "domain_id": "14",

--- a/tasks/engineering/abb_irb6700_asset_to_urdf_instance_1/task_card.json
+++ b/tasks/engineering/abb_irb6700_asset_to_urdf_instance_1/task_card.json
@@ -68,7 +68,10 @@
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free-ubuntu",
-    "timeout": 7200
+    "timeout": 7200,
+    "network": {
+      "mode": "off"
+    }
   },
   "taxonomy": {
     "domain_id": "1",

--- a/tasks/health_medicine/wsi_tumor_localization_1/task_card.json
+++ b/tasks/health_medicine/wsi_tumor_localization_1/task_card.json
@@ -50,7 +50,10 @@
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free-ubuntu",
-    "timeout": 7200
+    "timeout": 7200,
+    "network": {
+      "mode": "off"
+    }
   },
   "taxonomy": {
     "domain_id": "4",

--- a/tasks/life_sciences/tms_marrow_cell_type_annotation_instance_1/task_card.json
+++ b/tasks/life_sciences/tms_marrow_cell_type_annotation_instance_1/task_card.json
@@ -59,7 +59,10 @@
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free-ubuntu",
-    "timeout": 7200
+    "timeout": 7200,
+    "network": {
+      "mode": "off"
+    }
   },
   "taxonomy": {
     "domain_id": "3",

--- a/tasks/physical_sciences/ketcher_smiles_reproduction/task_card.json
+++ b/tasks/physical_sciences/ketcher_smiles_reproduction/task_card.json
@@ -34,7 +34,10 @@
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free",
-    "timeout": 7200
+    "timeout": 7200,
+    "network": {
+      "mode": "off"
+    }
   },
   "taxonomy": {
     "domain_id": "2",


### PR DESCRIPTION
Set `vm.network.mode` to `off` for five tasks whose inputs and runtimes are fully staged:

- health_medicine/wsi_tumor_localization_1
- life_sciences/tms_marrow_cell_type_annotation_instance_1
- engineering/abb_irb6700_asset_to_urdf_instance_1
- physical_sciences/ketcher_smiles_reproduction
- computing_math/go_game_reconstruction_1

Validation: JSON parsing, exact field assertions, `git diff --check`, and the task-card finalization test suite (4 tests).