### PR TITLE
feat(agents): add DeepSeek Harness SDK deployer

### DIFF
--- a/ale_run/agents/deepseek_harness/README.md
+++ b/ale_run/agents/deepseek_harness/README.md
@@ -1,0 +1,35 @@
+# DeepSeek Harness
+
+This deployer uses DeepSeek Harness's official Python SDK and bundled JSON-RPC runtime. It does not start the Web UI. The SDK owns one unattended session, streams canonical session notifications to `transcript.jsonl`, and returns after the whole agent becomes idle.
+
+## Why the SDK entry is used
+
+Upstream exposes two headless paths. `dsh --profile headless "task"` is a one-shot CLI whose stdout contains only the final response. `deepseek-harness-sdk` is the automation API: it returns the finish reason and the root session's canonical events, while its notification stream also includes descendants. ALE uses the SDK because these events can be converted to trajectory messages, tool calls, tool results, token usage, errors, and subagent metadata without scraping the browser or compressed session storage.
+
+The version is pinned by `DeepSeekHarnessConfig.sdk_version`. Installation also brings in the exact same-version `deepseek-harness-runtime-bin` platform wheel, which contains a standalone executable and default Cordis composition. Node.js is not required.
+
+## Configuration and authentication
+
+| Field | Default | Purpose |
+|---|---|---|
+| `model` | `deepseek-v4-flash` | Model id passed in the SDK initialize request. |
+| `provider` | `deepseek-official` | Provider route. The bundled composition registers this route. |
+| `api_key` | `null` | Literal key. ALE keeps it out of gathered specs. |
+| `api_key_env` | `DEEPSEEK_API_KEY` | Executor environment variable read when `api_key` is null. |
+| `base_url` | `null` | Optional OpenAI-compatible API root exported as `DEEPSEEK_BASE_URL`. Null uses the official endpoint. |
+| `max_tokens` | `null` | Optional positive output-token cap for the root session and in-process descendants. |
+| `system_prompt` | `null` | Optional deployment persona. Null uses the bundled coding-agent default. |
+| `sdk_version` | `0.1.0rc6` | Exact PyPI SDK/runtime release installed in the sandbox. |
+
+The deployer removes ambient `DSH_CORDIS_CONFIG` and `DSH_RUNTIME_MODE` so an experiment always uses the pinned bundled runtime. Session storage is isolated under the episode work directory. Upstream telemetry is disabled.
+
+## Permissions
+
+The bundled SDK composition is intentionally unattended. It mounts local bash and filesystem tools directly and does not mount the interactive approval or sandbox-policy plugins used by the Web profile. ALE therefore exposes no approval or permission-mode config for this harness. The security boundary is the disposable ALE sandbox VM, equivalent to Claude Code's permission bypass and Codex's danger-full-access mode inside the same outer isolation.
+
+## Current limits
+
+- ALE support is Linux sandbox only. Upstream publishes manylinux x86-64 and arm64 runtime wheels, plus macOS arm64, but no Windows runtime wheel.
+- The bundled SDK runtime does not include `@deepseek-ai/dsh-mcp-client`, so it cannot load ALE's CUA MCP bridge. This deployer is suitable for code and terminal tasks, not GUI tasks.
+- The full npm headless profile does include the MCP client, but upstream currently projects non-text MCP results such as screenshots to placeholders in model-visible history. Adding the CUA server there would not provide reliable visual control.
+- The raw transcript retains root and descendant notifications. ALE's normalized trajectory currently projects the root session and records the descendant count; the complete child event streams remain available in `transcript.jsonl`.

--- a/ale_run/agents/deepseek_harness/__init__.py
+++ b/ale_run/agents/deepseek_harness/__init__.py
@@ -1,0 +1,6 @@
+"""DeepSeek Harness SDK deployer."""
+
+from .config import DeepSeekHarnessConfig
+from .deployer import DeepSeekHarnessDeployer
+
+__all__ = ["DeepSeekHarnessConfig", "DeepSeekHarnessDeployer"]

--- a/ale_run/agents/deepseek_harness/config.py
+++ b/ale_run/agents/deepseek_harness/config.py
@@ -1,0 +1,44 @@
+"""Configuration for the official DeepSeek Harness Python SDK deployer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass
+class DeepSeekHarnessConfig:
+    """Per-episode DeepSeek Harness settings."""
+
+    name: ClassVar[str] = "deepseek-harness"
+
+    model: str = "deepseek-v4-flash"
+    provider: str = "deepseek-official"
+
+    api_key: str | None = None
+    """Literal key, kept out of gathered specs. ``None`` reads ``api_key_env``."""
+
+    api_key_env: str = "DEEPSEEK_API_KEY"
+    base_url: str | None = None
+    """Optional OpenAI-compatible API root passed as ``DEEPSEEK_BASE_URL``."""
+
+    max_tokens: int | None = None
+    """Optional positive output-token cap for the root agent and its descendants."""
+
+    system_prompt: str | None = None
+    """Deployment persona. ``None`` uses the bundled runtime's coding-agent default."""
+
+    sdk_version: str = "0.1.0rc6"
+    """Pinned ``deepseek-harness-sdk`` and bundled runtime wheel version."""
+
+    def __post_init__(self) -> None:
+        if not self.model.strip():
+            raise ValueError("deepseek_harness: model must not be empty")
+        if not self.provider.strip():
+            raise ValueError("deepseek_harness: provider must not be empty")
+        if not self.api_key_env.strip():
+            raise ValueError("deepseek_harness: api_key_env must not be empty")
+        if self.max_tokens is not None and self.max_tokens <= 0:
+            raise ValueError("deepseek_harness: max_tokens must be positive")
+        if not self.sdk_version.strip():
+            raise ValueError("deepseek_harness: sdk_version must not be empty")

--- a/ale_run/agents/deepseek_harness/deployer.py
+++ b/ale_run/agents/deepseek_harness/deployer.py
@@ -1,0 +1,579 @@
+"""Run DeepSeek Harness's official automation SDK inside an ALE sandbox."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.metadata
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, ClassVar
+
+from ale_run.base_interface import (
+    AgentRunResult,
+    BaseAgentDeployer,
+    ContentPart,
+    ImageSource,
+    Observation,
+    StepMetrics,
+    ToolCall,
+    ToolResult,
+    TrajectoryBuilder,
+)
+
+from .config import DeepSeekHarnessConfig
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_S = 1.0
+_TERM_GRACE_S = 2.0
+_SDK_DISTRIBUTION = "deepseek-harness-sdk"
+_RUNTIME_DISTRIBUTION = "deepseek-harness-runtime-bin"
+
+
+def _installed_version(distribution: str) -> str | None:
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _bundled_runtime_path() -> Path | None:
+    try:
+        runtime = importlib.import_module("deepseek_harness_runtime")
+        path = Path(runtime.bundled_runtime_path())
+    except (ImportError, FileNotFoundError, OSError, AttributeError):
+        return None
+    return path if path.is_file() else None
+
+
+class DeepSeekHarnessDeployer(BaseAgentDeployer):
+    """Linux sandbox deployer for ``deepseek-harness-sdk``."""
+
+    default_executor: ClassVar[str] = "sandbox"
+    supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
+    hot_artifacts: ClassVar[tuple[str, ...]] = ("transcript.jsonl", "stderr.log")
+
+    @property
+    def version(self) -> str | None:
+        config: DeepSeekHarnessConfig = self.config  # type: ignore[assignment]
+        return config.sdk_version
+
+    async def install(self) -> None:
+        config: DeepSeekHarnessConfig = self.config  # type: ignore[assignment]
+        if not self.executor.sandbox.is_linux:
+            raise RuntimeError(
+                "deepseek_harness: the official bundled SDK runtime has no Windows wheel; "
+                "use a Linux task image"
+            )
+
+        installed = await asyncio.to_thread(_installed_version, _SDK_DISTRIBUTION)
+        installed_runtime = await asyncio.to_thread(
+            _installed_version,
+            _RUNTIME_DISTRIBUTION,
+        )
+        runtime_path = await asyncio.to_thread(_bundled_runtime_path)
+        if (
+            installed == config.sdk_version
+            and installed_runtime == config.sdk_version
+            and runtime_path is not None
+        ):
+            logger.info(
+                "deepseek_harness: SDK/runtime %s already installed (%s)",
+                installed,
+                runtime_path,
+            )
+            return
+
+        package = f"{_SDK_DISTRIBUTION}=={config.sdk_version}"
+        pip_probe = await asyncio.to_thread(
+            subprocess.run,
+            [sys.executable, "-m", "pip", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            stdin=subprocess.DEVNULL,
+        )
+        if pip_probe.returncode != 0:
+            ensurepip = await asyncio.to_thread(
+                subprocess.run,
+                [sys.executable, "-m", "ensurepip", "--upgrade"],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                stdin=subprocess.DEVNULL,
+            )
+            if ensurepip.returncode != 0:
+                raise RuntimeError(
+                    "deepseek_harness: could not bootstrap pip: "
+                    f"{(ensurepip.stderr or ensurepip.stdout or '')[-1000:]}"
+                )
+        argv = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--disable-pip-version-check",
+            "--upgrade",
+        ]
+        if installed == config.sdk_version:
+            argv.append("--force-reinstall")
+        argv.append(package)
+        logger.info(
+            "deepseek_harness: installing %s "
+            "(installed_sdk=%s installed_runtime=%s runtime_path=%s)",
+            package,
+            installed or "missing",
+            installed_runtime or "missing",
+            runtime_path or "missing",
+        )
+        process = await asyncio.to_thread(
+            subprocess.run,
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=1200,
+            stdin=subprocess.DEVNULL,
+        )
+        if process.returncode != 0:
+            raise RuntimeError(
+                "deepseek_harness: pip install failed "
+                f"(rc={process.returncode}, package={package}): "
+                f"{(process.stderr or process.stdout or '')[-1000:]}"
+            )
+
+        importlib.invalidate_caches()
+        sys.modules.pop("deepseek_harness_runtime", None)
+        installed = await asyncio.to_thread(_installed_version, _SDK_DISTRIBUTION)
+        installed_runtime = await asyncio.to_thread(
+            _installed_version,
+            _RUNTIME_DISTRIBUTION,
+        )
+        runtime_path = await asyncio.to_thread(_bundled_runtime_path)
+        if (
+            installed != config.sdk_version
+            or installed_runtime != config.sdk_version
+            or runtime_path is None
+        ):
+            raise RuntimeError(
+                "deepseek_harness: SDK installation verification failed "
+                f"(expected={config.sdk_version}, installed_sdk={installed}, "
+                f"installed_runtime={installed_runtime}, "
+                f"runtime_path={runtime_path or 'missing'})"
+            )
+
+    async def launch(self, prompt: str) -> AgentRunResult:
+        config: DeepSeekHarnessConfig = self.config  # type: ignore[assignment]
+        work_dir = Path(self.executor.work_dir)
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        prompt_file = work_dir / "prompt.txt"
+        transcript_file = work_dir / "transcript.jsonl"
+        stderr_file = work_dir / "stderr.log"
+        pid_file = work_dir / "deepseek-harness.pid"
+        session_root = work_dir / "sessions"
+        for path in (transcript_file, stderr_file, pid_file):
+            path.unlink(missing_ok=True)
+        prompt_file.write_text(prompt, encoding="utf-8")
+
+        argv = self._build_argv(
+            config,
+            prompt_file=prompt_file,
+            work_dir=work_dir,
+            session_root=session_root,
+        )
+        env = self._build_env(config, session_root=session_root)
+        started = time.monotonic()
+        with transcript_file.open("wb") as transcript, stderr_file.open("wb") as stderr:
+            process = await asyncio.to_thread(
+                subprocess.Popen,
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=transcript,
+                stderr=stderr,
+                env=env,
+                cwd=str(work_dir),
+                start_new_session=True,
+            )
+        pid_file.write_text(str(process.pid), encoding="ascii")
+        logger.info("deepseek_harness: spawned driver pid=%s", process.pid)
+
+        try:
+            while process.poll() is None:
+                await asyncio.sleep(_POLL_INTERVAL_S)
+        except asyncio.CancelledError:
+            self._signal_process_group(process, signal.SIGTERM)
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(process.wait),
+                    timeout=_TERM_GRACE_S,
+                )
+            except (TimeoutError, asyncio.CancelledError):
+                self._signal_process_group(process, signal.SIGKILL)
+                await asyncio.shield(asyncio.to_thread(process.wait))
+            raise
+
+        duration_s = time.monotonic() - started
+        status = "completed" if process.returncode == 0 else "failed"
+        error = None
+        if status == "failed":
+            error = self._diagnose_failure(
+                transcript_file=transcript_file,
+                stderr_file=stderr_file,
+                exit_code=process.returncode,
+            )
+        return AgentRunResult(
+            status=status,
+            pid=process.pid,
+            exit_code=process.returncode,
+            transcript_path=str(transcript_file),
+            stderr_path=str(stderr_file),
+            duration_s=duration_s,
+            error=error,
+        )
+
+    @staticmethod
+    def _signal_process_group(process: subprocess.Popen[bytes], sig: signal.Signals) -> None:
+        try:
+            os.killpg(process.pid, sig)
+        except ProcessLookupError:
+            pass
+
+    @staticmethod
+    def _build_argv(
+        config: DeepSeekHarnessConfig,
+        *,
+        prompt_file: Path,
+        work_dir: Path,
+        session_root: Path,
+    ) -> list[str]:
+        argv = [
+            sys.executable,
+            "-m",
+            "ale_run.agents.deepseek_harness.driver",
+            "--prompt-file",
+            str(prompt_file),
+            "--cwd",
+            str(work_dir),
+            "--session-root",
+            str(session_root),
+            "--provider",
+            config.provider,
+            "--model",
+            config.model,
+        ]
+        if config.max_tokens is not None:
+            argv.extend(["--max-tokens", str(config.max_tokens)])
+        return argv
+
+    def _build_env(
+        self,
+        config: DeepSeekHarnessConfig,
+        *,
+        session_root: Path,
+    ) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(self.executor.env or {})
+        api_key = config.api_key or env.get(config.api_key_env)
+        if not api_key:
+            raise RuntimeError(
+                "deepseek_harness: no API key configured; set config.api_key or "
+                f"{config.api_key_env}"
+            )
+
+        env["DEEPSEEK_API_KEY"] = api_key
+        if config.base_url is None:
+            env.pop("DEEPSEEK_BASE_URL", None)
+        else:
+            env["DEEPSEEK_BASE_URL"] = config.base_url
+
+        env["DSH_SESSION_ROOT"] = str(session_root)
+        env["DSH_TELEMETRY_DISABLED"] = "1"
+        env.pop("DSH_CORDIS_CONFIG", None)
+        env.pop("DSH_RUNTIME_MODE", None)
+        if config.system_prompt is None:
+            env.pop("DSH_SYSTEM_PROMPT", None)
+        else:
+            env["DSH_SYSTEM_PROMPT"] = config.system_prompt
+        env["NO_COLOR"] = "1"
+        return env
+
+    @classmethod
+    def parse_artifacts(
+        cls,
+        *,
+        work_dir: Path,
+        config: DeepSeekHarnessConfig,
+        run_result: AgentRunResult,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        transcript_file = work_dir / "transcript.jsonl"
+        records = list(cls._json_lines(transcript_file))
+        if not records:
+            builder.add_step(
+                source="system",
+                message=f"deepseek_harness: no transcript at {transcript_file}",
+                extra={"reason": "no_transcript"},
+            )
+            return
+
+        result = next(
+            (record for record in reversed(records) if record.get("type") == "result"),
+            {},
+        )
+        root_session_id = result.get("session_id")
+        if not isinstance(root_session_id, str):
+            root_session_id = cls._first_session_id(records)
+
+        notification_count = 0
+        subagent_count = 0
+        for record in records:
+            record_type = record.get("type")
+            if record_type == "driver_error":
+                builder.add_step(
+                    source="system",
+                    message=str(
+                        record.get("message") or record.get("error_type") or "driver error"
+                    ),
+                    extra={
+                        "deepseek_harness_error": True,
+                        "error_type": record.get("error_type"),
+                    },
+                )
+                continue
+            if record_type != "notification":
+                continue
+            notification_count += 1
+            method = record.get("method")
+            params = record.get("params")
+            if method == "subagent.started":
+                subagent_count += 1
+                continue
+            if method != "session.event" or not isinstance(params, dict):
+                continue
+            if root_session_id is not None and params.get("sessionId") != root_session_id:
+                continue
+            event = params.get("event")
+            if isinstance(event, dict):
+                cls._consume_session_event(event, builder)
+
+        builder.trajectory.extra.setdefault("deepseek_harness", {}).update(
+            {
+                "exit_code": run_result.exit_code,
+                "transcript_path": str(transcript_file),
+                "stderr_path": run_result.stderr_path,
+                "session_id": root_session_id,
+                "finish_reason": result.get("finish_reason"),
+                "notification_count": notification_count,
+                "subagent_count": subagent_count,
+                "runtime": "python-sdk-bundled-jsonrpc",
+            }
+        )
+
+    @classmethod
+    def _consume_session_event(
+        cls,
+        event: dict[str, Any],
+        builder: TrajectoryBuilder,
+    ) -> None:
+        event_type = event.get("type")
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return
+
+        if event_type == "assistant/message":
+            message = data.get("message")
+            owner = message if isinstance(message, dict) else data
+            content = owner.get("content")
+            text: list[str] = []
+            reasoning: list[str] = []
+            tool_calls: list[ToolCall] = []
+            for block in content if isinstance(content, list) else []:
+                if not isinstance(block, dict):
+                    continue
+                block_type = block.get("type")
+                if block_type == "text" and isinstance(block.get("text"), str):
+                    text.append(block["text"])
+                elif block_type == "reasoning" and isinstance(block.get("text"), str):
+                    reasoning.append(block["text"])
+                elif block_type == "tool-call":
+                    tool_calls.append(
+                        ToolCall(
+                            id=str(block.get("id") or ""),
+                            name=str(block.get("name") or ""),
+                            arguments=cls._tool_arguments(block.get("arguments")),
+                        )
+                    )
+
+            usage = data.get("usage")
+            metrics = None
+            extra: dict[str, Any] = {
+                "turn": data.get("turn"),
+                "step": data.get("step"),
+                "event_seq": event.get("seq"),
+            }
+            if isinstance(usage, dict):
+                metrics = StepMetrics(
+                    input_tokens=cls._integer_or_none(usage.get("inputTokens")),
+                    output_tokens=cls._integer_or_none(usage.get("outputTokens")),
+                    cache_read_tokens=cls._integer_or_none(usage.get("cacheReadTokens")),
+                    cache_creation_tokens=cls._integer_or_none(usage.get("cacheWriteTokens")),
+                )
+                extra["usage"] = usage
+            if text or reasoning or tool_calls or metrics is not None:
+                builder.add_step(
+                    source="agent",
+                    message="".join(text) or None,
+                    reasoning="".join(reasoning) or None,
+                    tool_calls=tool_calls,
+                    metrics=metrics,
+                    extra=extra,
+                )
+            return
+
+        if event_type == "tool/result":
+            message = data.get("message")
+            content = message.get("content") if isinstance(message, dict) else None
+            results: list[ToolResult] = []
+            for block in content if isinstance(content, list) else []:
+                if not isinstance(block, dict) or block.get("type") != "tool-result":
+                    continue
+                results.append(
+                    ToolResult(
+                        tool_call_id=str(block.get("toolCallId") or ""),
+                        content=cls._content_parts(block.get("content")),
+                        is_error=bool(block.get("isError")),
+                    )
+                )
+            if results:
+                builder.add_step(
+                    source="environment",
+                    observation=Observation(results=results),
+                    extra={
+                        "turn": data.get("turn"),
+                        "step": data.get("step"),
+                        "event_seq": event.get("seq"),
+                    },
+                )
+            return
+
+        if event_type == "turn/end":
+            reason = data.get("reason")
+            if not isinstance(reason, dict) or reason.get("kind") != "error":
+                return
+            error = reason.get("error")
+            error_data = error if isinstance(error, dict) else {}
+            builder.add_step(
+                source="system",
+                message=str(error_data.get("message") or "DeepSeek Harness turn failed"),
+                extra={
+                    "deepseek_harness_error": True,
+                    "code": error_data.get("code"),
+                    "turn": data.get("turn"),
+                    "event_seq": event.get("seq"),
+                },
+            )
+
+    @staticmethod
+    def _first_session_id(records: list[dict[str, Any]]) -> str | None:
+        for record in records:
+            params = record.get("params")
+            if (
+                record.get("type") == "notification"
+                and record.get("method") == "session.event"
+                and isinstance(params, dict)
+                and isinstance(params.get("sessionId"), str)
+            ):
+                return params["sessionId"]
+        return None
+
+    @staticmethod
+    def _tool_arguments(raw: Any) -> dict[str, Any]:
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError:
+                return {"raw": raw}
+            return decoded if isinstance(decoded, dict) else {"value": decoded}
+        return {"value": raw}
+
+    @classmethod
+    def _content_parts(cls, content: Any) -> list[ContentPart]:
+        if not isinstance(content, list):
+            return [ContentPart(type="text", text=str(content))]
+        parts: list[ContentPart] = []
+        for block in content:
+            if not isinstance(block, dict):
+                parts.append(ContentPart(type="text", text=str(block)))
+                continue
+            if block.get("type") == "text":
+                parts.append(ContentPart(type="text", text=str(block.get("text") or "")))
+            elif block.get("type") == "image" and isinstance(block.get("data"), str):
+                parts.append(
+                    ContentPart(
+                        type="image",
+                        image=ImageSource(
+                            type="base64",
+                            data=block["data"],
+                            media_type=str(block.get("mimeType") or "image/png"),
+                        ),
+                    )
+                )
+            else:
+                parts.append(ContentPart(type="text", text=json.dumps(block, ensure_ascii=False)))
+        return parts
+
+    @staticmethod
+    def _integer_or_none(value: Any) -> int | None:
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    @staticmethod
+    def _json_lines(path: Path):
+        try:
+            handle = path.open(encoding="utf-8", errors="replace")
+        except (FileNotFoundError, OSError):
+            return
+        with handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict):
+                    yield record
+
+    @staticmethod
+    def _diagnose_failure(
+        *,
+        transcript_file: Path,
+        stderr_file: Path,
+        exit_code: int | None,
+    ) -> str:
+        transcript = (
+            transcript_file.read_text(encoding="utf-8", errors="replace")
+            if transcript_file.exists()
+            else ""
+        )
+        stderr = (
+            stderr_file.read_text(encoding="utf-8", errors="replace")
+            if stderr_file.exists()
+            else ""
+        )
+        parts = [
+            f"deepseek_harness failed (rc={exit_code})",
+            f"stderr={len(stderr)}B transcript={len(transcript)}B",
+        ]
+        if stderr.strip():
+            parts.append(f"stderr tail: ...{stderr[-1000:]}")
+        if transcript.strip():
+            parts.append(f"transcript tail: ...{transcript[-1000:]}")
+        return " | ".join(parts)

--- a/ale_run/agents/deepseek_harness/driver.py
+++ b/ale_run/agents/deepseek_harness/driver.py
@@ -1,0 +1,79 @@
+"""One-shot subprocess driver for the synchronous DeepSeek Harness SDK."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+
+def _emit(record: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt-file", required=True)
+    parser.add_argument("--cwd", required=True)
+    parser.add_argument("--session-root", required=True)
+    parser.add_argument("--provider", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--max-tokens", type=int)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one SDK turn and stream every notification as JSONL."""
+    args = _parser().parse_args(argv)
+    try:
+        from deepseek_harness import DeepSeekHarness
+
+        prompt = Path(args.prompt_file).read_text(encoding="utf-8")
+
+        def on_notification(notification: Any) -> None:
+            _emit(
+                {
+                    "type": "notification",
+                    "method": notification.method,
+                    "params": notification.payload,
+                }
+            )
+
+        with DeepSeekHarness(
+            provider=args.provider,
+            model=args.model,
+            max_tokens=args.max_tokens,
+            cwd=args.cwd,
+            runtime_cwd=args.cwd,
+            session_root=args.session_root,
+            shutdown_timeout_seconds=2.0,
+        ) as harness:
+            result = harness.run(prompt, on_notification=on_notification)
+
+        _emit(
+            {
+                "type": "result",
+                "session_id": result.session_id,
+                "final_response": result.final_response,
+                "finish_reason": result.finish_reason,
+            }
+        )
+        return 1 if result.finish_reason == "error" else 0
+    except Exception as exc:  # noqa: BLE001 - subprocess boundary serializes failures
+        _emit(
+            {
+                "type": "driver_error",
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            }
+        )
+        traceback.print_exc(file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ale_run/agents/deepseek_harness/pyproject.toml
+++ b/ale_run/agents/deepseek_harness/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "ale-deepseek-harness"
+version = "0.1.0"
+description = "DeepSeek Harness SDK in-sandbox deployer for ALE."
+requires-python = ">=3.12,<3.14"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = []
+sources = {}
+bypass-selection = true

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -34,6 +34,7 @@ _AGENT_FQNS: dict[str, str] = {
     "ale_claw": "ale_run.agents.ale_claw.deployer.AleClawDeployer",
     "gemini_cli": "ale_run.agents.gemini_cli.deployer.GeminiCliDeployer",
     "grok_build": "ale_run.agents.grok_build.deployer.GrokBuildDeployer",
+    "deepseek_harness": "ale_run.agents.deepseek_harness.deployer.DeepSeekHarnessDeployer",
     "grok_cli": "ale_run.agents.grok_cli.deployer.GrokCliDeployer",
     "cursor_cli": "ale_run.agents.cursor_cli.deployer.CursorCliDeployer",
     "droid": "ale_run.agents.droid.deployer.DroidDeployer",

--- a/configs/agents/deepseek_harness.yaml
+++ b/configs/agents/deepseek_harness.yaml
@@ -1,0 +1,23 @@
+# deepseek_harness - official Python SDK + bundled JSON-RPC runtime.
+# Linux sandbox only. This runtime is unattended and has direct bash/filesystem
+# access inside the disposable ALE VM; it does not support CUA MCP or GUI tasks.
+# Auth: export DEEPSEEK_API_KEY before launching the experiment.
+
+harness: deepseek_harness
+model: deepseek-v4-flash
+
+config:
+  provider: deepseek-official
+  api_key_env: DEEPSEEK_API_KEY
+
+  # Optional OpenAI-compatible DeepSeek endpoint. null uses the official API.
+  base_url: null
+
+  # Optional positive output-token cap. null uses the provider default.
+  max_tokens: null
+
+  # null uses the bundled runtime's default: "You are a coding agent."
+  system_prompt: null
+
+  # Official PyPI SDK. It installs the exact same-version bundled runtime wheel.
+  sdk_version: 0.1.0rc6

--- a/docs/ale-docs-site/pages/agents.html
+++ b/docs/ale-docs-site/pages/agents.html
@@ -56,6 +56,14 @@
       click. It is the natural fit for harnesses that are already command-line
       tools, like Claude Code or Codex.
     </p>
+    <div class="note">
+      <div class="note-title">Harness-specific tool support</div>
+      An in-sandbox runtime is not automatically a CUA. The current
+      <a href="https://github.com/rdi-berkeley/agents-last-exam/tree/main/ale_run/agents/deepseek_harness">DeepSeek Harness deployer</a>
+      uses upstream's bundled automation runtime, which has no MCP client. It is
+      Linux-only and supports code and terminal tasks, but not GUI tasks. See the
+      deployer README for the upstream runtime and image-result limitations.
+    </div>
 
     <h3>Out-of-sandbox</h3>
     <p>

--- a/tests/ale_run/test_deepseek_harness.py
+++ b/tests/ale_run/test_deepseek_harness.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+from dataclasses import fields
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Self
+
+import pytest
+
+from ale_run.agents.deepseek_harness import driver
+from ale_run.agents.deepseek_harness.config import DeepSeekHarnessConfig
+from ale_run.agents.deepseek_harness.deployer import DeepSeekHarnessDeployer
+from ale_run.base_interface import AgentRunResult, TrajectoryBuilder
+from ale_run.orchestration.factory import AGENT_REGISTRY
+
+
+def _executor(tmp_path: Path, config: DeepSeekHarnessConfig) -> SimpleNamespace:
+    return SimpleNamespace(
+        config=config,
+        env={config.api_key_env: "test-key"},
+        work_dir=str(tmp_path),
+        sandbox=SimpleNamespace(is_linux=True),
+    )
+
+
+def _builder() -> TrajectoryBuilder:
+    return TrajectoryBuilder(
+        agent_name="deepseek-harness",
+        model="deepseek-v4-flash",
+        task_path="demo/code-task",
+        variant_index=0,
+    )
+
+
+def test_deepseek_harness_is_registered() -> None:
+    assert AGENT_REGISTRY["deepseek_harness"] is DeepSeekHarnessDeployer
+
+
+def test_config_defaults_match_bundled_runtime() -> None:
+    config = DeepSeekHarnessConfig()
+
+    assert config.model == "deepseek-v4-flash"
+    assert config.provider == "deepseek-official"
+    assert config.sdk_version == "0.1.0rc6"
+
+
+def test_unattended_permissions_are_not_public_config_fields() -> None:
+    config_fields = {field.name for field in fields(DeepSeekHarnessConfig)}
+
+    assert config_fields.isdisjoint({"approval_policy", "permission_mode", "sandbox_mode", "yolo"})
+
+
+@pytest.mark.parametrize("max_tokens", [0, -1])
+def test_config_rejects_nonpositive_max_tokens(max_tokens: int) -> None:
+    with pytest.raises(ValueError, match="max_tokens must be positive"):
+        DeepSeekHarnessConfig(max_tokens=max_tokens)
+
+
+def test_build_env_isolates_runtime_and_maps_credentials(tmp_path: Path) -> None:
+    config = DeepSeekHarnessConfig(
+        api_key_env="CUSTOM_DEEPSEEK_KEY",
+        base_url="https://gateway.example/v1",
+        system_prompt="Work autonomously.",
+    )
+    executor = _executor(tmp_path, config)
+    executor.env.update(
+        {
+            "DSH_CORDIS_CONFIG": "/untrusted/ambient.yml",
+            "DSH_RUNTIME_MODE": "node",
+        }
+    )
+    deployer = DeepSeekHarnessDeployer(executor)
+
+    env = deployer._build_env(config, session_root=tmp_path / "sessions")
+
+    assert env["DEEPSEEK_API_KEY"] == "test-key"
+    assert env["DEEPSEEK_BASE_URL"] == "https://gateway.example/v1"
+    assert env["DSH_SYSTEM_PROMPT"] == "Work autonomously."
+    assert env["DSH_SESSION_ROOT"] == str(tmp_path / "sessions")
+    assert env["DSH_TELEMETRY_DISABLED"] == "1"
+    assert "DSH_CORDIS_CONFIG" not in env
+    assert "DSH_RUNTIME_MODE" not in env
+
+
+def test_build_env_requires_key_and_clears_ambient_endpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = DeepSeekHarnessConfig(api_key_env="ABSENT_DEEPSEEK_KEY")
+    executor = _executor(tmp_path, config)
+    executor.env = {}
+    deployer = DeepSeekHarnessDeployer(executor)
+    monkeypatch.setenv("DEEPSEEK_BASE_URL", "https://ambient.invalid/v1")
+    monkeypatch.delenv("ABSENT_DEEPSEEK_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="no API key configured"):
+        deployer._build_env(config, session_root=tmp_path / "sessions")
+
+    executor.env["ABSENT_DEEPSEEK_KEY"] = "key"
+    env = deployer._build_env(config, session_root=tmp_path / "sessions")
+    assert "DEEPSEEK_BASE_URL" not in env
+
+
+def test_build_argv_uses_driver_without_putting_key_on_command_line(tmp_path: Path) -> None:
+    config = DeepSeekHarnessConfig(api_key="secret", max_tokens=8192)
+
+    argv = DeepSeekHarnessDeployer._build_argv(
+        config,
+        prompt_file=tmp_path / "prompt.txt",
+        work_dir=tmp_path,
+        session_root=tmp_path / "sessions",
+    )
+
+    assert argv[:3] == [
+        sys.executable,
+        "-m",
+        "ale_run.agents.deepseek_harness.driver",
+    ]
+    assert argv[-2:] == ["--max-tokens", "8192"]
+    assert "secret" not in argv
+
+
+@pytest.mark.asyncio
+async def test_install_bootstraps_pip_and_verifies_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = DeepSeekHarnessConfig()
+    deployer = DeepSeekHarnessDeployer(_executor(tmp_path, config))
+    runtime = tmp_path / "dsh-jsonrpc-agent"
+    runtime.write_text("runtime", encoding="utf-8")
+    versions = iter([None, None, config.sdk_version, config.sdk_version])
+    runtimes = iter([None, runtime])
+    calls: list[list[str]] = []
+    results = iter(
+        [
+            subprocess.CompletedProcess([], 1, "", "pip missing"),
+            subprocess.CompletedProcess([], 0, "pip installed", ""),
+            subprocess.CompletedProcess([], 0, "sdk installed", ""),
+        ]
+    )
+
+    monkeypatch.setattr(
+        "ale_run.agents.deepseek_harness.deployer._installed_version",
+        lambda _distribution: next(versions),
+    )
+    monkeypatch.setattr(
+        "ale_run.agents.deepseek_harness.deployer._bundled_runtime_path",
+        lambda: next(runtimes),
+    )
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return next(results)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    await deployer.install()
+
+    assert calls[0][-2:] == ["pip", "--version"]
+    assert calls[1][-2:] == ["ensurepip", "--upgrade"]
+    assert calls[2][-1] == "deepseek-harness-sdk==0.1.0rc6"
+
+
+@pytest.mark.asyncio
+async def test_install_rejects_windows_before_package_install(tmp_path: Path) -> None:
+    config = DeepSeekHarnessConfig()
+    executor = _executor(tmp_path, config)
+    executor.sandbox.is_linux = False
+
+    with pytest.raises(RuntimeError, match="no Windows wheel"):
+        await DeepSeekHarnessDeployer(executor).install()
+
+
+def test_parse_canonical_session_events(tmp_path: Path) -> None:
+    session_id = "session-root"
+    records = [
+        {
+            "type": "notification",
+            "method": "session.event",
+            "params": {
+                "sessionId": session_id,
+                "event": {
+                    "type": "assistant/message",
+                    "seq": 10,
+                    "data": {
+                        "turn": 1,
+                        "step": 1,
+                        "message": {
+                            "content": [
+                                {"type": "reasoning", "text": "Inspect files."},
+                                {
+                                    "type": "tool-call",
+                                    "id": "call-1",
+                                    "name": "bash",
+                                    "arguments": json.dumps({"command": "pwd"}),
+                                },
+                            ]
+                        },
+                        "usage": {
+                            "inputTokens": 20,
+                            "outputTokens": 5,
+                            "cacheReadTokens": 3,
+                            "cacheWriteTokens": 2,
+                            "reasoningTokens": 4,
+                        },
+                    },
+                },
+            },
+        },
+        {
+            "type": "notification",
+            "method": "session.event",
+            "params": {
+                "sessionId": session_id,
+                "event": {
+                    "type": "tool/result",
+                    "seq": 12,
+                    "data": {
+                        "turn": 1,
+                        "step": 1,
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool-result",
+                                    "toolCallId": "call-1",
+                                    "content": [{"type": "text", "text": "/workspace"}],
+                                    "isError": False,
+                                }
+                            ]
+                        },
+                    },
+                },
+            },
+        },
+        {
+            "type": "notification",
+            "method": "subagent.started",
+            "params": {
+                "parentSessionId": session_id,
+                "childSessionId": "session-child",
+            },
+        },
+        {
+            "type": "notification",
+            "method": "session.event",
+            "params": {
+                "sessionId": "session-child",
+                "event": {
+                    "type": "assistant/message",
+                    "data": {"content": [{"type": "text", "text": "child only"}]},
+                },
+            },
+        },
+        {
+            "type": "notification",
+            "method": "session.event",
+            "params": {
+                "sessionId": session_id,
+                "event": {
+                    "type": "assistant/message",
+                    "seq": 20,
+                    "data": {
+                        "turn": 1,
+                        "step": 2,
+                        "message": {"content": [{"type": "text", "text": "Done."}]},
+                        "usage": {"inputTokens": 30, "outputTokens": 6},
+                    },
+                },
+            },
+        },
+        {
+            "type": "result",
+            "session_id": session_id,
+            "final_response": "Done.",
+            "finish_reason": "completed",
+        },
+    ]
+    (tmp_path / "transcript.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    DeepSeekHarnessDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=DeepSeekHarnessConfig(),
+        run_result=AgentRunResult(
+            status="completed",
+            exit_code=0,
+            stderr_path=str(tmp_path / "stderr.log"),
+        ),
+        builder=builder,
+    )
+    trajectory = builder.finalize(reward=1.0)
+
+    tool_step, result_step, final_step = trajectory.steps
+    assert tool_step.reasoning == "Inspect files."
+    assert tool_step.tool_calls[0].name == "bash"
+    assert tool_step.tool_calls[0].arguments == {"command": "pwd"}
+    assert tool_step.metrics.input_tokens == 20
+    assert tool_step.metrics.cache_read_tokens == 3
+    assert tool_step.metrics.cache_creation_tokens == 2
+    assert result_step.observation.results[0].content[0].text == "/workspace"
+    assert final_step.message == "Done."
+    assert trajectory.final_metrics.total_input_tokens == 50
+    assert trajectory.final_metrics.total_output_tokens == 11
+    assert trajectory.extra["deepseek_harness"]["session_id"] == session_id
+    assert trajectory.extra["deepseek_harness"]["subagent_count"] == 1
+    assert "child only" not in [step.message for step in trajectory.steps]
+
+
+def test_parse_turn_error_and_missing_transcript(tmp_path: Path) -> None:
+    (tmp_path / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "notification",
+                "method": "session.event",
+                "params": {
+                    "sessionId": "failed-session",
+                    "event": {
+                        "type": "turn/end",
+                        "seq": 4,
+                        "data": {
+                            "turn": 1,
+                            "reason": {
+                                "kind": "error",
+                                "error": {
+                                    "message": "credential rejected",
+                                    "code": "INVALID_CREDENTIAL",
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    builder = _builder()
+
+    DeepSeekHarnessDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=DeepSeekHarnessConfig(),
+        run_result=AgentRunResult(status="failed", exit_code=1),
+        builder=builder,
+    )
+
+    assert builder.trajectory.steps[0].message == "credential rejected"
+    assert builder.trajectory.steps[0].extra["code"] == "INVALID_CREDENTIAL"
+
+    (tmp_path / "transcript.jsonl").unlink()
+    missing_builder = _builder()
+    DeepSeekHarnessDeployer.parse_artifacts(
+        work_dir=tmp_path,
+        config=DeepSeekHarnessConfig(),
+        run_result=AgentRunResult(status="failed", exit_code=1),
+        builder=missing_builder,
+    )
+    assert missing_builder.trajectory.steps[0].extra["reason"] == "no_transcript"
+
+
+def test_driver_streams_notifications_and_terminal_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("finish the task", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    class FakeHarness:
+        def __init__(self, **kwargs: object) -> None:
+            captured["kwargs"] = kwargs
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def run(self, prompt: str, *, on_notification: object) -> SimpleNamespace:
+            captured["prompt"] = prompt
+            on_notification(
+                SimpleNamespace(
+                    method="session.event",
+                    payload={"sessionId": "s1", "event": {"type": "turn/start"}},
+                )
+            )
+            return SimpleNamespace(
+                session_id="s1",
+                final_response="ok",
+                finish_reason="completed",
+            )
+
+    module = ModuleType("deepseek_harness")
+    module.DeepSeekHarness = FakeHarness
+    monkeypatch.setitem(sys.modules, "deepseek_harness", module)
+
+    exit_code = driver.main(
+        [
+            "--prompt-file",
+            str(prompt_file),
+            "--cwd",
+            str(tmp_path),
+            "--session-root",
+            str(tmp_path / "sessions"),
+            "--provider",
+            "deepseek-official",
+            "--model",
+            "deepseek-v4-flash",
+        ]
+    )
+
+    output = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert exit_code == 0
+    assert captured["prompt"] == "finish the task"
+    assert output[0]["method"] == "session.event"
+    assert output[-1] == {
+        "type": "result",
+        "session_id": "s1",
+        "final_response": "ok",
+        "finish_reason": "completed",
+    }
+
+
+def test_signal_process_group_targets_driver_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(os, "killpg", lambda pid, sig: calls.append((pid, sig)))
+
+    DeepSeekHarnessDeployer._signal_process_group(
+        SimpleNamespace(pid=1234),
+        signal.SIGTERM,
+    )
+
+    assert calls == [(1234, signal.SIGTERM)]


### PR DESCRIPTION
## Summary

- add a Linux sandbox deployer for DeepSeek Harness through its official Python automation SDK and bundled JSON-RPC runtime
- install and verify the exact SDK/runtime version, isolate credentials and session state, stream canonical notifications, and reap the full runtime process group on cancellation
- normalize root-session messages, reasoning, tool calls/results, cache-aware token usage, and errors into ALE trajectories while retaining raw descendant notifications
- add the agent config, registry entry, documentation, and focused tests

## Integration decision

The Web UI is not required for automation. Upstream now exposes both a [one-shot headless CLI](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/architecture/headless.md) and an [official Python SDK](https://github.com/deepseek-ai/deepseek-harness/blob/master/python/sdk/README.md). This integration uses the SDK because its canonical event stream is substantially richer than the CLI's final-response-only stdout.

The bundled SDK composition is deliberately unattended: it mounts local bash and filesystem tools without the Web profile's interactive approval or sandbox-policy plugins. ALE's disposable sandbox VM is therefore the permission boundary, and the deployer does not expose a misleading approval mode.

Current scope is code and terminal tasks, not GUI tasks. The bundled SDK runtime has no MCP client. The full npm headless profile does have one, but its [MCP client currently projects non-text results such as screenshots to placeholders](https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/mcp/mcp-client/README.md), which is insufficient for reliable CUA visual feedback. Upstream's runtime wheels are also Linux/macOS only, so ALE support is intentionally Linux-only.

## Configuration

- model and provider route
- API key by literal secret field or configurable environment variable
- optional OpenAI-compatible base URL
- optional output-token cap and system prompt
- exact SDK/runtime version pin

## Validation

- `uv run ruff check ale_run/agents/deepseek_harness tests/ale_run/test_deepseek_harness.py`
- `uv run ruff format --check ale_run/agents/deepseek_harness tests/ale_run/test_deepseek_harness.py`
- `uv run pytest tests/ale_run/test_deepseek_harness.py` (14 passed)
- initialized the official `0.1.0rc6` SDK against its bundled runtime and verified the runtime executable/version
- exercised the full ALE deployer -> driver -> bundled JSON-RPC runtime -> mock OpenAI-compatible SSE endpoint -> trajectory parser path

The repository-wide Ruff check remains red on the current base with 2,096 pre-existing findings; the new module and tests are clean.
