### PR TITLE
fix(tasks): harden RGI MCR-1 scorer and paths

### DIFF
--- a/tasks/life_sciences/rgi_mcr1_colistin_v2/main.py
+++ b/tasks/life_sciences/rgi_mcr1_colistin_v2/main.py
@@ -58,7 +58,6 @@ DOMAIN_NAME = "life_sciences"
 TASK_NAME = "rgi_mcr1_colistin_v2"
 TASK_ID = f"{DOMAIN_NAME}/{TASK_NAME}"
 VARIANT_NAME = "base"
-VISIBLE_TASK_NAME = "amr_contig_annotation_instance_1"
 CANONICAL_OUTPUT_DIR_NAMES = {
     "output",
     "output_test_pos",
@@ -88,18 +87,6 @@ class RgiMcr1ColistinV2Config(LinuxTaskConfig):
     VARIANT_NAME: str = VARIANT_NAME
 
     @property
-    def data_task_dir(self) -> str:
-        return f"{self.REMOTE_ROOT_DIR}/{self.DOMAIN_NAME}/{TASK_NAME}/{self.VARIANT_NAME}"
-
-    @property
-    def task_dir(self) -> str:
-        return f"{self.REMOTE_ROOT_DIR}/{self.DOMAIN_NAME}/{VISIBLE_TASK_NAME}/{self.VARIANT_NAME}"
-
-    @property
-    def reference_dir(self) -> str:
-        return f"{self.data_task_dir}/reference"
-
-    @property
     def eval_dir(self) -> str:
         return f"{self.data_task_dir}/eval_data"
 
@@ -109,9 +96,7 @@ class RgiMcr1ColistinV2Config(LinuxTaskConfig):
 
     @property
     def remote_output_dir(self) -> str:
-        if self.output_dir_name == "output":
-            return f"{self.task_dir}/{self.output_dir_name}"
-        return f"{self.data_task_dir}/{self.output_dir_name}"
+        return f"{self.task_dir}/{self.output_dir_name}"
 
     @property
     def input_fasta(self) -> str:
@@ -225,26 +210,17 @@ def load():
 @cb.setup_task(split="train")
 async def start(task_cfg, session: cb.DesktopSession):
     await _setup(task_cfg, session)
-    # Materialize the agent-visible output directory. The runner stages input/
-    # straight to the visible amr_contig_annotation_instance_1 workspace, but only
-    # mkdir's the *canonical* rgi_mcr1_colistin_v2 output dir, never the visible one
-    # the prompt and grader use (remote_output_dir). The BaseTaskSetup migration
-    # dropped the original `makedirs(remote_output_dir)` here as a presumed no-op —
-    # it is not: without it the visible output/ never exists, so the agent cannot
-    # write answer.json at the path it is told to use and evaluate() hard-fails on
-    # file_exists.
-    await session.interface.create_dir(task_cfg.metadata["remote_output_dir"])
 
 
 @cb.evaluate_task(split="train")
 async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
     meta = task_cfg.metadata
 
-    if not (await session.file_exists(meta["answer_file"]) or await session.directory_exists(meta["answer_file"])):
+    if not await session.file_exists(meta["answer_file"]):
         logger.error("agent missing output: %s", meta["answer_file"])
         return [0.0]
 
-    if not (await session.file_exists(meta["verification_targets_file"]) or await session.directory_exists(meta["verification_targets_file"])):
+    if not await session.file_exists(meta["verification_targets_file"]):
         raise RuntimeError(
             f"evaluator-controlled reference missing: {meta['verification_targets_file']}"
         )

--- a/tasks/life_sciences/rgi_mcr1_colistin_v2/scripts/score_output.py
+++ b/tasks/life_sciences/rgi_mcr1_colistin_v2/scripts/score_output.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-SPECIFIC_MCR_PATTERN = re.compile(r"\bMCR-[A-Z0-9]", re.IGNORECASE)
+MAX_IDENTITY_TOLERANCE = 0.05
+CRITICAL_FAILURE_SCORE_CAP = 0.5
 
 
 @dataclass
@@ -28,10 +28,12 @@ class ScoreResult:
     reported_identity: float | None
     reference_identity: float | None
     reported_drug_class: str | None
-    required_drug_keyword: str
+    reference_drug_class: str
     reported_resistance_mechanism: str | None
-    required_resistance_mechanism_keyword: str
+    reference_resistance_mechanism: str
+    identity_tolerance: float
     pass_threshold: float
+    critical_fields_match: bool
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -48,20 +50,22 @@ def _coerce_json_object(raw_text: str, *, label: str) -> dict[str, Any]:
 
 
 def _coerce_float(value: Any) -> float:
-    if isinstance(value, bool):
-        raise ValueError("booleans are not valid numeric values")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("value must be a JSON number")
     parsed = float(value)
     if not math.isfinite(parsed):
         raise ValueError("numeric value must be finite")
     return parsed
 
 
-def _stringify(value: Any) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, list):
-        return "; ".join(str(item) for item in value)
-    return str(value)
+def _normalize_text(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def _reference_text(value: Any, *, label: str) -> tuple[str, str]:
+    if not isinstance(value, str) or not _normalize_text(value):
+        raise ValueError(f"{label} must be a non-empty string")
+    return value, _normalize_text(value)
 
 
 def score_output_payloads(*, output_json_text: str, reference_json_text: str) -> ScoreResult:
@@ -82,44 +86,63 @@ def score_output_payloads(*, output_json_text: str, reference_json_text: str) ->
         label="resistance_mechanism",
     )
 
-    reference_gene = _stringify(gene_cfg.get("reference_value"))
-    gene_prefix = str(gene_cfg["full_credit_prefix"]).strip().upper()
-    partial_gene_hint = str(gene_cfg["partial_credit_contains"]).strip().lower()
+    reference_gene, normalized_reference_gene = _reference_text(
+        gene_cfg.get("reference_value"), label="gene_name.reference_value"
+    )
 
     reference_identity = _coerce_float(identity_cfg["target"])
-    full_credit_tolerance = _coerce_float(identity_cfg["full_credit_tolerance"])
-    partial_credit_tolerance = _coerce_float(identity_cfg["partial_credit_tolerance"])
+    configured_identity_tolerance = _coerce_float(identity_cfg["full_credit_tolerance"])
+    if configured_identity_tolerance < 0:
+        raise ValueError("percent_identity.full_credit_tolerance must be non-negative")
+    identity_tolerance = min(configured_identity_tolerance, MAX_IDENTITY_TOLERANCE)
 
-    reference_drug_class = _stringify(drug_cfg.get("reference_value"))
-    required_drug_keyword = str(drug_cfg["required_keyword"]).strip().lower()
+    reference_drug_class, normalized_reference_drug_class = _reference_text(
+        drug_cfg.get("reference_value"), label="drug_class.reference_value"
+    )
 
-    reference_mechanism = _stringify(mechanism_cfg.get("reference_value"))
-    required_mechanism_keyword = str(mechanism_cfg["required_keyword"]).strip().lower()
+    reference_mechanism, normalized_reference_mechanism = _reference_text(
+        mechanism_cfg.get("reference_value"),
+        label="resistance_mechanism.reference_value",
+    )
 
     pass_threshold = _coerce_float(score_mapping["pass_threshold"])
+    if not 0.0 <= pass_threshold <= 1.0:
+        raise ValueError("score_mapping.pass_threshold must be between 0 and 1")
 
-    try:
-        output = _coerce_json_object(output_json_text, label="output_json")
-    except ValueError as exc:
+    def invalid_result(
+        reason: str,
+        *,
+        reported_gene: str | None = None,
+        gene_score: float = 0.0,
+        reported_drug_class: str | None = None,
+        reported_mechanism: str | None = None,
+    ) -> ScoreResult:
         return ScoreResult(
             score=0.0,
             passed=False,
             valid=False,
-            reason=str(exc),
-            gene_score=0.0,
+            reason=reason,
+            gene_score=gene_score,
             identity_score=0.0,
             drug_class_score=0.0,
             resistance_mechanism_score=0.0,
-            reported_gene=None,
+            reported_gene=reported_gene,
             reference_gene=reference_gene,
             reported_identity=None,
             reference_identity=reference_identity,
-            reported_drug_class=None,
-            required_drug_keyword=required_drug_keyword,
-            reported_resistance_mechanism=None,
-            required_resistance_mechanism_keyword=required_mechanism_keyword,
+            reported_drug_class=reported_drug_class,
+            reference_drug_class=reference_drug_class,
+            reported_resistance_mechanism=reported_mechanism,
+            reference_resistance_mechanism=reference_mechanism,
+            identity_tolerance=identity_tolerance,
             pass_threshold=pass_threshold,
+            critical_fields_match=False,
         )
+
+    try:
+        output = _coerce_json_object(output_json_text, label="output_json")
+    except ValueError as exc:
+        return invalid_result(str(exc))
 
     required_keys = (
         "best_hit_aro",
@@ -129,88 +152,48 @@ def score_output_payloads(*, output_json_text: str, reference_json_text: str) ->
     )
     missing_keys = [key for key in required_keys if key not in output]
     if missing_keys:
-        return ScoreResult(
-            score=0.0,
-            passed=False,
-            valid=False,
-            reason="missing required keys: " + ", ".join(missing_keys),
-            gene_score=0.0,
-            identity_score=0.0,
-            drug_class_score=0.0,
-            resistance_mechanism_score=0.0,
-            reported_gene=None,
-            reference_gene=reference_gene,
-            reported_identity=None,
-            reference_identity=reference_identity,
-            reported_drug_class=None,
-            required_drug_keyword=required_drug_keyword,
-            reported_resistance_mechanism=None,
-            required_resistance_mechanism_keyword=required_mechanism_keyword,
-            pass_threshold=pass_threshold,
-        )
+        return invalid_result("missing required keys: " + ", ".join(missing_keys))
 
-    reported_gene = _stringify(output.get("best_hit_aro"))
-    reported_gene_stripped = (reported_gene or "").strip()
-    reported_gene_normalized = reported_gene_stripped.upper()
-    reported_gene_lower = reported_gene_stripped.lower()
-    if SPECIFIC_MCR_PATTERN.search(reported_gene_stripped):
-        gene_score = 1.0
-    elif partial_gene_hint and partial_gene_hint in reported_gene_lower:
-        gene_score = 0.5
-    else:
-        gene_score = 0.0
+    text_fields = ("best_hit_aro", "drug_class", "resistance_mechanism")
+    invalid_text_fields = [key for key in text_fields if not isinstance(output[key], str)]
+    if invalid_text_fields:
+        return invalid_result("fields must be strings: " + ", ".join(invalid_text_fields))
+
+    reported_gene = output["best_hit_aro"]
+    gene_score = float(_normalize_text(reported_gene) == normalized_reference_gene)
 
     try:
         reported_identity = _coerce_float(output.get("percent_identity"))
     except (TypeError, ValueError) as exc:
-        return ScoreResult(
-            score=0.0,
-            passed=False,
-            valid=False,
-            reason=f"percent_identity is not numeric: {exc}",
-            gene_score=gene_score,
-            identity_score=0.0,
-            drug_class_score=0.0,
-            resistance_mechanism_score=0.0,
+        return invalid_result(
+            f"percent_identity is not numeric: {exc}",
             reported_gene=reported_gene,
-            reference_gene=reference_gene,
-            reported_identity=None,
-            reference_identity=reference_identity,
-            reported_drug_class=_stringify(output.get("drug_class")),
-            required_drug_keyword=required_drug_keyword,
-            reported_resistance_mechanism=_stringify(output.get("resistance_mechanism")),
-            required_resistance_mechanism_keyword=required_mechanism_keyword,
-            pass_threshold=pass_threshold,
+            gene_score=gene_score,
+            reported_drug_class=output["drug_class"],
+            reported_mechanism=output["resistance_mechanism"],
         )
 
     absolute_error = abs(reported_identity - reference_identity)
-    if absolute_error <= full_credit_tolerance:
-        identity_score = 1.0
-    elif absolute_error <= partial_credit_tolerance:
-        identity_score = 0.5
-    else:
-        identity_score = 0.0
+    identity_score = float(absolute_error <= identity_tolerance)
 
-    reported_drug_class = _stringify(output.get("drug_class"))
-    drug_class_score = (
-        1.0 if required_drug_keyword in (reported_drug_class or "").strip().lower() else 0.0
+    reported_drug_class = output["drug_class"]
+    drug_class_score = float(
+        _normalize_text(reported_drug_class) == normalized_reference_drug_class
     )
 
-    reported_mechanism = _stringify(output.get("resistance_mechanism"))
-    resistance_mechanism_score = (
-        1.0
-        if required_mechanism_keyword in (reported_mechanism or "").strip().lower()
-        else 0.0
+    reported_mechanism = output["resistance_mechanism"]
+    resistance_mechanism_score = float(
+        _normalize_text(reported_mechanism) == normalized_reference_mechanism
     )
 
-    final_score = (
-        gene_score + identity_score + drug_class_score + resistance_mechanism_score
-    ) / 4.0
+    raw_score = (gene_score + identity_score + drug_class_score + resistance_mechanism_score) / 4.0
+    critical_fields_match = gene_score == 1.0 and identity_score == 1.0
+    final_score = raw_score if critical_fields_match else min(raw_score, CRITICAL_FAILURE_SCORE_CAP)
     return ScoreResult(
         score=final_score,
-        passed=final_score >= pass_threshold,
+        passed=critical_fields_match and final_score >= pass_threshold,
         valid=True,
-        reason="scored successfully",
+        reason=("scored successfully" if critical_fields_match else "critical field mismatch"),
         gene_score=gene_score,
         identity_score=identity_score,
         drug_class_score=drug_class_score,
@@ -220,10 +203,12 @@ def score_output_payloads(*, output_json_text: str, reference_json_text: str) ->
         reported_identity=reported_identity,
         reference_identity=reference_identity,
         reported_drug_class=reported_drug_class,
-        required_drug_keyword=required_drug_keyword,
+        reference_drug_class=reference_drug_class,
         reported_resistance_mechanism=reported_mechanism,
-        required_resistance_mechanism_keyword=required_mechanism_keyword,
+        reference_resistance_mechanism=reference_mechanism,
+        identity_tolerance=identity_tolerance,
         pass_threshold=pass_threshold,
+        critical_fields_match=critical_fields_match,
     )
 
 

--- a/tasks/life_sciences/rgi_mcr1_colistin_v2/task_card.json
+++ b/tasks/life_sciences/rgi_mcr1_colistin_v2/task_card.json
@@ -46,7 +46,7 @@
       "description": "Required output containing the best-hit ARO gene name, percent identity, drug class, and resistance mechanism."
     }
   ],
-  "evaluation": "Hard fails: missing or invalid `output/answer.json`, missing required keys, or non-numeric `percent_identity` score `0.0`.\n\nScoring compares the output against hidden evaluator metadata and averages four components:\n- gene name: `1.0` for a specific `MCR-*` hit, `0.5` for a generic phosphoethanolamine-transferase family string, otherwise `0.0`\n- percent identity: `1.0` within `+-0.5`, `0.5` within `+-2.0`, otherwise `0.0`\n- drug class: `1.0` if the reported text contains `peptide`\n- resistance mechanism: `1.0` if the reported text contains `target alteration`\n\nThe final score is the raw mean of those four components. Passing threshold: `>= 0.75`.",
+  "evaluation": "Hard fails: missing or invalid `output/answer.json`, missing required keys, non-string categorical fields, or a non-numeric/non-finite `percent_identity` score `0.0`.\n\nScoring compares the output against hidden evaluator metadata and averages four components. Text is normalized for case and whitespace; the best-hit ARO allele, drug class, and resistance mechanism must otherwise match their hidden reference values exactly. Percent identity must be within `+-0.05` of its hidden reference value. The best-hit ARO allele and percent identity are critical fields: if either is wrong, the final score is capped at `0.5`. Passing threshold: `>= 0.75`.",
   "vm": {
     "machineType": "c4-standard-4",
     "snapshot": "cpu-free-ubuntu",

--- a/tests/tasks/test_rgi_mcr1_colistin_v2.py
+++ b/tests/tasks/test_rgi_mcr1_colistin_v2.py
@@ -1,0 +1,124 @@
+"""Public regression coverage for the RGI MCR-1 task contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TASK_ROOT = REPO_ROOT / "tasks" / "life_sciences" / "rgi_mcr1_colistin_v2"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.path.insert(0, str(REPO_ROOT))
+SCORER = load_module("public_rgi_mcr1_scorer", TASK_ROOT / "scripts" / "score_output.py")
+TASK = load_module("public_rgi_mcr1_task", TASK_ROOT / "main.py")
+
+REFERENCE = json.dumps(
+    {
+        "score_mapping": {"pass_threshold": 0.75},
+        "grading": {
+            "gene_name": {
+                "reference_value": "ARO-X.7",
+                "full_credit_prefix": "ARO",
+                "partial_credit_contains": "transferase",
+            },
+            "percent_identity": {
+                "target": 88.5,
+                "full_credit_tolerance": 0.5,
+                "partial_credit_tolerance": 2.0,
+            },
+            "drug_class": {
+                "reference_value": "synthetic class alpha",
+                "required_keyword": "alpha",
+            },
+            "resistance_mechanism": {
+                "reference_value": "synthetic mechanism beta",
+                "required_keyword": "beta",
+            },
+        },
+    }
+)
+
+EXACT_ANSWER = {
+    "best_hit_aro": "ARO-X.7",
+    "percent_identity": 88.5,
+    "drug_class": "synthetic class alpha",
+    "resistance_mechanism": "synthetic mechanism beta",
+}
+
+
+def score(answer: dict[str, object]):
+    return SCORER.score_output_payloads(
+        output_json_text=json.dumps(answer),
+        reference_json_text=REFERENCE,
+    )
+
+
+def test_config_uses_canonical_task_path():
+    config = TASK.RgiMcr1ColistinV2Config(REMOTE_ROOT_DIR="/remote")
+    expected = "/remote/life_sciences/rgi_mcr1_colistin_v2/base"
+    assert config.task_dir == expected
+    assert config.data_task_dir == expected
+    assert config.remote_output_dir == f"{expected}/output"
+    assert "amr_contig_annotation_instance_1" not in config.task_description
+
+
+def test_exact_and_normalized_answers_pass():
+    exact = score(EXACT_ANSWER)
+    assert exact.score == 1.0
+    assert exact.passed
+
+    normalized = score(
+        {
+            **EXACT_ANSWER,
+            "best_hit_aro": " aro-x.7 ",
+            "drug_class": "SYNTHETIC   CLASS ALPHA",
+            "resistance_mechanism": "synthetic\tmechanism beta",
+        }
+    )
+    assert normalized.score == 1.0
+    assert normalized.passed
+
+
+def test_critical_fields_cannot_be_bypassed():
+    wrong_allele = score({**EXACT_ANSWER, "best_hit_aro": "ARO-X"})
+    assert wrong_allele.score == 0.5
+    assert not wrong_allele.passed
+
+    old_tolerance_only = score({**EXACT_ANSWER, "percent_identity": 88.56})
+    assert old_tolerance_only.identity_tolerance == 0.05
+    assert old_tolerance_only.score == 0.5
+    assert not old_tolerance_only.passed
+
+
+def test_substring_only_categorical_fields_receive_no_credit():
+    result = score(
+        {
+            **EXACT_ANSWER,
+            "drug_class": "synthetic class alpha plus another class",
+            "resistance_mechanism": "putative synthetic mechanism beta",
+        }
+    )
+    assert result.drug_class_score == 0.0
+    assert result.resistance_mechanism_score == 0.0
+    assert result.score == 0.5
+    assert not result.passed
+
+
+def test_invalid_candidate_is_a_safe_failure():
+    result = score({**EXACT_ANSWER, "percent_identity": "88.5"})
+    assert result.score == 0.0
+    assert not result.passed
+    assert not result.valid


### PR DESCRIPTION
Remove the visible-name path alias and use the canonical task path throughout. Tighten scoring to exact normalized hidden-reference matching with a critical gene and identity gate.

Validation: 5 targeted tests passed; ruff, formatting, compilation, JSON, and diff checks passed.