### PR TITLE
Fix Codex + GPT-5.6 CUA coordinate space

### DIFF
--- a/ale_run/agents/_assets/cua_mcp_server/README.md
+++ b/ale_run/agents/_assets/cua_mcp_server/README.md
@@ -13,10 +13,10 @@ control bridge injected alongside agents; the more general non-GUI surface
 
 ## Coordinate system
 
-All coordinates are **normalized to `[0, 1000]`** on both axes, independent of
-the VM's real resolution. The bridge queries the screen size once (cached) and
-converts to absolute pixels before calling the backend. `[0,0]` is top-left,
-`[1000,1000]` bottom-right.
+Coordinates are normalized to `[0, 1000]` by default, independent of the VM's
+real resolution. Set `CUA_COORDINATE_SPACE=pixel` for models that emit
+screenshot-pixel coordinates. The bridge schema advertises the selected space
+and converts normalized coordinates before calling the backend.
 
 ## Return values
 
@@ -58,14 +58,15 @@ page_up, page_down, f1-f12`, or any single character.
 | Tool | Parameters | Returns |
 |------|------------|---------|
 | `screenshot` | `save_path?: string` (absolute path on the VM) | text confirmation **+ image** block (base64 PNG). If `save_path` given, the parent dir is validated and the PNG is written there too. |
-| `cursor_position` | — | text: `Cursor at [x, y]` (normalized). |
+| `cursor_position` | — | text: `Cursor at [x, y]` in the configured coordinate space. |
 | `wait` | `duration: number` (seconds) | text: `Waited <d>s`. Client-side pause. |
 
 ## Local testing
 
 ```bash
 npm install
-CUA_SERVER_URL=http://<host>:5000 node src/index.js --test   # smoke test
+npm run test:unit                                            # unit tests
+CUA_SERVER_URL=http://<host>:5000 npm test                   # smoke test
 CUA_SERVER_URL=http://<host>:5000 node src/index.js           # start stdio server
 ```
 

--- a/ale_run/agents/_assets/cua_mcp_server/package.json
+++ b/ale_run/agents/_assets/cua_mcp_server/package.json
@@ -7,7 +7,8 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "node src/index.js --test"
+    "test": "node src/index.js --test",
+    "test:unit": "node --test test/*.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/ale_run/agents/_assets/cua_mcp_server/src/coordinate-space.js
+++ b/ale_run/agents/_assets/cua_mcp_server/src/coordinate-space.js
@@ -1,0 +1,39 @@
+const COORD_MAX = 1000;
+const VALID_SPACES = new Set(["normalized", "pixel"]);
+
+export function parseCoordinateSpace(value) {
+  const coordinateSpace = (value || "normalized").trim().toLowerCase();
+  if (!VALID_SPACES.has(coordinateSpace)) {
+    throw new Error(
+      `Invalid CUA_COORDINATE_SPACE=${JSON.stringify(coordinateSpace)}; ` +
+      'expected "normalized" or "pixel".'
+    );
+  }
+  return coordinateSpace;
+}
+
+export function coordinateDescription(coordinateSpace) {
+  return coordinateSpace === "pixel"
+    ? "(x, y) coordinates in screenshot pixels."
+    : "(x, y) coordinates normalized to [0, 1000].";
+}
+
+export function toAbsoluteCoordinate(coordinate, coordinateSpace, screen) {
+  if (coordinateSpace === "pixel") {
+    return { x: Math.round(coordinate[0]), y: Math.round(coordinate[1]) };
+  }
+  return {
+    x: Math.round((coordinate[0] / COORD_MAX) * screen.width),
+    y: Math.round((coordinate[1] / COORD_MAX) * screen.height),
+  };
+}
+
+export function fromAbsoluteCoordinate(absX, absY, coordinateSpace, screen) {
+  if (coordinateSpace === "pixel") {
+    return [Math.round(absX), Math.round(absY)];
+  }
+  return [
+    Math.round((absX / screen.width) * COORD_MAX),
+    Math.round((absY / screen.height) * COORD_MAX),
+  ];
+}

--- a/ale_run/agents/_assets/cua_mcp_server/src/index.js
+++ b/ale_run/agents/_assets/cua_mcp_server/src/index.js
@@ -3,10 +3,10 @@
  * CUA MCP Server — LiteDesktopActionSpace over MCP (stdio).
  *
  * Wraps CUA computer-server HTTP API into MCP tools aligned with
- * LiteDesktopActionSpace (normalized [0, 1000] coordinates).
+ * LiteDesktopActionSpace pointer actions.
  *
- * The MCP bridge converts normalized coordinates to absolute pixels
- * by querying screen size from the CUA server on first use, then caching.
+ * Pointer coordinates default to normalized [0, 1000]. Set
+ * CUA_COORDINATE_SPACE=pixel to use screenshot pixels instead.
  *
  * Runs on the VM, consumed by Claude Code / Codex via stdio transport.
  *
@@ -20,6 +20,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { CuaClient } from "./cua-client.js";
+import {
+  coordinateDescription,
+  fromAbsoluteCoordinate,
+  parseCoordinateSpace,
+  toAbsoluteCoordinate,
+} from "./coordinate-space.js";
 
 // Key normalization — maps LLM-style key names to CUA server pynput names.
 // CUA server's Windows handler has its own _key_from_string with .lower(),
@@ -91,10 +97,11 @@ const CUA_URL = process.env.CUA_SERVER_URL || "http://localhost:5000";
 const client = new CuaClient(CUA_URL);
 
 // ------------------------------------------------------------------
-// Coordinate conversion: normalized [0, 1000] → absolute pixels
+// Coordinate conversion
 // ------------------------------------------------------------------
 
-const COORD_MAX = 1000;
+const COORDINATE_SPACE = parseCoordinateSpace(process.env.CUA_COORDINATE_SPACE);
+const COORDINATE_DESCRIPTION = coordinateDescription(COORDINATE_SPACE);
 let _screenSize = null;
 
 async function getScreenSize() {
@@ -105,19 +112,19 @@ async function getScreenSize() {
 }
 
 async function toAbsolute(coordinate) {
+  if (COORDINATE_SPACE === "pixel") {
+    return toAbsoluteCoordinate(coordinate, COORDINATE_SPACE);
+  }
   const screen = await getScreenSize();
-  return {
-    x: Math.round((coordinate[0] / COORD_MAX) * screen.width),
-    y: Math.round((coordinate[1] / COORD_MAX) * screen.height),
-  };
+  return toAbsoluteCoordinate(coordinate, COORDINATE_SPACE, screen);
 }
 
 async function toNormalized(absX, absY) {
+  if (COORDINATE_SPACE === "pixel") {
+    return fromAbsoluteCoordinate(absX, absY, COORDINATE_SPACE);
+  }
   const screen = await getScreenSize();
-  return [
-    Math.round((absX / screen.width) * COORD_MAX),
-    Math.round((absY / screen.height) * COORD_MAX),
-  ];
+  return fromAbsoluteCoordinate(absX, absY, COORDINATE_SPACE, screen);
 }
 
 // ------------------------------------------------------------------
@@ -165,9 +172,8 @@ const server = new McpServer({
   version: "0.3.0",
 });
 
-// Zod schema for normalized [0, 1000] coordinate pair
 const zCoordinate = z.array(z.number()).length(2).describe(
-  "(x, y) coordinates normalized to [0, 1000]."
+  COORDINATE_DESCRIPTION
 );
 
 // ================================================================
@@ -275,7 +281,7 @@ server.tool(
   "click",
   "On a desktop, perform mouse click at specified coordinates.",
   {
-    coordinate: zCoordinate.optional().describe("(x, y) coordinates normalized to [0, 1000]."),
+    coordinate: zCoordinate.optional().describe(COORDINATE_DESCRIPTION),
     button: z.enum(["left", "right", "middle"]).default("left").describe("Mouse button to click."),
     clicks: z.union([z.literal(1), z.literal(2), z.literal(3)]).default(1).describe(
       "Number of clicks: 1=single, 2=double, 3=triple."
@@ -314,9 +320,9 @@ server.tool(
   "drag",
   "On a desktop, drag the mouse from start to end coordinates. Uses mouse_down + move_cursor + mouse_up for reliable cross-platform dragging.",
   {
-    coordinate: zCoordinate.describe("Ending (x, y) coordinates, normalized to [0, 1000]."),
+    coordinate: zCoordinate.describe(`Ending ${COORDINATE_DESCRIPTION}`),
     start_coordinate: z.array(z.number()).length(2).optional().describe(
-      "Starting (x, y) coordinates, normalized to [0, 1000]."
+      `Starting ${COORDINATE_DESCRIPTION}`
     ),
     button: z.enum(["left", "right", "middle"]).default("left").describe(
       "Mouse button to hold while dragging."
@@ -374,7 +380,7 @@ server.tool(
     direction: z.enum(["up", "down", "left", "right"]).describe("The direction to scroll."),
     amount: z.number().describe("Number of scroll units."),
     coordinate: zCoordinate.optional().describe(
-      "(x, y) coordinates. If provided, cursor moves here before scrolling."
+      `${COORDINATE_DESCRIPTION} If provided, cursor moves here before scrolling.`
     ),
   },
   async ({ direction, amount, coordinate }) => {
@@ -460,8 +466,8 @@ server.tool(
   async () => {
     const result = await client.sendCommand("get_cursor_position");
     const pos = result.position;
-    const norm = await toNormalized(pos.x, pos.y);
-    return textOnly(`Cursor at [${norm[0]}, ${norm[1]}]`);
+    const coordinate = await toNormalized(pos.x, pos.y);
+    return textOnly(`Cursor at [${coordinate[0]}, ${coordinate[1]}]`);
   }
 );
 
@@ -469,9 +475,8 @@ server.registerTool(
   "get_screen_size",
   {
     description:
-      "On a desktop, get the screen size in absolute pixels. Coordinates for the " +
-      "other tools are normalized to [0, 1000]; this reports the underlying pixel " +
-      "dimensions for callers that work in pixel space.",
+      "On a desktop, get the screen size in absolute pixels. Pointer tools use " +
+      `${COORDINATE_SPACE} coordinates.`,
     inputSchema: {},
     outputSchema: { width: z.number().int(), height: z.number().int() },
   },

--- a/ale_run/agents/_assets/cua_mcp_server/test/coordinate-space.test.js
+++ b/ale_run/agents/_assets/cua_mcp_server/test/coordinate-space.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  coordinateDescription,
+  fromAbsoluteCoordinate,
+  parseCoordinateSpace,
+  toAbsoluteCoordinate,
+} from "../src/coordinate-space.js";
+
+const SCREEN = { width: 1024, height: 768 };
+
+test("normalized remains the default coordinate space", () => {
+  assert.equal(parseCoordinateSpace(undefined), "normalized");
+  assert.deepEqual(
+    toAbsoluteCoordinate([500, 500], "normalized", SCREEN),
+    { x: 512, y: 384 }
+  );
+});
+
+test("pixel coordinates pass through without scaling", () => {
+  assert.equal(parseCoordinateSpace("PIXEL"), "pixel");
+  assert.deepEqual(
+    toAbsoluteCoordinate([688, 320], "pixel"),
+    { x: 688, y: 320 }
+  );
+  assert.deepEqual(
+    fromAbsoluteCoordinate(688, 320, "pixel"),
+    [688, 320]
+  );
+  assert.match(coordinateDescription("pixel"), /screenshot pixels/);
+});
+
+test("normalized cursor coordinates retain the existing contract", () => {
+  assert.deepEqual(
+    fromAbsoluteCoordinate(512, 384, "normalized", SCREEN),
+    [500, 500]
+  );
+});
+
+test("unknown coordinate spaces fail fast", () => {
+  assert.throws(() => parseCoordinateSpace("auto"), /expected.*normalized.*pixel/);
+});

--- a/ale_run/agents/codex/README.md
+++ b/ale_run/agents/codex/README.md
@@ -59,6 +59,7 @@ CUA MCP Server, stdio transport. Written to `~/.codex/config.toml`:
 type = "stdio"
 command = "/usr/local/bin/node"
 args = ["/home/user/cua_mcp_server/src/index.js"]
+env = { CUA_SERVER_URL = "http://127.0.0.1:5000", CUA_COORDINATE_SPACE = "pixel" }
 ```
 
 ## Config
@@ -70,6 +71,7 @@ Config fields (standalone dataclass):
 | `sandbox_mode` | str | `"danger-full-access"` | Codex sandbox policy |
 | `yolo` | bool | `true` | Bypass all approval prompts |
 | `reasoning_effort` | str | `"high"` | Model reasoning effort hint |
+| `coordinate_space` | str \| null | `null` | Pointer coordinates emitted by the model. Auto-detects Gemini as normalized and other models as pixels |
 | `codex_version` | str | `"0.114.0"` | NPM package version to install |
 | `patched_binary_url` | str | `""` | GitHub Release URL for patched Linux native binary (`codex`, musl x86-64) |
 | `patched_binary_url_windows` | str | `""` | GitHub Release URL for patched Windows binary (`codex.exe`, windows-msvc); used instead of `patched_binary_url` on Windows |

--- a/ale_run/agents/codex/config.py
+++ b/ale_run/agents/codex/config.py
@@ -105,6 +105,13 @@ class CodexConfig:
     # the Responses-API wire as ``reasoning.effort``.
     reasoning_effort: str = "high"
 
+    coordinate_space: str | None = None
+    """Coordinate space emitted for CUA pointer actions.
+
+    ``None`` infers ``"normalized"`` for Gemini-family models and ``"pixel"``
+    for other models. Set either value explicitly to override that inference.
+    """
+
     # NPM package version to install.
     codex_version: str = _DEFAULT_CODEX_VERSION
 
@@ -162,6 +169,12 @@ class CodexConfig:
     otel_enabled: bool = True
 
     def __post_init__(self) -> None:
+        if self.coordinate_space not in {None, "pixel", "normalized"}:
+            raise ValueError(
+                f"CodexConfig.coordinate_space={self.coordinate_space!r} "
+                "not in {pixel, normalized, None}"
+            )
+
         # Load the catalog host-side (build_config) and embed its content so it
         # reaches the in-sandbox deployer. On the in-sandbox reconstruction the
         # content kwarg is already populated → we skip the (host-only) file read.

--- a/ale_run/agents/codex/deployer.py
+++ b/ale_run/agents/codex/deployer.py
@@ -195,6 +195,14 @@ class CodexDeployer(BaseAgentDeployer):
         from ale_run.agents._bootstrap import ensure_cua_mcp_server
         await ensure_cua_mcp_server(sandbox)
 
+        # The ensure fast-path keeps prebaked bridges. Refresh the source so the
+        # Codex-specific coordinate contract is present on older images too.
+        bridge_source = (
+            Path(__file__).resolve().parents[1] / "_assets/cua_mcp_server/src"
+        )
+        bridge_target = Path(sandbox.mcp_server_dir) / "src"
+        shutil.copytree(bridge_source, bridge_target, dirs_exist_ok=True)
+
         # 5. Write MCP config (config.toml) for CUA bridge
         await self._write_codex_config(cfg)
 
@@ -389,17 +397,21 @@ class CodexDeployer(BaseAgentDeployer):
 
         config_toml = preamble + "\n"
 
+        coordinate_space = cfg.coordinate_space or (
+            "normalized" if "gemini" in cfg.model.lower() else "pixel"
+        )
+
         # MCP server config for CUA bridge. CUA_SERVER_URL points the bridge at
         # this image's cua-server port (it otherwise defaults to 5000, wrong on
-        # ale-kasm which runs on 8000). URL is host:port only — no backslashes,
-        # safe in a TOML basic string.
+        # ale-kasm which runs on 8000).
         cua_url = self.executor.cua_bridge_url()
         config_toml += (
             "[mcp_servers.cua]\n"
             'type = "stdio"\n'
             f'command = "{node_exe}"\n'
             f'args = ["{mcp_entry}"]\n'
-            f'env = {{ CUA_SERVER_URL = "{cua_url}" }}\n'
+            f'env = {{ CUA_SERVER_URL = "{cua_url}", '
+            f'CUA_COORDINATE_SPACE = "{coordinate_space}" }}\n'
         )
 
         # OpenRouter provider block

--- a/configs/agents/codex.yaml
+++ b/configs/agents/codex.yaml
@@ -45,6 +45,10 @@ config:
   # model_reasoning_effort → Responses-API reasoning.effort. off|low|medium|high.
   reasoning_effort: high
 
+  # Pointer coordinates emitted by the model. null auto-detects normalized for
+  # Gemini-family models and screenshot pixels for other models.
+  coordinate_space: null
+
   # npm package version to install (@openai/codex@<version>).
   codex_version: "0.114.0"
 

--- a/tests/ale_run/test_codex_coordinate_space.py
+++ b/tests/ale_run/test_codex_coordinate_space.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ale_run.agents.codex.config import CodexConfig
+from ale_run.agents.codex.deployer import CodexDeployer
+
+
+def _executor(tmp_path: Path, config: CodexConfig) -> SimpleNamespace:
+    return SimpleNamespace(
+        config=config,
+        work_dir=str(tmp_path),
+        sandbox=SimpleNamespace(
+            is_linux=True,
+            node="/usr/bin/node",
+            mcp_server_dir="/home/user/cua_mcp_server",
+        ),
+        cua_bridge_url=lambda: "http://127.0.0.1:5000",
+    )
+
+
+def _render_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    config: CodexConfig,
+) -> str:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    deployer = CodexDeployer(_executor(tmp_path, config))
+    asyncio.run(deployer._write_codex_config(config))
+    return (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("coordinate_space", ["pixel", "normalized"])
+def test_codex_writes_explicit_cua_coordinate_space(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    coordinate_space: str,
+) -> None:
+    rendered = _render_config(
+        tmp_path,
+        monkeypatch,
+        CodexConfig(provider="direct", coordinate_space=coordinate_space),
+    )
+    assert 'CUA_SERVER_URL = "http://127.0.0.1:5000"' in rendered
+    assert f'CUA_COORDINATE_SPACE = "{coordinate_space}"' in rendered
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("openai/gpt-5.6", "pixel"),
+        ("google/gemini-3.1-pro", "normalized"),
+    ],
+)
+def test_codex_infers_cua_coordinate_space_from_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    model: str,
+    expected: str,
+) -> None:
+    rendered = _render_config(
+        tmp_path,
+        monkeypatch,
+        CodexConfig(provider="direct", model=model),
+    )
+    assert f'CUA_COORDINATE_SPACE = "{expected}"' in rendered
+
+
+def test_codex_rejects_unknown_coordinate_space() -> None:
+    with pytest.raises(ValueError, match="coordinate_space"):
+        CodexConfig(coordinate_space="auto")


### PR DESCRIPTION
## Problem

Codex calls the CUA MCP server directly instead of going through AleClaw's Python computer handler. GPT-5.6 emits coordinates in screenshot pixels, but the bridge treated them as normalized `[0, 1000]` coordinates and scaled them again.

For example, `[688, 320]` on a `1024 × 768` screenshot was executed near `[704, 246]`. This caused missed clicks, repeated screenshots, and fallback to keyboard navigation.

## Change

- Add `CodexConfig.coordinate_space` with `null`, `pixel`, and `normalized` modes.
- Default Gemini-family models to `normalized`; default other models, including GPT-5.6, to `pixel`.
- Pass the selected mode to the CUA MCP server through `CUA_COORDINATE_SPACE`.
- Pass screenshot-pixel coordinates through unchanged in `pixel` mode and retain `[0, 1000]` conversion in `normalized` mode.
- Refresh the bridge entry used by Codex when the container image contains an older prebaked copy.

## Relation to PR #57

PR #57 introduced the same `coordinate_space` contract for AleClaw, but it fixed the opposite mismatch: Gemini emits normalized coordinates while AleClaw previously treated them as pixels. It converts Gemini's normalized coordinates to pixels at the AleClaw computer-handler boundary.

Codex does not pass through those AleClaw handlers, so PR #57 does not affect its direct CUA MCP path. In this PR, GPT-5.6 already emits screenshot pixels, but the bridge treated them as normalized and scaled them a second time. This change applies PR #57's configuration semantics to the Codex/MCP boundary and makes pixel coordinates pass through unchanged.

Both fixes follow the same rule: describe the coordinate space emitted by the model and convert exactly once at the model-to-execution boundary.

## Tests

- `npm run test:unit` — 4 passed
- `uv run pytest -q tests/ale_run/test_codex_coordinate_space.py tests/ale_run/test_codex_telemetry.py` — 9 passed
- `uv run ruff check ale_run/agents/codex/config.py tests/ale_run/test_codex_coordinate_space.py`
- `node --check` for both bridge source files

Fixes #75