### PR TITLE
fix(cua): use clipboard paste for reliable Unicode input

### DIFF
--- a/ale_run/agents/_assets/cua_mcp_server/README.md
+++ b/ale_run/agents/_assets/cua_mcp_server/README.md
@@ -11,6 +11,20 @@ control bridge injected alongside agents; the more general non-GUI surface
 - **Endpoint:** read from `CUA_SERVER_URL` (the executor injects this via
   `cua_bridge_env`), default `http://localhost:5000`
 
+## Text input
+
+The `type` tool keeps a single `{ text }` interface for agents. The bridge
+chooses the delivery path using `CUA_TEXT_INPUT_MODE`:
+
+- `auto` (default): ASCII uses CUA `type_text`; text containing non-ASCII
+  characters uses desktop clipboard paste.
+- `keystroke`: always use CUA `type_text`.
+- `clipboard`: always use clipboard paste.
+
+Clipboard mode avoids the temporary X11 keyboard mappings used by pynput for
+arbitrary Unicode, which can corrupt long CJK text. Linux and Windows paste
+with `Ctrl+V`; macOS uses `Cmd+V`.
+
 ## Coordinate system
 
 All coordinates are **normalized to `[0, 1000]`** on both axes, independent of
@@ -65,8 +79,9 @@ page_up, page_down, f1-f12`, or any single character.
 
 ```bash
 npm install
-CUA_SERVER_URL=http://<host>:5000 node src/index.js --test   # smoke test
-CUA_SERVER_URL=http://<host>:5000 node src/index.js           # start stdio server
+npm test                                                     # unit tests
+CUA_SERVER_URL=http://<host>:5000 npm run test:smoke          # CUA smoke test
+CUA_SERVER_URL=http://<host>:5000 node src/index.js            # start stdio server
 ```
 
 `node_modules` is not vendored — it is rebuilt on the substrate by

--- a/ale_run/agents/_assets/cua_mcp_server/package.json
+++ b/ale_run/agents/_assets/cua_mcp_server/package.json
@@ -7,7 +7,8 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "node src/index.js --test"
+    "test": "node --test test/*.test.js",
+    "test:smoke": "node src/index.js --test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/ale_run/agents/_assets/cua_mcp_server/src/index.js
+++ b/ale_run/agents/_assets/cua_mcp_server/src/index.js
@@ -20,6 +20,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { CuaClient } from "./cua-client.js";
+import {
+  parseTextInputMode,
+  typeTextReliably,
+} from "./text-input.js";
 
 // Key normalization — maps LLM-style key names to CUA server pynput names.
 // CUA server's Windows handler has its own _key_from_string with .lower(),
@@ -89,6 +93,7 @@ function normalizeKey(key) {
 
 const CUA_URL = process.env.CUA_SERVER_URL || "http://localhost:5000";
 const client = new CuaClient(CUA_URL);
+const TEXT_INPUT_MODE = parseTextInputMode(process.env.CUA_TEXT_INPUT_MODE);
 
 // ------------------------------------------------------------------
 // Coordinate conversion: normalized [0, 1000] → absolute pixels
@@ -228,7 +233,7 @@ server.tool(
     text: z.string().describe("The text content to type."),
   },
   async ({ text }) => {
-    await client.sendCommand("type_text", { text });
+    await typeTextReliably(client, text, { mode: TEXT_INPUT_MODE });
     const preview = text.length > 50 ? text.slice(0, 50) + "..." : text;
     return textOnly(`Typed: "${preview}"`);
   }

--- a/ale_run/agents/_assets/cua_mcp_server/src/text-input.js
+++ b/ale_run/agents/_assets/cua_mcp_server/src/text-input.js
@@ -1,0 +1,59 @@
+/**
+ * Reliable text entry policy for the CUA bridge.
+ *
+ * The legacy Linux CUA server implements `type_text` with pynput. Pynput can
+ * type ASCII directly, but arbitrary Unicode characters require temporary X11
+ * keyboard-map entries. Long Unicode strings can therefore arrive in apps with
+ * duplicated, missing, or reordered characters. Clipboard paste sends the
+ * Unicode string as one value and avoids that per-character remapping.
+ */
+
+const TEXT_INPUT_MODES = new Set(["auto", "keystroke", "clipboard"]);
+const NON_ASCII_RE = /[^\x00-\x7f]/u;
+
+/** Parse and validate the developer-controlled input policy. */
+export function parseTextInputMode(value) {
+  const mode = (value || "auto").trim().toLowerCase();
+  if (!TEXT_INPUT_MODES.has(mode)) {
+    throw new Error(
+      `Invalid CUA_TEXT_INPUT_MODE=${JSON.stringify(mode)}; ` +
+      'expected "auto", "keystroke", or "clipboard".'
+    );
+  }
+  return mode;
+}
+
+/** Return true when this call should use clipboard paste. */
+export function shouldPasteText(text, mode = "auto") {
+  if (mode === "clipboard") return true;
+  if (mode === "keystroke") return false;
+  return NON_ASCII_RE.test(text);
+}
+
+/** Resolve the platform paste shortcut used by the CUA server. */
+export function pasteKeys(platform = process.platform) {
+  return [platform === "darwin" ? "cmd" : "ctrl", "v"];
+}
+
+/**
+ * Enter text without exposing the transport choice to the agent.
+ *
+ * In auto mode, ASCII keeps the existing type_text behavior while any Unicode
+ * text is placed on the desktop clipboard and pasted into the focused field.
+ * We intentionally leave the clipboard populated: restoring it immediately
+ * can race with applications that consume the paste event asynchronously.
+ */
+export async function typeTextReliably(
+  client,
+  text,
+  { mode = "auto", platform = process.platform } = {}
+) {
+  if (shouldPasteText(text, mode)) {
+    await client.sendCommand("set_clipboard", { text });
+    await client.sendCommand("hotkey", { keys: pasteKeys(platform) });
+    return "clipboard";
+  }
+
+  await client.sendCommand("type_text", { text });
+  return "keystroke";
+}

--- a/ale_run/agents/_assets/cua_mcp_server/test/text-input.test.js
+++ b/ale_run/agents/_assets/cua_mcp_server/test/text-input.test.js
@@ -52,7 +52,7 @@ test("paste shortcut is platform-aware", () => {
 
 test("Unicode is copied and pasted without calling type_text", async () => {
   const client = recordingClient();
-  const text = "中文ABC，估值6–8亿美元🙂\n第二行";
+  const text = "中文ABC，🙂ALE2.0真棒！";
 
   const route = await typeTextReliably(client, text, {
     mode: "auto",

--- a/ale_run/agents/_assets/cua_mcp_server/test/text-input.test.js
+++ b/ale_run/agents/_assets/cua_mcp_server/test/text-input.test.js
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseTextInputMode,
+  pasteKeys,
+  shouldPasteText,
+  typeTextReliably,
+} from "../src/text-input.js";
+
+function recordingClient() {
+  const calls = [];
+  return {
+    calls,
+    async sendCommand(command, params) {
+      calls.push({ command, params });
+      return { success: true };
+    },
+  };
+}
+
+test("text input mode defaults to auto and is case-insensitive", () => {
+  assert.equal(parseTextInputMode(undefined), "auto");
+  assert.equal(parseTextInputMode(" Clipboard "), "clipboard");
+});
+
+test("text input mode rejects unknown values", () => {
+  assert.throws(
+    () => parseTextInputMode("unicode"),
+    /Invalid CUA_TEXT_INPUT_MODE/
+  );
+});
+
+test("auto mode uses keystrokes for ASCII and clipboard for Unicode", () => {
+  assert.equal(shouldPasteText("user@example.com", "auto"), false);
+  assert.equal(shouldPasteText("Valuation: $700M\n", "auto"), false);
+  assert.equal(shouldPasteText("估值为7亿美元", "auto"), true);
+  assert.equal(shouldPasteText("hello🙂", "auto"), true);
+  assert.equal(shouldPasteText("full-width，comma", "auto"), true);
+});
+
+test("explicit modes override text inspection", () => {
+  assert.equal(shouldPasteText("中文", "keystroke"), false);
+  assert.equal(shouldPasteText("ASCII", "clipboard"), true);
+});
+
+test("paste shortcut is platform-aware", () => {
+  assert.deepEqual(pasteKeys("linux"), ["ctrl", "v"]);
+  assert.deepEqual(pasteKeys("win32"), ["ctrl", "v"]);
+  assert.deepEqual(pasteKeys("darwin"), ["cmd", "v"]);
+});
+
+test("Unicode is copied and pasted without calling type_text", async () => {
+  const client = recordingClient();
+  const text = "中文ABC，估值6–8亿美元🙂\n第二行";
+
+  const route = await typeTextReliably(client, text, {
+    mode: "auto",
+    platform: "linux",
+  });
+
+  assert.equal(route, "clipboard");
+  assert.deepEqual(client.calls, [
+    { command: "set_clipboard", params: { text } },
+    { command: "hotkey", params: { keys: ["ctrl", "v"] } },
+  ]);
+});
+
+test("ASCII preserves the existing type_text path", async () => {
+  const client = recordingClient();
+  const text = "Valuation: $700M";
+
+  const route = await typeTextReliably(client, text, { mode: "auto" });
+
+  assert.equal(route, "keystroke");
+  assert.deepEqual(client.calls, [
+    { command: "type_text", params: { text } },
+  ]);
+});
+
+test("clipboard failure is surfaced and does not fall back to keystrokes", async () => {
+  const calls = [];
+  const client = {
+    async sendCommand(command, params) {
+      calls.push({ command, params });
+      throw new Error("clipboard unavailable");
+    },
+  };
+
+  await assert.rejects(
+    typeTextReliably(client, "中文", { mode: "auto" }),
+    /clipboard unavailable/
+  );
+  assert.deepEqual(calls, [
+    { command: "set_clipboard", params: { text: "中文" } },
+  ]);
+});

--- a/ale_run/agents/codex/deployer.py
+++ b/ale_run/agents/codex/deployer.py
@@ -195,6 +195,14 @@ class CodexDeployer(BaseAgentDeployer):
         from ale_run.agents._bootstrap import ensure_cua_mcp_server
         await ensure_cua_mcp_server(sandbox)
 
+        # The ensure fast-path keeps prebaked bridges. Refresh the source so
+        # the Unicode text-input policy is present on older images too.
+        bridge_source = (
+            Path(__file__).resolve().parents[1] / "_assets/cua_mcp_server/src"
+        )
+        bridge_target = Path(sandbox.mcp_server_dir) / "src"
+        shutil.copytree(bridge_source, bridge_target, dirs_exist_ok=True)
+
         # 5. Write MCP config (config.toml) for CUA bridge
         await self._write_codex_config(cfg)
 


### PR DESCRIPTION
## Problem

Typing Chinese text through CUA can produce garbled text in the target application. Characters may be duplicated, missing, substituted, or reordered, so an otherwise correct email or document can look corrupted or as if the model is stuttering.

The model is not generating the corrupted text. The `type` MCP tool receives the correct string, but on the Linux ALE image the CUA computer server sends it through pynput `Controller.type`. ASCII characters map directly, while arbitrary Unicode requires temporary X11 keyboard mappings. During long CJK input, those mappings can be reused before Chrome consumes the queued events, damaging the text that reaches the focused field.

The corruption therefore happens below the model and MCP JSON layers, between the CUA text-input implementation and the desktop application.

## Change

- Keep the agent-facing `type({ text })` interface unchanged.
- Add `CUA_TEXT_INPUT_MODE=auto|keystroke|clipboard`.
- In the default `auto` mode, preserve `type_text` for ASCII and use `set_clipboard` plus the platform paste shortcut for non-ASCII text.
- Use `Ctrl+V` on Linux and Windows and `Cmd+V` on macOS.
- Surface clipboard failures instead of silently falling back to the corruptible Unicode keystroke path.
- Refresh the bridge source in the Codex deployer so prebaked images receive the policy.
- Add Node unit tests and document the behavior.

The clipboard is intentionally not restored immediately because applications may consume paste events asynchronously.

## Validation

- `npm test`: 8 passed.
- `pytest -q tests/ale_run/test_codex*.py`: 4 passed.
- JavaScript syntax, Ruff, and `git diff --check`: passed.
- Real `agentslastexam/ale-ubuntu22-docker:latest` plus Chrome textarea test:
  - ASCII input selected the keystroke route and matched exactly.
  - `中文ABC，🙂ALE2.0真棒！` selected the clipboard route and matched exactly.
  - Forcing the old keystroke route reproduced the CJK duplication and substitution.