### PR TITLE
fix(docker): add init and UTF-8 locale to containers

### DIFF
--- a/ale_run/environments/providers/docker.py
+++ b/ale_run/environments/providers/docker.py
@@ -226,6 +226,9 @@ class DockerProvider(Provider):
             "-p", f"0:{cua_internal_port}",
             "-p", f"0:{_VNC_INTERNAL_PORT}",
             f"--shm-size={self._cfg.shm_size}",
+            "--init",
+            "-e", "LANG=C.UTF-8",
+            "-e", "LC_ALL=C.UTF-8",
             # Virtual display size for the in-container Xvfb (the entrypoint reads
             # this; falls back to its own default if unset).
             "-e", f"ALE_SCREEN_RESOLUTION={res[0]}x{res[1]}",


### PR DESCRIPTION
## Summary

- run ALE Docker sandboxes with `--init` so PID 1 forwards signals and reaps orphaned browser processes
- set `LANG` and `LC_ALL` to `C.UTF-8` for non-ASCII filesystem paths

## Problem

Browser tasks may open and close Chrome. Without a reaping PID 1, exited Chrome children can remain as zombies. This can also surface as unreliable relaunches or profile-lock symptoms when browser processes outlive the expected lifecycle. Docker's `--init` supplies a small init process that handles signal forwarding and child reaping.

The current Docker image otherwise starts with a POSIX locale. In that locale, Chrome's native file chooser can fail to select a filesystem path containing non-ASCII characters. For example, in an ALE task that uses Gmail to send `/tmp/ALE分数.md` as an attachment, selecting the file can leave the file input empty and issue no upload request. With `LANG=C.UTF-8` and `LC_ALL=C.UTF-8`, Chrome selects the exact filename and uploads it successfully.

## Validation

- command-construction smoke test confirmed `--init` appears exactly once and both UTF-8 variables are passed before the image reference
- `uv run ruff check --ignore I001,BLE001 ale_run/environments/providers/docker.py`
- manual Chrome file-chooser reproduction confirmed that a Markdown attachment with a non-ASCII filename is accepted under the UTF-8 locale

`origin/main` currently has unrelated import-order, broad-exception, and whole-file formatting findings in this file, so this PR intentionally leaves those lines unchanged.
