### PR TITLE
feat(agents): add Octavus Agent CLI harness

### DIFF
--- a/ale_run/agents/octavus_cli/README.md
+++ b/ale_run/agents/octavus_cli/README.md
@@ -1,0 +1,96 @@
+# Octavus Agent CLI
+
+An Octavus agent driven by the public `octoagent` CLI (`@octavus/agent`),
+deployed in `sandbox` environments.
+
+The agent under test is a cloud Octavus agent. The CLI runs on the ALE eval box
+and drives that machine's own desktop, filesystem, and shell; the brain (model,
+prompt, tools, workers, skills, memory) runs in the Octavus cloud. Only the
+computer is local, so the single credential the harness needs is the agent key.
+
+Official CLI docs: https://octavus.ai/docs/workforce-agents/cli
+
+## Architecture
+
+```
+FRAMEWORK                                 SANDBOX (ALE eval box)
+lifecycle.py                              cua-computer-server (:0 desktop)
+  install()   -> npm install -g @octavus/agent, install Chrome for Testing
+  launch()    -> octoagent run --json --workdir <task variant dir> "<prompt>"
+                   |                      (agent brain runs in the Octavus cloud;
+                   |                       the CLI drives the local computer)
+  parse_artifacts() <- octoagent.result.json  (threadId / threadUrl / status)
+                    <- thread read API         (transcript, usage/cost, model)
+```
+
+`launch()` spawns the CLI detached and polls it under the orchestration wall
+budget, so a run that exceeds the budget is reaped. `parse_artifacts()` runs
+host-side: it reads the single `--json` result off stdout, then reads the
+observable thread with the same agent key to attach the transcript, per-run cost,
+tokens, and effective model to the trajectory. Pure stdlib (subprocess / pathlib
+/ json / urllib) plus the shared node bootstrap; no Octavus-internal or admin
+surface.
+
+## Auth
+
+Set `OCTAVUS_AGENT_API_KEY` in `secret/.env` to the agent's `oct_agt_*` key,
+minted from the agent's Settings -> API tab. The agent's Computer must be set to
+"Your own machine (CLI)" in the dashboard. The key is named `api_key` in the
+config, so the framework carries it as a secret (into the sandbox via a read-once
+sidecar; never written to gathered host logs) and passes it to the run via the
+`OCTAVUS_API_KEY` env var, never argv.
+
+## Per-run overrides
+
+The stored agent already defines the model, prompt, tools, workers, skills, and
+memory. These `config:` keys optionally override, per run, without touching the
+stored agent (unset inherits the dashboard default):
+
+| Key | CLI flag | Notes |
+|---|---|---|
+| `model` (or top-level `model:`) | `--model` | Primary model, `provider/model-id`. |
+| `backup_model` | `--backup-model` | Backup model, `provider/model-id`. |
+| `capabilities` | `--capability slug=on\|off` | Per-capability toggle. A toggle only applies to a capability the agent's protocol declares; toggling an undeclared one is rejected (HTTP 400). |
+| `record` / `record_visibility` | `--record` / `--record-public` | Record the execution view to a shareable video. Gated to funded tiers; `public` yields a permanent URL. |
+
+A model override must resolve to a provider the org has a key for (project/org
+BYOK or platform default), otherwise the run is rejected at session creation.
+
+## Run it
+
+Reference the preset from an experiment (see `example_exp.yaml` for the shape):
+
+```yaml
+agents:
+  - configs/agents/octavus_cli.yaml
+environment: configs/environments/environment_gcloud.yaml
+tasks: selected_tasks/ale_cli.txt      # 105 cpu-free-ubuntu (Linux) tasks
+```
+
+```bash
+uv run python -m ale_run run <experiment>.yaml --dry-run   # preview units
+uv run python -m ale_run run <experiment>.yaml             # run
+```
+
+## Browser tasks
+
+Branded Chrome 137+ cannot load the automation extension (`--load-extension` was
+removed), the Chromium snap's confinement blocks it too, and the ALE images bake
+branded Google Chrome (which the CLI refuses). `install()` therefore installs
+Chrome for Testing via `@puppeteer/browsers` to `~/.octavus/browsers` - the exact
+location the CLI auto-detects (matching the public installer) - and also points
+the CLI at the binary with `--chrome-path`, so the browser tools come up during
+`computer-ensure-ready`. Set `chrome_path` to pin your own Chrome for Testing or
+Chromium instead. The display stack (Xvfb, AT-SPI + its python bindings, xdotool,
+scrot, Chrome libs) is best-effort `apt-get`ed at setup unless the box already has
+both the screenshot/automation tools and the AT-SPI2 python bindings that
+`computer-use__label` needs (checking only the former misses images that bake a
+desktop but omit `python3-gi`); set `install_prereqs: false` on an image that
+already bakes the full stack.
+
+`computer-use__label` runs an AT-SPI driver as `python3`, which must import the
+distro `python3-gi` bindings. Those live only in the system interpreter, so
+`launch()` pins the CLI's `PATH` to `/usr/bin` first: the ALE image otherwise
+prepends a gi-less uv venv (`/opt/cua-server/.venv`, Python 3.14) that a bare
+`python3` would resolve to, and labeling would fail with "AT-SPI2 not available"
+even though the bindings are installed for `/usr/bin/python3`.

--- a/ale_run/agents/octavus_cli/__init__.py
+++ b/ale_run/agents/octavus_cli/__init__.py
@@ -1,0 +1,6 @@
+"""Octavus Agent CLI in-VM deployer."""
+
+from .config import OctavusCliConfig
+from .deployer import OctavusCliDeployer
+
+__all__ = ["OctavusCliConfig", "OctavusCliDeployer"]

--- a/ale_run/agents/octavus_cli/config.py
+++ b/ale_run/agents/octavus_cli/config.py
@@ -1,0 +1,107 @@
+"""OctavusCliConfig: per-episode knobs for the Octavus Agent CLI deployer.
+
+The agent under test is one cloud Octavus agent, selected entirely by its
+``oct_agt_*`` key. The single credential is ``api_key`` (typically
+``api_key: ${env:OCTAVUS_AGENT_API_KEY}`` in the agent yaml, resolved host-side):
+the framework treats any field named ``api_key`` as a secret, so it travels into
+the sandbox via the read-once sidecar and never lands in gathered host logs.
+
+Everything else about the harness (prompt, tools, workers, skills, memory,
+model) lives in the agent's configuration on the Octavus platform. ``model`` /
+``backup_model`` / ``capabilities`` here are per-run overrides so one deployer
+can express many harness variants without touching the stored agent.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+
+@dataclass
+class OctavusCliConfig:
+    """Tunables for :class:`OctavusCliDeployer`.
+
+    Standalone config (no shared base). The episode wall-budget is
+    orchestration-owned; there is no agent-side ``timeout_s``.
+    """
+
+    name: ClassVar[str] = "octavus-cli"
+
+    # ---- platform target (the hosted Octavus platform, https://octavus.ai) ----
+    operator_url: str | None = None
+    """Optional operator WebSocket override (``--operator-url``). Normally
+    unset: the platform returns a reachable operator URL per run."""
+
+    api_key: str | None = None
+    """The agent ``oct_agt_*`` key. Passed to the run via ``OCTAVUS_API_KEY``
+    (kept out of argv). Set it as ``${env:OCTAVUS_AGENT_API_KEY}`` in the agent
+    yaml; the ``api_key`` name makes the framework carry it as a secret."""
+
+    # ---- per-run harness overrides (variants) ----
+    model: str | None = None
+    """Per-run primary model ``provider/model-id`` (``--model``). Also settable
+    as the agent-yaml ``model:`` sugar. ``None`` inherits the agent's default."""
+
+    backup_model: str | None = None
+    """Per-run backup model ``provider/model-id`` (``--backup-model``)."""
+
+    capabilities: dict[str, bool] = field(default_factory=dict)
+    """Per-run capability toggles (repeated ``--capability slug=on|off``), e.g.
+    ``{"memory": false}`` for an ablation. Unlisted inherits the agent default.
+    A toggle only applies to a capability the agent's protocol declares; toggling
+    one it does not declare is rejected by the platform (HTTP 400)."""
+
+    # ---- recording ----
+    record: bool = False
+    """When true, record each task's execution view (the streamed working process
+    beside the live computer) to a single shareable video (``--record``). Off by
+    default; the platform gates it to funded tiers, so the benchmark org must be
+    on a paid/trial/internal plan for it to take effect."""
+
+    record_visibility: str = "private"
+    """Where a recording is stored/served: ``private`` (signed, org-only playback)
+    or ``public`` (a permanent, unguessable, shareable URL, via ``--record-public``).
+    Benchmark content is non-sensitive, so set ``public`` to get a paste-anywhere
+    link per task. Ignored when ``record`` is false."""
+
+    # ---- computer wiring ----
+    display: str = ":0"
+    """X display the CLI acts on (the desktop ALE's graders screenshot). The
+    ALE Linux box runs cua-server on ``:0``; the CLI reuses an existing display,
+    so setting this makes screen-graded tasks see the agent's actions. File-
+    graded tasks (the majority) are unaffected."""
+
+    chrome_path: str | None = None
+    """Explicit browser binary (``--chrome-path``). ``None`` installs Chrome for
+    Testing at setup and points the CLI at it. Branded Chrome 137+ cannot load the
+    automation extension (``--load-extension`` was removed), so the deployer never
+    uses a baked ``google-chrome``; set this only to pin your own CfT/Chromium."""
+
+    # ---- install ----
+    cli_version: str | None = "@octavus/agent@1.0.2"
+    """npm spec installed globally at setup. Pin a version for reproducibility;
+    ``None`` installs the latest ``@octavus/agent``. 1.0.0+ raises the browser
+    window so it is visible and maximized in recordings on the reused ``:0``;
+    1.0.1+ resolves an extension-capable Chrome for Testing (never branded Chrome),
+    so the browser tools come up during ``computer-ensure-ready``; 1.0.2+ streams
+    the live computer view in near real-time (efficient I420 capture with
+    latest-frame-wins dropping), so the side-by-side/recorded computer keeps up
+    with the agent instead of lagging seconds behind."""
+
+    install_prereqs: bool = True
+    """When true, ``install()`` best-effort ``apt-get``s the computer's display
+    stack (Xvfb, AT-SPI + its python bindings, xdotool, scrot, Chrome libraries)
+    unless the box already has both the screenshot/automation tools and the
+    AT-SPI2 python bindings the computer-use ``label`` tool needs (checking only
+    the former misses images that bake a desktop but omit python3-gi). Set false
+    on an image that already bakes the full stack, or for shell/filesystem-only
+    runs that need no display."""
+
+    def __post_init__(self) -> None:
+        # Only the exact literal "public" enables --record-public; validate here
+        # so a typo fails loud at load time instead of silently downgrading the
+        # recording to private.
+        if self.record_visibility not in ("private", "public"):
+            raise ValueError(
+                f"record_visibility must be 'private' or 'public', got {self.record_visibility!r}"
+            )

--- a/ale_run/agents/octavus_cli/deployer.py
+++ b/ale_run/agents/octavus_cli/deployer.py
@@ -1,0 +1,637 @@
+"""OctavusCliDeployer - drives the public ``@octavus/agent`` (``octoagent``) CLI.
+
+The agent under test is a cloud Octavus agent; the CLI runs on the machine that *is*
+the ALE eval box and drives that machine's own desktop / filesystem / shell,
+while the brain (model, prompt, tools, workers, skills, memory) runs in the
+Octavus cloud. This is the same shape ALE expects from a ``sandbox``-executor
+agent: read everything from the executor/sandbox handle, spawn a local CLI,
+poll it under the orchestration wall budget.
+
+Pure stdlib (``subprocess`` / ``pathlib`` / ``json`` / ``urllib``) plus the
+shared node bootstrap. It uses only the public CLI and the consumer (agent-key)
+API - no Octavus-internal or admin surface - so the integration relies only on
+surfaces any user (including the ALE authors) can access.
+
+CLI reference: https://octavus.ai/docs/workforce-agents/cli
+
+Responsibilities:
+
+* :meth:`install` - ensure node, the computer's display prerequisites, and the
+  ``octoagent`` CLI (via npm); optionally fetch Chrome for Testing.
+* :meth:`launch` - ``octoagent run --json --workdir <task variant dir>`` on the
+  graded desktop, spawned detached and polled so the wall budget can reap it.
+* :meth:`parse_artifacts` - host-side: read the ``--json`` result, then read the
+  observable thread with the same agent key for the transcript + per-run cost.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import ClassVar
+
+from ale_run.base_interface import (
+    AgentRunResult,
+    BaseAgentDeployer,
+    ContentPart,
+    Observation,
+    ToolCall,
+    ToolResult,
+    TrajectoryBuilder,
+)
+
+from .config import OctavusCliConfig
+
+logger = logging.getLogger(__name__)
+
+
+_POLL_INTERVAL_S = 2.0
+_TERM_GRACE_S = 3.0
+
+# Terminal thread statuses on the consumer read surface.
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+# The computer's display + accessibility stack the CLI's browser / computer-use
+# tools need. Mirrors the public install script's apt set; a shell/filesystem-
+# only run needs none of it, so a failure here is a warning, not fatal.
+_PREREQ_APT_PACKAGES = (
+    "xvfb", "dbus-x11", "at-spi2-core", "x11-utils", "xdotool", "wmctrl", "scrot", "ffmpeg",
+    "python3", "python3-gi", "gir1.2-atspi-2.0", "python3-pil",
+    "libnss3", "libatk-bridge2.0-0", "libgtk-3-0", "libgbm1",
+    "fonts-liberation",
+)
+# The ALSA runtime lib is resolved at install time, not listed above: libasound2
+# became a virtual package on Ubuntu 24.04 (renamed libasound2t64 in the 64-bit
+# time_t transition), so the literal name has no install candidate there.
+
+# The computer-use MCP runs its AT-SPI `label` driver (linux-driver.py) as
+# `python3`, resolved from PATH. That driver imports the distro PyGObject
+# bindings (python3-gi), which exist ONLY for the system interpreter - never in
+# the uv/conda venvs some images prepend to PATH. The ALE image, for one, puts
+# /opt/cua-server/.venv/bin (a gi-less uv Python 3.14) first, so a bare `python3`
+# lands there and `label` dies with "AT-SPI2 not available" even though the
+# packages are installed for /usr/bin/python3. Pin the driver to the system
+# interpreter that carries the bindings (cloud/desktop/VM never hit this: their
+# `python3` is already that interpreter).
+_SYSTEM_PYTHON = "/usr/bin/python3"
+_SYSTEM_BIN = os.path.dirname(_SYSTEM_PYTHON)
+
+# Absolute path tokens the task prompt renders (backtick spans + bare POSIX
+# paths), used to locate the task's output dir -> variant dir.
+_BACKTICK = re.compile(r"`([^`]+)`")
+_UNIXPATH = re.compile(r"/(?:[\w.\-]+/)+[\w.\-]+")
+# octoagent --json threadUrl is ``<platform>/agents/<agentId>/chat/<threadId>``.
+_AGENT_URL = re.compile(r"/agents/([^/]+)/chat/")
+
+
+def _variant_dir_from_prompt(prompt: str, fallback: str) -> str:
+    """Best-effort absolute variant directory (the parent of ``output/``).
+
+    ALE task descriptions render absolute paths; the graded output directory is
+    the segment ending at ``output`` (either the dir itself or a file under it),
+    and the variant dir is its parent. Rooting the CLI's ``--workdir`` there puts
+    the filesystem/shell tools where ``input/`` and ``output/`` live and match
+    the prompt's paths. Falls back to the whole task-data root (the only staged
+    variant lives under it) when no output path is present.
+    """
+    candidates: set[str] = set()
+    for span in _BACKTICK.findall(prompt):
+        for token in span.split():
+            token = token.strip().strip("\"'").rstrip("/")
+            if token.startswith("/"):
+                candidates.add(token)
+    for match in _UNIXPATH.findall(prompt):
+        candidates.add(match.rstrip("/"))
+
+    variant_dirs: list[str] = []
+    for path in candidates:
+        segments = path.split("/")
+        output_idx = [i for i, seg in enumerate(segments) if seg == "output"]
+        if output_idx:
+            variant_dirs.append("/".join(segments[: output_idx[-1]]))
+    # A task renders one output tree in practice; ``min`` is only a deterministic
+    # tie-break for the rare prompt that references several output paths.
+    return min(variant_dirs) if variant_dirs else fallback
+
+
+def _read_text_tolerant(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (FileNotFoundError, OSError):
+        return ""
+
+
+class OctavusCliDeployer(BaseAgentDeployer):
+    """Stdlib-only deployer for the ``@octavus/agent`` (``octoagent``) CLI."""
+
+    default_executor: ClassVar[str] = "sandbox"
+    supported_executors: ClassVar[frozenset[str]] = frozenset({"sandbox"})
+    hot_artifacts: ClassVar[tuple[str, ...]] = (
+        "octoagent.result.json",
+        "octoagent.stdout.log",
+        "octoagent.stderr.log",
+    )
+
+    _octoagent_path: str
+    _chrome_path: str | None = None
+
+    @property
+    def version(self) -> str | None:
+        cfg: OctavusCliConfig = self.config  # type: ignore[assignment]
+        return cfg.cli_version
+
+    # =========================================================================
+    # install
+    # =========================================================================
+
+    async def install(self) -> None:
+        cfg: OctavusCliConfig = self.config  # type: ignore[assignment]
+
+        from ale_run.agents._bootstrap import ensure_node_npm
+        _, npm = await ensure_node_npm()
+
+        if cfg.install_prereqs:
+            await self._ensure_computer_prereqs()
+
+        pkg = cfg.cli_version or "@octavus/agent"
+        env = {**os.environ, "npm_config_cache": os.path.join(os.path.expanduser("~"), ".npm-ale")}
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            [npm, "install", "-g", "--force", pkg],
+            capture_output=True, text=True, timeout=600, env=env,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"octavus_cli: npm install -g {pkg} failed "
+                f"(rc={proc.returncode}): {(proc.stderr or '')[-500:]}"
+            )
+
+        octoagent = self._resolve_octoagent()
+        if not octoagent:
+            raise RuntimeError(
+                f"octavus_cli: 'octoagent' not found after npm install -g {pkg}"
+            )
+        self._octoagent_path = octoagent
+        logger.info("octavus_cli: octoagent CLI ready at %s", octoagent)
+
+        self._chrome_path = cfg.chrome_path or await self._ensure_chrome()
+
+        Path(self.executor.work_dir).mkdir(parents=True, exist_ok=True)
+
+    async def _ensure_computer_prereqs(self) -> None:
+        """Best-effort ``apt-get`` of the display + accessibility stack.
+
+        Skipped only when the box already has BOTH the screenshot/automation
+        tools AND the AT-SPI2 python bindings the computer-use ``label`` driver
+        imports. The screenshot/automation binaries do not imply those bindings:
+        an image can bake a desktop plus scrot/xdotool/ffmpeg (for other agents)
+        yet omit python3-gi/gir1.2-atspi-2.0, which leaves ``computer-use__label``
+        dead with "AT-SPI2 not available" while screenshots still work. Non-fatal:
+        a shell/filesystem-only task still runs, and a browser/computer-use task
+        surfaces a clear diagnostic itself.
+        """
+        def _atspi_bindings_importable() -> bool:
+            # The `label` driver reaches AT-SPI2 through GObject introspection.
+            # Probe the SYSTEM interpreter the MCP is pinned to (see _SYSTEM_PYTHON
+            # / _build_env), not a bare `python3` that a venv on PATH would shadow -
+            # otherwise the check reflects the wrong interpreter and apt runs every
+            # time even though the bindings are present for /usr/bin/python3.
+            try:
+                return subprocess.run(
+                    [_SYSTEM_PYTHON, "-c",
+                     "import gi; gi.require_version('Atspi', '2.0'); from gi.repository import Atspi"],
+                    capture_output=True, text=True, timeout=30, check=False,
+                ).returncode == 0
+            except (OSError, subprocess.SubprocessError):
+                return False
+
+        have_tools = bool(
+            shutil.which("scrot") and shutil.which("xdotool") and shutil.which("ffmpeg")
+        )
+        if have_tools and await asyncio.to_thread(_atspi_bindings_importable):
+            logger.info("octavus_cli: computer prerequisites already present")
+            return
+        packages = " ".join(_PREREQ_APT_PACKAGES)
+        # Pick the real ALSA package the distro ships (libasound2t64 on Ubuntu 24.04+,
+        # libasound2 on older Debian/Ubuntu), mirroring the public installer.
+        cmd = (
+            "sudo apt-get update -y; "
+            "alsa_pkg=libasound2t64; "
+            "apt-cache show libasound2t64 >/dev/null 2>&1 || alsa_pkg=libasound2; "
+            f'sudo apt-get install -y --no-install-recommends {packages} "$alsa_pkg"'
+        )
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            ["bash", "-c", cmd],
+            capture_output=True, text=True, timeout=900,
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "octavus_cli: prerequisite apt-get failed (rc=%s); browser/"
+                "computer-use tools may be unavailable: %s",
+                proc.returncode, (proc.stderr or "")[-400:],
+            )
+        else:
+            logger.info("octavus_cli: installed computer prerequisites")
+
+    async def _ensure_chrome(self) -> str | None:
+        """Install Chrome for Testing to ``~/.octavus/browsers`` and return its path.
+
+        The browser tools load the automation extension with ``--load-extension``,
+        which branded Chrome 137+ removed and the Chromium snap's confinement blocks;
+        only Chrome for Testing (or a real Chromium) still supports it. The ALE images
+        bake branded Google Chrome, which the CLI refuses. The deployer therefore
+        provisions Chrome for Testing to ``~/.octavus/browsers`` - the exact location
+        the CLI auto-detects (matching the public installer) - so it is the browser
+        that comes up during ``computer-ensure-ready``, and also points the CLI at the
+        binary explicitly via ``--chrome-path``. Set ``chrome_path`` in the agent
+        config to pin your own CfT.
+        """
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            ["bash", "-c", 'npx --yes @puppeteer/browsers install chrome@stable --path "$HOME/.octavus/browsers"'],
+            capture_output=True, text=True, timeout=600,
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "octavus_cli: could not install Chrome for Testing; browser tasks "
+                "may fail to load the extension: %s",
+                (proc.stderr or proc.stdout or "")[-400:],
+            )
+            return None
+        # @puppeteer/browsers lays the build out as
+        # ~/.octavus/browsers/chrome/<platform>-<buildId>/chrome-linux64/chrome (the
+        # layout the CLI's resolver scans); pick the newest install.
+        browsers_dir = Path(os.path.expanduser("~")) / ".octavus" / "browsers"
+        binaries = sorted(
+            browsers_dir.glob("chrome/*/chrome-linux64/chrome"),
+            key=lambda p: p.stat().st_mtime,
+        )
+        if binaries:
+            chrome = str(binaries[-1])
+            logger.info("octavus_cli: using Chrome for Testing at %s", chrome)
+            return chrome
+        logger.warning(
+            "octavus_cli: Chrome for Testing not found under %s after install", browsers_dir
+        )
+        return None
+
+    @staticmethod
+    def _resolve_octoagent() -> str | None:
+        home = os.path.expanduser("~")
+        for candidate in (
+            os.path.join(home, ".npm-global", "bin", "octoagent"),
+            os.path.join(home, ".local", "bin", "octoagent"),
+        ):
+            if os.path.exists(candidate):
+                return candidate
+        return shutil.which("octoagent")
+
+    # =========================================================================
+    # launch
+    # =========================================================================
+
+    async def launch(self, prompt: str) -> AgentRunResult:
+        cfg: OctavusCliConfig = self.config  # type: ignore[assignment]
+        wd = Path(self.executor.work_dir)
+        wd.mkdir(parents=True, exist_ok=True)
+
+        result_file = wd / "octoagent.result.json"
+        stdout_log = wd / "octoagent.stdout.log"
+        stderr_log = wd / "octoagent.stderr.log"
+        pid_file = wd / "octoagent.pid"
+        for stale in (result_file, stdout_log, stderr_log, pid_file):
+            if stale.exists():
+                try:
+                    stale.unlink()
+                except OSError:
+                    pass
+
+        workdir = _variant_dir_from_prompt(prompt, self.executor.sandbox.task_data_root)
+        argv = self._build_argv(cfg, workdir=workdir, prompt=prompt)
+        env = self._build_env(cfg)
+
+        t0 = time.monotonic()
+        with open(stdout_log, "wb") as out, open(stderr_log, "wb") as err:
+            proc = await asyncio.to_thread(
+                subprocess.Popen,
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=out,
+                stderr=err,
+                env=env,
+                cwd=str(wd),
+                start_new_session=hasattr(os, "setsid"),
+            )
+        pid_file.write_text(str(proc.pid), encoding="ascii")
+        logger.info("octavus_cli: spawned pid=%s workdir=%s", proc.pid, workdir)
+
+        try:
+            while proc.poll() is None:
+                await asyncio.sleep(_POLL_INTERVAL_S)
+        except asyncio.CancelledError:
+            self._reap(proc, force=False)
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(proc.wait), timeout=_TERM_GRACE_S,
+                )
+            except (TimeoutError, asyncio.CancelledError):
+                self._reap(proc, force=True)
+            raise
+
+        duration_s = time.monotonic() - t0
+        exit_code = proc.returncode
+        result = self._extract_result_json(stdout_log, result_file)
+        status = "completed" if exit_code == 0 else "failed"
+        error: str | None = None
+        if status == "failed":
+            error = self._diagnose_failure(exit_code, result, stderr_log)
+
+        return AgentRunResult(
+            status=status,
+            pid=proc.pid,
+            exit_code=exit_code,
+            transcript_path=str(result_file),
+            stderr_path=str(stderr_log),
+            duration_s=duration_s,
+            error=error,
+        )
+
+    def _build_argv(self, cfg: OctavusCliConfig, *, workdir: str, prompt: str) -> list[str]:
+        # This integration targets the hosted production platform, which is the
+        # CLI's default, so neither --env nor --platform-url is passed.
+        argv = [self._octoagent_path, "run", "--json", "--workdir", workdir]
+        if cfg.operator_url:
+            argv += ["--operator-url", cfg.operator_url]
+        if cfg.model:
+            argv += ["--model", cfg.model]
+        if cfg.backup_model:
+            argv += ["--backup-model", cfg.backup_model]
+        for slug, enabled in cfg.capabilities.items():
+            argv += ["--capability", f"{slug}={'on' if enabled else 'off'}"]
+        if cfg.record:
+            # --record-public implies recording and stores at a permanent, shareable
+            # URL; --record alone keeps the recording private (signed playback).
+            argv.append("--record-public" if cfg.record_visibility == "public" else "--record")
+        chrome = cfg.chrome_path or self._chrome_path
+        if chrome:
+            argv += ["--chrome-path", chrome]
+        argv.append(prompt)
+        return argv
+
+    def _build_env(self, cfg: OctavusCliConfig) -> dict[str, str]:
+        env = os.environ.copy()
+        for k, v in (self.executor.env or {}).items():
+            env[k] = v
+        env["DISPLAY"] = cfg.display
+        # Put the system bin first so the MCP-spawned `python3` (the AT-SPI
+        # `label` driver) is the gi-carrying system interpreter, not a gi-less
+        # venv the image prepends to PATH. The MCP child inherits this PATH, so
+        # this is what makes computer-use labeling work. See _SYSTEM_PYTHON.
+        if os.path.isfile(_SYSTEM_PYTHON):
+            env["PATH"] = _SYSTEM_BIN + os.pathsep + env.get("PATH", "")
+        if cfg.api_key:
+            # Pass the key by env, never argv, so it stays out of the process
+            # list and any gathered log.
+            env["OCTAVUS_API_KEY"] = cfg.api_key
+        return env
+
+    @staticmethod
+    def _reap(proc: subprocess.Popen, *, force: bool) -> None:
+        """Signal the CLI and its whole process group on wall-budget cancellation.
+
+        ``launch()`` sets ``start_new_session=True`` on POSIX, so the child leads
+        its own process group; signalling the group (``killpg``) reaps the CLI's
+        children (browser, MCP drivers) instead of orphaning them, falling back to
+        the single child where the group is gone. ``force`` picks SIGKILL over
+        SIGTERM. The caller does the bounded wait between the two signals.
+        """
+        sig = signal.SIGKILL if force else signal.SIGTERM
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.send_signal(sig)
+            except ProcessLookupError:
+                pass
+
+    @staticmethod
+    def _extract_result_json(stdout_log: Path, result_file: Path) -> dict | None:
+        """Pull the single ``--json`` object off stdout and persist it."""
+        text = _read_text_tolerant(stdout_log)
+        for line in reversed(text.splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                result_file.write_text(json.dumps(obj, indent=2), encoding="utf-8")
+                return obj
+        return None
+
+    @staticmethod
+    def _diagnose_failure(
+        exit_code: int | None, result: dict | None, stderr_log: Path,
+    ) -> str:
+        parts = [f"octoagent exited rc={exit_code}"]
+        if exit_code == 2:
+            parts.append("bad usage (check --platform-url / --api-key)")
+        elif exit_code == 3:
+            parts.append("CLI update required (platform minimum version)")
+        if result and result.get("error"):
+            parts.append(f"error: {result['error']}")
+        stderr_text = _read_text_tolerant(stderr_log)
+        if stderr_text.strip():
+            parts.append(f"stderr tail: ...{stderr_text[-600:]}")
+        return " | ".join(parts)
+
+    # =========================================================================
+    # parse_artifacts - host-side, runs on the gathered work_dir
+    # =========================================================================
+
+    @classmethod
+    def parse_artifacts(
+        cls,
+        *,
+        work_dir: Path,
+        config: OctavusCliConfig,
+        run_result: AgentRunResult,
+        builder: TrajectoryBuilder,
+    ) -> None:
+        result_file = work_dir / "octoagent.result.json"
+        if not result_file.exists():
+            builder.add_step(
+                source="system",
+                message=f"octavus_cli: no result json at {result_file}",
+                extra={"reason": "no_result"},
+            )
+            return
+
+        try:
+            result = json.loads(result_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            builder.add_step(
+                source="system",
+                message=f"octavus_cli: unreadable result json: {exc}",
+                extra={"reason": "bad_result"},
+            )
+            return
+
+        thread_url = str(result.get("threadUrl") or "")
+        thread_id = str(result.get("threadId") or "")
+        builder.trajectory.extra.setdefault("octavus_cli", {}).update({
+            "thread_id": thread_id,
+            "thread_url": thread_url,
+            "cli_status": result.get("status"),
+            "exit_code": run_result.exit_code,
+        })
+
+        agent_match = _AGENT_URL.search(thread_url)
+        # The sandbox strips config.api_key from the gathered spec (it is a
+        # secret), so host-side reads fall back to the env the CLI key lives in.
+        api_key = (
+            config.api_key
+            or os.environ.get("OCTAVUS_AGENT_API_KEY")
+            or os.environ.get("OCTAVUS_API_KEY")
+        )
+        platform_match = re.match(r"(https?://[^/]+)", thread_url)
+        platform_url = platform_match.group(1) if platform_match else None
+        if not (agent_match and thread_id and api_key and platform_url):
+            builder.add_step(
+                source="system",
+                message=(
+                    "octavus_cli: cannot read thread "
+                    f"(url={thread_url or 'missing'}); recorded CLI result only"
+                ),
+                extra={"reason": "thread_unreadable"},
+            )
+            return
+
+        octo_agent_id = agent_match.group(1)
+        thread = cls._read_thread(platform_url, octo_agent_id, thread_id, api_key)
+        if thread is None:
+            builder.add_step(
+                source="system",
+                message=f"octavus_cli: thread read failed; view: {thread_url}",
+                extra={"reason": "thread_read_error"},
+            )
+            return
+
+        cls._map_messages(thread.get("messages") or [], builder)
+
+        usage = thread.get("usage") or {}
+        if usage:
+            builder.override_final_metrics(
+                total_cost_usd=usage.get("costUsd"),
+                total_input_tokens=usage.get("inputTokens"),
+                total_output_tokens=usage.get("outputTokens"),
+            )
+        run_config = thread.get("runConfig") or {}
+        model = run_config.get("model") or config.model
+        if model:
+            builder.trajectory.agent.model = model
+
+        recording = thread.get("recording") or {}
+        builder.trajectory.extra["octavus_cli"].update({
+            "thread_status": thread.get("status"),
+            "failure_reason": thread.get("failureReason"),
+            "usage": usage or None,
+            "run_config": run_config or None,
+            "recording": recording or None,
+        })
+
+    @classmethod
+    def _read_thread(
+        cls, platform_url: str, agent_id: str, thread_id: str, api_key: str,
+    ) -> dict | None:
+        """Read the observable thread, polling briefly for terminal status/usage.
+
+        The CLI already waited for the run to finish, so the thread is normally
+        terminal by the time this host-side pass runs; a short poll absorbs the
+        few seconds usage aggregation can lag.
+        """
+        url = (
+            f"{platform_url}/api/v1/workforce/agents/{agent_id}"
+            f"/threads/{thread_id}"
+        )
+        deadline = time.monotonic() + 60.0
+        last: dict | None = None
+        while True:
+            try:
+                request = urllib.request.Request(
+                    url,
+                    headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+                )
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    last = json.loads(response.read().decode("utf-8"))
+            except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+                logger.warning("octavus_cli: thread read error: %s", exc)
+                if time.monotonic() >= deadline:
+                    return last
+                time.sleep(5.0)
+                continue
+            status = str((last or {}).get("status") or "")
+            if status in _TERMINAL_STATUSES and (last or {}).get("usage"):
+                return last
+            if time.monotonic() >= deadline:
+                return last
+            time.sleep(5.0)
+
+    @staticmethod
+    def _map_messages(messages: list[dict], builder: TrajectoryBuilder) -> None:
+        """Map consumer UIMessages to trajectory steps (best-effort).
+
+        The instruction ``user`` step is already seeded by the framework, so only
+        assistant turns are mapped: text/reasoning -> an ``agent`` step (with any
+        tool calls), and each tool call's result -> an ``environment`` step.
+        """
+        for message in messages:
+            if message.get("role") != "assistant":
+                continue
+            texts: list[str] = []
+            reasonings: list[str] = []
+            tool_calls: list[ToolCall] = []
+            results: list[ToolResult] = []
+            for part in message.get("parts") or []:
+                ptype = part.get("type")
+                if ptype == "text":
+                    texts.append(part.get("text") or "")
+                elif ptype == "reasoning":
+                    reasonings.append(part.get("text") or "")
+                elif ptype == "tool-call":
+                    call_id = part.get("toolCallId") or ""
+                    tool_calls.append(ToolCall(
+                        id=call_id,
+                        name=part.get("toolName") or "",
+                        arguments=part.get("args") or {},
+                    ))
+                    payload = part.get("result")
+                    if payload is None:
+                        payload = part.get("error")
+                    if payload is not None:
+                        content = payload if isinstance(payload, str) else json.dumps(payload)
+                        results.append(ToolResult(
+                            tool_call_id=call_id,
+                            content=[ContentPart(type="text", text=content)],
+                            is_error=part.get("status") == "error" or bool(part.get("error")),
+                        ))
+            builder.add_step(
+                source="agent",
+                message="\n".join(t for t in texts if t) or None,
+                reasoning="\n".join(r for r in reasonings if r) or None,
+                tool_calls=tool_calls or None,
+            )
+            if results:
+                builder.add_step(source="environment", observation=Observation(results=results))

--- a/ale_run/agents/octavus_cli/pyproject.toml
+++ b/ale_run/agents/octavus_cli/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "ale-octavus-cli"
+version = "0.1.0"
+description = "Octavus Agent CLI in-VM deployer for ALE."
+requires-python = ">=3.12,<3.14"
+dependencies = [
+    # No runtime Python deps - install/launch/parse use stdlib only
+    # (subprocess, pathlib, json, urllib) plus the shared node bootstrap.
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# Per-agent workspace member marker; the real package is
+# `ale_run.agents.octavus_cli`, shipped by the parent wheel. Package an empty
+# marker so uv installs this member without duplicating the code.
+only-include = []
+sources = {}
+bypass-selection = true

--- a/ale_run/orchestration/factory.py
+++ b/ale_run/orchestration/factory.py
@@ -43,6 +43,7 @@ _AGENT_FQNS: dict[str, str] = {
     "openhands_cli": "ale_run.agents.openhands_cli.deployer.OpenHandsCliDeployer",
     "hermes": "ale_run.agents.hermes.deployer.HermesDeployer",
     "terminus_2": "ale_run.agents.terminus_2.deployer.Terminus2Deployer",
+    "octavus_cli": "ale_run.agents.octavus_cli.deployer.OctavusCliDeployer",
     "dummy": "ale_run.agents.dummy.deployer.DummyDeployer",
 }
 

--- a/configs/agents/octavus_cli.yaml
+++ b/configs/agents/octavus_cli.yaml
@@ -1,0 +1,70 @@
+# octavus_cli - one cloud Octavus agent driven by the public `octoagent` CLI
+# (`@octavus/agent`), run headless on the ALE eval box (executor: sandbox). The
+# brain (model, prompt, tools, workers, skills, memory) runs in the Octavus
+# cloud; only the computer is local. The single credential is the agent key.
+#
+# Auth: set OCTAVUS_AGENT_API_KEY in secret/.env to the agent's oct_agt_* key
+# (minted from the agent's Settings -> API tab). The agent's Computer must be set
+# to "Your own machine (CLI)" in the dashboard.
+#
+# Docs: https://octavus.ai/docs/workforce-agents/cli
+#
+# Keys under `config:` show each knob at its dataclass default, except recording
+# (enabled to a public, shareable URL below). See
+# ale_run/agents/octavus_cli/config.py. Reference from an experiment as:
+#   agents: [ configs/agents/octavus_cli.yaml ]
+
+harness: octavus_cli
+# executor: sandbox          # only supported value (deployer default); runs inside the eval box.
+
+# Example per-run model override (sugar for config.model). Unset => the agent's
+# dashboard model is used, and is recorded on the trajectory from the effective
+# runConfig. Set it to pin (and record) an exact model for every run, e.g.:
+# model: anthropic/claude-opus-4-8
+
+config:
+  # The agent key. Named `api_key` so the framework carries it as a secret (into
+  # the sandbox via a read-once sidecar; never written to gathered host logs).
+  # The CLI targets the hosted Octavus platform (octavus.ai) by default.
+  api_key: ${env:OCTAVUS_AGENT_API_KEY}
+
+  # Optional operator WebSocket override (container/tunnel setups). Normally the
+  # platform returns a reachable operator URL per run, so leave null.
+  operator_url: null
+
+  # Per-run harness overrides (null/empty => inherit the agent's dashboard config).
+  backup_model: null
+  capabilities: {}          # e.g. { memory: false } for an ablation. NOTE: a toggle
+                            # only applies to a capability the agent's protocol
+                            # declares; toggling an undeclared one is rejected (400).
+
+  # Record each task's execution view (streamed working process + live computer)
+  # to one shareable video, stored at a permanent, paste-anywhere public URL.
+  # Best-effort and gated to funded tiers (a no-op on a free org; it never affects
+  # the run). Use record: false to disable, or record_visibility: private for
+  # signed, org-only playback.
+  record: true
+  record_visibility: public
+
+  # The graded desktop the CLI acts on. The ALE Linux box runs cua-server on :0;
+  # the CLI reuses it, so screen-graded tasks see the agent's actions.
+  display: ":0"
+
+  # Explicit browser binary. null => the deployer installs Chrome for Testing and
+  # points the CLI at it. Branded Chrome (baked into the ALE images) can't load the
+  # automation extension, so the deployer never uses it; set a path only to pin
+  # your own CfT.
+  chrome_path: null
+
+  # npm spec installed globally at setup. Pin for reproducibility; null => latest.
+  # 1.0.1+ resolves an extension-capable Chrome for Testing (the deployer installs it
+  # to ~/.octavus/browsers), so the browser tools come up during ensure-computer.
+  # 1.0.2+ streams the live computer view in near real-time (I420 capture,
+  # latest-frame-wins) so the recorded/side-by-side computer keeps up with the agent.
+  cli_version: "@octavus/agent@1.0.2"
+
+  # Best-effort apt-get of the display/accessibility stack (Xvfb, AT-SPI + its
+  # python bindings, xdotool, scrot, Chrome libs) unless the box already has both
+  # the screenshot/automation tools and the AT-SPI2 python bindings computer-use
+  # `label` needs. Set false on an image that bakes the full stack.
+  install_prereqs: true

--- a/secret/.env.example
+++ b/secret/.env.example
@@ -22,6 +22,14 @@ MOONSHOT_API_KEY=
 # Optional — only needed if you re-enable ale_claw's `web_search` tool.
 BRAVE_API_KEY=
 
+# ---- Octavus Agent CLI (octavus_cli deployer) ------------------------------
+# The one credential the octavus_cli agent needs: the oct_agt_* key minted from
+# the agent's Settings -> API tab (its Computer must be "Your own machine (CLI)").
+# Referenced by configs/agents/octavus_cli.yaml as ${env:OCTAVUS_AGENT_API_KEY}.
+# The agent's own model/tools/keys live in its cloud config, so no LLM keys above
+# are needed to run octavus_cli.
+OCTAVUS_AGENT_API_KEY=
+
 # ---- Baked task data -------------------------------------------------------
 # Public project-wide key used by the host after agent execution.
 # It is intentionally not forwarded into the agent sandbox environment.

--- a/tests/ale_run/test_octavus_cli_prereqs.py
+++ b/tests/ale_run/test_octavus_cli_prereqs.py
@@ -1,0 +1,81 @@
+"""OctavusCliDeployer computer-prereq + python-interpreter pinning behavior.
+
+Regression tests for a `computer-use__label` break on the ALE box. The AT-SPI
+`label` driver runs as `python3`; the ALE image prepends a gi-less venv to PATH,
+so a bare `python3` could not import the AT-SPI2 bindings (which are installed
+only for /usr/bin/python3) and label died with "AT-SPI2 not available" while
+screenshots (scrot, no gi) still worked. The fix pins the driver to the system
+interpreter (_build_env) and the prereq guard probes / installs against that same
+interpreter (_ensure_computer_prereqs).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from types import SimpleNamespace
+
+import ale_run.agents.octavus_cli.deployer as deployer_mod
+from ale_run.agents.octavus_cli.deployer import OctavusCliDeployer
+
+
+def _make_deployer() -> OctavusCliDeployer:
+    # _ensure_computer_prereqs never touches self; a stub executor carrying a
+    # `config` attribute is all BaseAgentDeployer.__init__ needs.
+    return OctavusCliDeployer(SimpleNamespace(config=SimpleNamespace(), env={}))  # type: ignore[arg-type]
+
+
+def _fake_run(atspi_rc: int, apt_calls: list[list[str]]):
+    """subprocess.run stand-in: the `python3` AT-SPI probe returns atspi_rc; any
+    `bash -c` (the apt-get install) is recorded and reported successful."""
+    def _run(argv, *_args, **_kwargs):
+        if argv[:1] == [deployer_mod._SYSTEM_PYTHON]:
+            return subprocess.CompletedProcess(argv, atspi_rc)
+        apt_calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    return _run
+
+
+async def test_installs_when_atspi_bindings_missing(monkeypatch) -> None:
+    monkeypatch.setattr(deployer_mod.shutil, "which", lambda _cmd: "/usr/bin/x")
+    apt_calls: list[list[str]] = []
+    monkeypatch.setattr(deployer_mod.subprocess, "run", _fake_run(atspi_rc=1, apt_calls=apt_calls))
+
+    await _make_deployer()._ensure_computer_prereqs()
+
+    assert apt_calls, "apt-get must run when the AT-SPI2 python bindings do not import"
+    assert "apt-get install" in apt_calls[0][2]
+
+
+async def test_skips_when_tools_and_atspi_present(monkeypatch) -> None:
+    monkeypatch.setattr(deployer_mod.shutil, "which", lambda _cmd: "/usr/bin/x")
+    apt_calls: list[list[str]] = []
+    monkeypatch.setattr(deployer_mod.subprocess, "run", _fake_run(atspi_rc=0, apt_calls=apt_calls))
+
+    await _make_deployer()._ensure_computer_prereqs()
+
+    assert not apt_calls, "apt-get must be skipped when both tools and AT-SPI bindings are present"
+
+
+async def test_installs_when_screenshot_tools_missing(monkeypatch) -> None:
+    # A missing screenshot/automation tool must install even if AT-SPI imports.
+    monkeypatch.setattr(deployer_mod.shutil, "which", lambda _cmd: None)
+    apt_calls: list[list[str]] = []
+    monkeypatch.setattr(deployer_mod.subprocess, "run", _fake_run(atspi_rc=0, apt_calls=apt_calls))
+
+    await _make_deployer()._ensure_computer_prereqs()
+
+    assert apt_calls, "apt-get must run when scrot/xdotool/ffmpeg are missing"
+
+
+def test_build_env_pins_system_python_first_on_path(monkeypatch) -> None:
+    # The MCP's `python3` (AT-SPI driver) must resolve to the gi-carrying system
+    # interpreter, not a venv the image prepends to PATH.
+    monkeypatch.setenv("PATH", "/opt/cua-server/.venv/bin:/usr/local/bin:/usr/bin:/bin")
+    monkeypatch.setattr(deployer_mod.os.path, "isfile", lambda p: p == deployer_mod._SYSTEM_PYTHON)
+    cfg = SimpleNamespace(display=":0", api_key=None)
+
+    env = _make_deployer()._build_env(cfg)  # type: ignore[arg-type]
+
+    assert env["PATH"].split(os.pathsep)[0] == deployer_mod._SYSTEM_BIN
+    assert env["DISPLAY"] == ":0"


### PR DESCRIPTION
## Summary

- add an ALE harness for the public Octavus Agent CLI (`@octavus/agent`, the `octoagent` command) without modifying or vendoring upstream
- install and verify `@octavus/agent@1.0.2` inside the sandbox via npm
- run a cloud Octavus agent that uses the eval box as its own computer: the model, prompt, tools, sub-agents, skills, and memory run in the Octavus cloud, and the CLI drives the machine's local desktop, filesystem, and shell, so the only credential the harness needs is the agent key
- provision the computer's display and accessibility stack (Xvfb, AT-SPI plus its Python bindings, `xdotool`, `scrot`, `ffmpeg`, Chrome libraries) and Chrome for Testing so the CLI's built-in browser and computer-use tools work on the graded desktop
- reuse ALE's existing `:0` desktop so screen-graded tasks observe the agent's actions
- produce standard ALE trajectories, token usage, cost, effective model, and, when enabled, a shareable per-task recording URL

## Relation to existing harnesses

This follows the in-sandbox CLI conventions established by #52 and #59 (pinned official CLI install and verification, `sandbox` executor, process-only credentials, standard trajectory/usage/screenshot/output artifacts) with one deliberate architectural difference:

- `claude_code` / `codex` mount ALE's CUA MCP bridge onto a CLI that otherwise has only a shell.
- The Octavus agent ships its own computer tools (browser, computer-use, filesystem, shell). So this harness does not wire the CUA bridge; instead it prepares the desktop and accessibility stack the CLI's own tools require, and points the agent at ALE's existing `:0` display.

## How it plugs in

Standard `sandbox`-executor lifecycle, pure stdlib (`subprocess` / `pathlib` / `json` / `urllib`) plus ALE's shared Node bootstrap. Only the public CLI and the documented consumer (agent-key) API are used, no internal or admin surface:

- `install()` — bootstrap Node, best-effort `apt-get` the display/accessibility stack, `npm install -g @octavus/agent@1.0.2`, and install Chrome for Testing to `~/.octavus/browsers`.
- `launch(prompt)` — `octoagent run --json --workdir <task variant dir> "<prompt>"`, spawned detached and polled under the orchestration wall budget (reaped, with its process group, if it exceeds the budget). The `--workdir` is rooted at the task's variant directory (parent of `output/`) so the CLI's filesystem/shell tools land where the prompt's `input/` and `output/` paths live.
- `parse_artifacts()` — host-side: read the single `--json` result (`threadId` / `threadUrl` / `status`), then read the observable thread with the same agent key to attach the transcript, per-run usage/cost, and effective model to the trajectory. Thread and recording metadata are stored under `trajectory.extra`.

## Configuration

The preset is `configs/agents/octavus_cli.yaml`:

- harness: `octavus_cli`
- executor: `sandbox` (only supported value)
- credential: `OCTAVUS_AGENT_API_KEY`
- CLI: `@octavus/agent@1.0.2`
- recording: `record: true`, `record_visibility: public` (the recording URL can be shard, but is only accessible to the org users).
- display: `:0`
- model: unset (inherits the agent's configured model; the effective model is recorded on the trajectory from the run config)

Per-run overrides, all optional (unset inherits the agent's dashboard configuration): `model` (`--model`), `backup_model` (`--backup-model`), and `capabilities` (repeated `--capability slug=on|off`). A capability toggle only applies to a capability the agent's protocol declares; toggling an undeclared one is rejected by the platform.

Recording is best-effort and gated to funded platform tiers, so it is a no-op on an org without it and never affects the run itself. Use `record: false` to disable or `record_visibility: private` for signed, org-only playback.

## Credentials

The single credential is the agent API key. It is named `api_key` in the config, so ALE carries it through the existing read-once `_secrets.json` sidecar into the sandbox and passes it to the CLI via the `OCTAVUS_API_KEY` environment variable, never on argv and never written to gathered `_spec.json` or host logs. No LLM provider keys are required: the agent's model, tools, and provider keys live in its cloud configuration.

Set it in `secret/.env`:

```text
OCTAVUS_AGENT_API_KEY=oct_agt_...
```

The agent's Computer must be set to "Your own machine (CLI)" in the dashboard so it is driven only from the CLI.

## Browser and accessibility tasks

Branded Chrome 137+ cannot load the automation extension (`--load-extension` was removed), the Chromium snap's confinement blocks it too, and the ALE images bake branded Google Chrome, which the CLI refuses. `install()` therefore installs Chrome for Testing via `@puppeteer/browsers` to `~/.octavus/browsers` (the location the CLI auto-detects) and also passes `--chrome-path`, so the browser tools come up during the CLI's computer-readiness check. Set `chrome_path` to pin your own Chrome for Testing or Chromium.

The computer-use `label` tool runs an AT-SPI driver as `python3`, which must import the distro `python3-gi` bindings that exist only for the system interpreter. `launch()` pins `PATH` to `/usr/bin` first so a gi-less venv that the ALE image prepends (for example `/opt/cua-server/.venv`) does not shadow it, otherwise labeling fails with "AT-SPI2 not available" even though the bindings are installed. The apt step is guarded and skipped when the box already has both the screenshot/automation tools and the AT-SPI2 Python bindings; set `install_prereqs: false` on an image that already bakes the full stack, or for shell/filesystem-only runs.

## Run it

```yaml
agents:
  - configs/agents/octavus_cli.yaml
environment: configs/environments/environment_gcloud.yaml
tasks: selected_tasks/ale_cli.txt
```

```bash
uv run python -m ale_run run <experiment>.yaml --dry-run   # preview units
uv run python -m ale_run run <experiment>.yaml             # run
```

## Validation

- `tests/ale_run/test_octavus_cli_prereqs.py`: `4 passed` (prereq guard installs when the AT-SPI2 bindings or screenshot tools are missing and skips when both are present; `_build_env` pins the system interpreter first on `PATH` and sets `DISPLAY`).
- `uv sync --all-packages --extra dev`: the new workspace member resolves.
- registry + config smoke: `octavus_cli` resolves to `OctavusCliDeployer` / `OctavusCliConfig`, `default_executor = sandbox`, and every preset `config:` key maps to the dataclass.
- focused Ruff lint on the new files introduces no rule violations beyond the repository's existing harness house style (the same `open()`-in-async and `subprocess` patterns already present in `claude_code` and `codex`).
- end-to-end evaluation on the Linux task list (`selected_tasks/ale_cli.txt`) is being validated separately.

## Upstream references

- https://octavus.ai/docs/workforce-agents/cli
- https://www.npmjs.com/package/@octavus/agent
- https://github.com/rdi-berkeley/agents-last-exam/pull/52
- https://github.com/rdi-berkeley/agents-last-exam/pull/59