### PR TITLE
Robustness fixes for the Linux tasks, the gcloud provider, and the octavus_cli harness

### DIFF
--- a/ale_run/agents/octavus_cli/config.py
+++ b/ale_run/agents/octavus_cli/config.py
@@ -78,7 +78,7 @@ class OctavusCliConfig:
     uses a baked ``google-chrome``; set this only to pin your own CfT/Chromium."""
 
     # ---- install ----
-    cli_version: str | None = "@octavus/agent@1.0.8"
+    cli_version: str | None = "@octavus/agent@1.0.9"
     """npm spec installed globally at setup. Pin a version for reproducibility;
     ``None`` installs the latest ``@octavus/agent``."""
 

--- a/ale_run/agents/octavus_cli/config.py
+++ b/ale_run/agents/octavus_cli/config.py
@@ -8,8 +8,8 @@ the sandbox via the read-once sidecar and never lands in gathered host logs.
 
 Everything else about the harness (prompt, tools, workers, skills, memory,
 model) lives in the agent's configuration on the Octavus platform. ``model`` /
-``backup_model`` / ``capabilities`` here are per-run overrides so one deployer
-can express many harness variants without touching the stored agent.
+``backup_model`` / ``thinking`` / ``capabilities`` here are per-run overrides so
+one deployer can express many harness variants without touching the stored agent.
 """
 from __future__ import annotations
 
@@ -45,6 +45,12 @@ class OctavusCliConfig:
     backup_model: str | None = None
     """Per-run backup model ``provider/model-id`` (``--backup-model``)."""
 
+    thinking: str | None = None
+    """Per-run thinking/reasoning effort (``--thinking``): one of ``off`` /
+    ``low`` / ``medium`` / ``high`` / ``max``. ``max`` is each provider's
+    maximum; ``off`` disables thinking. ``None`` (or empty) inherits the agent's
+    default, omitting the flag."""
+
     capabilities: dict[str, bool] = field(default_factory=dict)
     """Per-run capability toggles (repeated ``--capability slug=on|off``), e.g.
     ``{"memory": false}`` for an ablation. Unlisted inherits the agent default.
@@ -78,9 +84,10 @@ class OctavusCliConfig:
     uses a baked ``google-chrome``; set this only to pin your own CfT/Chromium."""
 
     # ---- install ----
-    cli_version: str | None = "@octavus/agent@1.0.9"
+    cli_version: str | None = "@octavus/agent@1.0.10"
     """npm spec installed globally at setup. Pin a version for reproducibility;
-    ``None`` installs the latest ``@octavus/agent``."""
+    ``None`` installs the latest ``@octavus/agent``. ``--thinking`` needs
+    ``>=1.0.10``; older CLIs ignore the flag."""
 
     install_prereqs: bool = True
     """When true, ``install()`` best-effort ``apt-get``s the computer's display
@@ -98,4 +105,12 @@ class OctavusCliConfig:
         if self.record_visibility not in ("private", "public"):
             raise ValueError(
                 f"record_visibility must be 'private' or 'public', got {self.record_visibility!r}"
+            )
+        # Validate the thinking effort at load time (empty/None inherits the
+        # agent default); a typo would otherwise reach the platform and be
+        # rejected only at session creation.
+        if self.thinking and self.thinking not in ("off", "low", "medium", "high", "max"):
+            raise ValueError(
+                "thinking must be one of off/low/medium/high/max (or empty to "
+                f"inherit the agent default), got {self.thinking!r}"
             )

--- a/ale_run/agents/octavus_cli/config.py
+++ b/ale_run/agents/octavus_cli/config.py
@@ -28,6 +28,11 @@ class OctavusCliConfig:
     name: ClassVar[str] = "octavus-cli"
 
     # ---- platform target (the hosted Octavus platform, https://octavus.ai) ----
+    platform_url: str | None = None
+    """Optional platform base URL override (``--platform-url``). ``None`` uses the
+    CLI's built-in default. Set it to point the run at a different platform
+    deployment; the value is supplied by the caller, so no host is baked in here."""
+
     operator_url: str | None = None
     """Optional operator WebSocket override (``--operator-url``). Normally
     unset: the platform returns a reachable operator URL per run."""

--- a/ale_run/agents/octavus_cli/config.py
+++ b/ale_run/agents/octavus_cli/config.py
@@ -78,15 +78,9 @@ class OctavusCliConfig:
     uses a baked ``google-chrome``; set this only to pin your own CfT/Chromium."""
 
     # ---- install ----
-    cli_version: str | None = "@octavus/agent@1.0.2"
+    cli_version: str | None = "@octavus/agent@1.0.8"
     """npm spec installed globally at setup. Pin a version for reproducibility;
-    ``None`` installs the latest ``@octavus/agent``. 1.0.0+ raises the browser
-    window so it is visible and maximized in recordings on the reused ``:0``;
-    1.0.1+ resolves an extension-capable Chrome for Testing (never branded Chrome),
-    so the browser tools come up during ``computer-ensure-ready``; 1.0.2+ streams
-    the live computer view in near real-time (efficient I420 capture with
-    latest-frame-wins dropping), so the side-by-side/recorded computer keeps up
-    with the agent instead of lagging seconds behind."""
+    ``None`` installs the latest ``@octavus/agent``."""
 
     install_prereqs: bool = True
     """When true, ``install()`` best-effort ``apt-get``s the computer's display

--- a/ale_run/agents/octavus_cli/deployer.py
+++ b/ale_run/agents/octavus_cli/deployer.py
@@ -370,9 +370,11 @@ class OctavusCliDeployer(BaseAgentDeployer):
         )
 
     def _build_argv(self, cfg: OctavusCliConfig, *, workdir: str, prompt: str) -> list[str]:
-        # This integration targets the hosted production platform, which is the
-        # CLI's default, so neither --env nor --platform-url is passed.
+        # Use the CLI's built-in default platform unless the caller pins a
+        # platform_url to point the run at a different platform deployment.
         argv = [self._octoagent_path, "run", "--json", "--workdir", workdir]
+        if cfg.platform_url:
+            argv += ["--platform-url", cfg.platform_url]
         if cfg.operator_url:
             argv += ["--operator-url", cfg.operator_url]
         if cfg.model:

--- a/ale_run/agents/octavus_cli/deployer.py
+++ b/ale_run/agents/octavus_cli/deployer.py
@@ -63,8 +63,11 @@ _TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
 # The computer's display + accessibility stack the CLI's browser / computer-use
 # tools need. Mirrors the public install script's apt set; a shell/filesystem-
 # only run needs none of it, so a failure here is a warning, not fatal.
+# `fluxbox` is a lightweight window manager the CLI starts on a bare display so the
+# computer-use `label` driver can find the foreground window; a no-op on the
+# standard ALE `:0`, which already runs a WM.
 _PREREQ_APT_PACKAGES = (
-    "xvfb", "dbus-x11", "at-spi2-core", "x11-utils", "xdotool", "wmctrl", "scrot", "ffmpeg",
+    "xvfb", "fluxbox", "dbus-x11", "at-spi2-core", "x11-utils", "xdotool", "wmctrl", "scrot", "ffmpeg",
     "python3", "python3-gi", "gir1.2-atspi-2.0", "python3-pil",
     "libnss3", "libatk-bridge2.0-0", "libgtk-3-0", "libgbm1",
     "fonts-liberation",

--- a/ale_run/agents/octavus_cli/deployer.py
+++ b/ale_run/agents/octavus_cli/deployer.py
@@ -379,6 +379,8 @@ class OctavusCliDeployer(BaseAgentDeployer):
             argv += ["--model", cfg.model]
         if cfg.backup_model:
             argv += ["--backup-model", cfg.backup_model]
+        if cfg.thinking:
+            argv += ["--thinking", cfg.thinking]
         for slug, enabled in cfg.capabilities.items():
             argv += ["--capability", f"{slug}={'on' if enabled else 'off'}"]
         if cfg.record:

--- a/ale_run/environments/providers/gcloud.py
+++ b/ale_run/environments/providers/gcloud.py
@@ -70,6 +70,15 @@ _GCP_RETRYABLE_ZONE = [
     "insufficient", "does not have enough resources",
     "not enough resources", "zone does not have enough",
 ]
+# A machine type simply not offered in a given zone (distinct from capacity):
+# recover by trying the next machine/zone, not by waiting. Newer families like
+# c4 are absent from some zones that the n2 fallback still covers.
+_GCP_MACHINE_UNAVAILABLE = [
+    "does not exist in zone",
+    "machine type with name",
+    "invalid value for field 'resource.machinetype'",
+    "machine type not found",
+]
 
 
 # ============================================================================
@@ -406,6 +415,18 @@ def _is_transient_error(stderr: str) -> bool:
 def _is_zone_capacity_error(stderr: str) -> bool:
     lower = stderr.lower()
     return any(pat in lower for pat in _GCP_RETRYABLE_ZONE)
+
+
+def _is_machine_unavailable_error(stderr: str) -> bool:
+    lower = stderr.lower()
+    return any(pat in lower for pat in _GCP_MACHINE_UNAVAILABLE)
+
+
+def _is_retryable_create_error(stderr: str) -> bool:
+    """A create error to recover from by trying the next machine x zone combo
+    (capacity/quota exhaustion, or a machine type not offered in that zone),
+    rather than failing the unit. Anything else is fatal and surfaced at once."""
+    return _is_zone_capacity_error(stderr) or _is_machine_unavailable_error(stderr)
 
 
 def _boot_disk_type(machine_type: str) -> str:
@@ -777,7 +798,11 @@ class GcloudProvider(Provider):
             )
 
         is_gpu = snap.gpu is not None
-        zones = snap.zones
+        # Shuffle a copy of the zone list per VM so concurrent units spread across
+        # zones/regions instead of all hammering zones[0]: finds capacity faster
+        # and keeps per-region IP/SSD quota usage from concentrating in one region.
+        zones = list(snap.zones)
+        random.shuffle(zones)
 
         # Machine fallback: task-card override (or default) → N2 (CPU only).
         base_machine = spec.machine_type or (
@@ -807,10 +832,14 @@ class GcloudProvider(Provider):
         used_machine = machines[0]
         stdout = ""
 
-        # machine × zone, in order: each machine tried across all zones first.
-        for machine in machines:
-            for zone in zones:
-                ok, out, stderr, used_zone = await _try_create_in_zone(
+        # zone × machine, in order: try every candidate machine within a zone
+        # before moving on, so the reliable fallback (c* → n2) is reached in the
+        # first zone instead of after crawling the requested machine across every
+        # zone. First success wins; a capacity/quota exhaustion or a machine type
+        # not offered in that zone moves on, anything else is fatal and raised.
+        for zone in zones:
+            for machine in machines:
+                ok, out, stderr, _ = await _try_create_in_zone(
                     name=name,
                     image=snap.image,
                     gpu=snap.gpu,
@@ -824,16 +853,17 @@ class GcloudProvider(Provider):
                 )
                 if ok:
                     stdout = out
+                    used_zone = zone
                     used_machine = machine
                     break
                 last_stderr = stderr
-                if not _is_zone_capacity_error(stderr):
+                if not _is_retryable_create_error(stderr):
                     raise RuntimeError(f"gcloud instances create failed: {stderr}")
             if stdout:
                 break
         else:
             raise RuntimeError(
-                f"gcloud instances create failed for all machines/zones: {last_stderr}"
+                f"gcloud instances create failed for all zones/machines: {last_stderr}"
             )
 
         # VM is now created. Until the SandboxHandle is returned below, ANY

--- a/ale_run/environments/providers/gcloud.py
+++ b/ale_run/environments/providers/gcloud.py
@@ -493,7 +493,7 @@ async def _try_create_in_zone(
     zone: str,
     label_str: str,
     project: str,
-) -> tuple[bool, str, str, str]:
+) -> tuple[bool, str, str]:
     args = _build_create_args(
         name=name,
         image=image,
@@ -515,7 +515,7 @@ async def _try_create_in_zone(
         )
         rc, stdout, stderr = await _run_gcloud(*args, project=project)
         if rc == 0:
-            return True, stdout, "", zone
+            return True, stdout, ""
         last_stderr = stderr
 
         if _is_zone_capacity_error(stderr):
@@ -523,7 +523,7 @@ async def _try_create_in_zone(
                 "machine=%s exhausted in %s: %s",
                 machine_type, zone, stderr[:300],
             )
-            return False, "", last_stderr, zone
+            return False, "", last_stderr
 
         if _is_transient_error(stderr):
             # Ambiguous outcome (esp. ConnectionError / RemoteDisconnected): the
@@ -551,8 +551,8 @@ async def _try_create_in_zone(
                 await asyncio.sleep(delay)
                 continue
 
-        return False, "", last_stderr, zone
-    return False, "", last_stderr, zone
+        return False, "", last_stderr
+    return False, "", last_stderr
 
 
 def _extract_external_ip(inst: dict) -> str | None:
@@ -839,7 +839,7 @@ class GcloudProvider(Provider):
         # not offered in that zone moves on, anything else is fatal and raised.
         for zone in zones:
             for machine in machines:
-                ok, out, stderr, _ = await _try_create_in_zone(
+                ok, out, stderr = await _try_create_in_zone(
                     name=name,
                     image=snap.image,
                     gpu=snap.gpu,

--- a/configs/agents/octavus_cli.yaml
+++ b/configs/agents/octavus_cli.yaml
@@ -34,6 +34,9 @@ config:
 
   # Per-run harness overrides (null/empty => inherit the agent's dashboard config).
   backup_model: null
+  thinking: null            # off | low | medium | high | max (max = each provider's
+                            # maximum; off disables thinking). null inherits the
+                            # agent's default. Needs @octavus/agent >=1.0.10.
   capabilities: {}          # e.g. { memory: false } for an ablation. NOTE: a toggle
                             # only applies to a capability the agent's protocol
                             # declares; toggling an undeclared one is rejected (400).
@@ -57,7 +60,8 @@ config:
   chrome_path: null
 
   # npm spec installed globally at setup. Pin for reproducibility; null => latest.
-  cli_version: "@octavus/agent@1.0.9"
+  # >=1.0.10 is required for the per-run `thinking:` override above.
+  cli_version: "@octavus/agent@1.0.10"
 
   # Best-effort apt-get of the display/accessibility stack (Xvfb, AT-SPI + its
   # python bindings, xdotool, scrot, Chrome libs) unless the box already has both

--- a/configs/agents/octavus_cli.yaml
+++ b/configs/agents/octavus_cli.yaml
@@ -57,11 +57,7 @@ config:
   chrome_path: null
 
   # npm spec installed globally at setup. Pin for reproducibility; null => latest.
-  # 1.0.1+ resolves an extension-capable Chrome for Testing (the deployer installs it
-  # to ~/.octavus/browsers), so the browser tools come up during ensure-computer.
-  # 1.0.2+ streams the live computer view in near real-time (I420 capture,
-  # latest-frame-wins) so the recorded/side-by-side computer keeps up with the agent.
-  cli_version: "@octavus/agent@1.0.2"
+  cli_version: "@octavus/agent@1.0.8"
 
   # Best-effort apt-get of the display/accessibility stack (Xvfb, AT-SPI + its
   # python bindings, xdotool, scrot, Chrome libs) unless the box already has both

--- a/configs/agents/octavus_cli.yaml
+++ b/configs/agents/octavus_cli.yaml
@@ -57,7 +57,7 @@ config:
   chrome_path: null
 
   # npm spec installed globally at setup. Pin for reproducibility; null => latest.
-  cli_version: "@octavus/agent@1.0.8"
+  cli_version: "@octavus/agent@1.0.9"
 
   # Best-effort apt-get of the display/accessibility stack (Xvfb, AT-SPI + its
   # python bindings, xdotool, scrot, Chrome libs) unless the box already has both

--- a/tasks/engineering/mpc_control_building_v1/main.py
+++ b/tasks/engineering/mpc_control_building_v1/main.py
@@ -35,9 +35,8 @@ def _parse_verifier_result(result: dict) -> float:
     stderr = str(result.get("stderr", ""))
     try:
         # verify_outputs.py prints its JSON via `uv run --with pandas --with numpy`,
-        # whose dependency-resolution output can precede the JSON on stdout. Parse
-        # the JSON object out of the surrounding text instead of assuming stdout is
-        # pure JSON (a plain json.loads(stdout) fails on the leading log lines).
+        # whose dependency-resolution output can precede the JSON on stdout, so
+        # parse the JSON object out of the surrounding text.
         text = stdout.strip()
         if not text:
             raise ValueError("verifier produced no stdout")

--- a/tasks/engineering/mpc_control_building_v1/main.py
+++ b/tasks/engineering/mpc_control_building_v1/main.py
@@ -30,11 +30,24 @@ def _read_script(name: str) -> str:
 
 
 def _parse_verifier_result(result: dict) -> float:
-    stdout = result.get("output", result.get("stdout", ""))
+    stdout = str(result.get("stdout", result.get("output", "")))
     return_code = result.get("return_code", result.get("returncode"))
     stderr = str(result.get("stderr", ""))
     try:
-        data = json.loads(stdout)
+        # verify_outputs.py prints its JSON via `uv run --with pandas --with numpy`,
+        # whose dependency-resolution output can precede the JSON on stdout. Parse
+        # the JSON object out of the surrounding text instead of assuming stdout is
+        # pure JSON (a plain json.loads(stdout) fails on the leading log lines).
+        text = stdout.strip()
+        if not text:
+            raise ValueError("verifier produced no stdout")
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            start, end = text.find("{"), text.rfind("}")
+            if start == -1 or end <= start:
+                raise
+            data = json.loads(text[start : end + 1])
         if not isinstance(data, dict):
             raise TypeError("verifier result must be a JSON object")
         passed = data.get("passed")
@@ -50,7 +63,7 @@ def _parse_verifier_result(result: dict) -> float:
     except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise RuntimeError(
             "MPC verifier failed to produce a valid result: "
-            f"return_code={return_code!r}, stderr={stderr[:1000]!r}"
+            f"return_code={return_code!r}, stdout={stdout[-500:]!r} stderr={stderr[:1000]!r}"
         ) from exc
     logger.info("MPC control building eval result: %s", data)
     return score

--- a/tasks/engineering/openroad_sky130_ibex_pnr_signoff/main.py
+++ b/tasks/engineering/openroad_sky130_ibex_pnr_signoff/main.py
@@ -139,7 +139,8 @@ async def _run_verifier_background(
             "failed to launch verifier: "
             f"stdout={launch.get('stdout')} stderr={launch.get('stderr')}"
         )
-    pid = (launch.get("stdout") or "").strip().splitlines()[-1] if launch.get("stdout") else ""
+    launch_lines = (launch.get("stdout") or "").strip().splitlines()
+    pid = launch_lines[-1] if launch_lines else ""
     logger.info("[%s] verifier started in background pid=%s run_dir=%s", tag, pid or "unknown", run_dir)
 
     waited = 0
@@ -326,7 +327,8 @@ async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
             run_dir_result.get("stderr", ""),
         )
         return [0.0]
-    run_dir = (run_dir_result.get("stdout") or "").strip().splitlines()[-1]
+    run_dir_lines = (run_dir_result.get("stdout") or "").strip().splitlines()
+    run_dir = run_dir_lines[-1] if run_dir_lines else ""
     if not run_dir:
         logger.error("[%s] failed to create verifier run dir: empty mktemp output", tag)
         return [0.0]

--- a/tasks/physical_sciences/mose2_bse_absorption_soc/main.py
+++ b/tasks/physical_sciences/mose2_bse_absorption_soc/main.py
@@ -17,6 +17,7 @@ from tasks.linux_runtime import LinuxTaskConfig
 from tasks.physical_sciences._shared.materials_science._common import (
     MOSE2_BSE_ABSORPTION_SOC_SPEC,
     evaluate_remote_output_dir,
+    run_command,
 )
 
 logger = logging.getLogger(__name__)
@@ -110,13 +111,13 @@ _setup = BaseTaskSetup()
 async def start(task_cfg, session: cb.DesktopSession):
     await _setup(task_cfg, session)
     install_script = f"{task_cfg.metadata['software_dir']}/install_software.sh"
-    result = await session.run_command(
-        "bash " + shlex.quote(install_script), timeout=600, check=False
+    result = await run_command(
+        session, "bash " + shlex.quote(install_script), timeout=600, check=False
     )
-    if result.returncode != 0:
+    if result.get("return_code", 0) != 0:
         raise RuntimeError(
             "QE/BerkeleyGW task runtime verification failed: "
-            f"{(result.stderr or result.stdout or '').strip()[-2000:]}"
+            f"{(result.get('stderr') or result.get('stdout') or '').strip()[-2000:]}"
         )
 
 

--- a/tasks/physical_sciences/silicon_bse_absorption/main.py
+++ b/tasks/physical_sciences/silicon_bse_absorption/main.py
@@ -17,6 +17,7 @@ from tasks.linux_runtime import LinuxTaskConfig
 from tasks.physical_sciences._shared.materials_science._common import (
     SILICON_BSE_ABSORPTION_SPEC,
     evaluate_remote_output_dir,
+    run_command,
 )
 
 logger = logging.getLogger(__name__)
@@ -115,13 +116,13 @@ _setup = BaseTaskSetup()
 async def start(task_cfg, session: cb.DesktopSession):
     await _setup(task_cfg, session)
     install_script = f"{task_cfg.metadata['software_dir']}/install_software.sh"
-    result = await session.run_command(
-        "bash " + shlex.quote(install_script), timeout=600, check=False
+    result = await run_command(
+        session, "bash " + shlex.quote(install_script), timeout=600, check=False
     )
-    if result.returncode != 0:
+    if result.get("return_code", 0) != 0:
         raise RuntimeError(
             "QE/BerkeleyGW task runtime verification failed: "
-            f"{(result.stderr or result.stdout or '').strip()[-2000:]}"
+            f"{(result.get('stderr') or result.get('stdout') or '').strip()[-2000:]}"
         )
 
 

--- a/tests/ale_run/test_octavus_cli_argv.py
+++ b/tests/ale_run/test_octavus_cli_argv.py
@@ -1,0 +1,33 @@
+"""OctavusCliDeployer._build_argv construction.
+
+The deployer uses the CLI's built-in default platform unless the caller pins a
+platform_url to point the run at a different deployment. These tests lock that in:
+the --platform-url flag appears iff platform_url is set, and the prompt stays last.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ale_run.agents.octavus_cli import OctavusCliConfig, OctavusCliDeployer
+
+
+def _deployer() -> OctavusCliDeployer:
+    d = OctavusCliDeployer(SimpleNamespace(config=SimpleNamespace(), env={}))  # type: ignore[arg-type]
+    d._octoagent_path = "octoagent"
+    return d
+
+
+def test_build_argv_omits_platform_url_by_default() -> None:
+    cfg = OctavusCliConfig()
+    argv = _deployer()._build_argv(cfg, workdir="/wd", prompt="do it")
+
+    assert "--platform-url" not in argv
+    assert argv[-1] == "do it"
+
+
+def test_build_argv_includes_platform_url_when_set() -> None:
+    cfg = OctavusCliConfig(platform_url="https://platform.example")
+    argv = _deployer()._build_argv(cfg, workdir="/wd", prompt="do it")
+
+    assert argv[argv.index("--platform-url") + 1] == "https://platform.example"
+    assert argv[-1] == "do it"


### PR DESCRIPTION
## Summary

Reliability fixes surfaced by running the suite on GCE Linux VMs, plus a small harness enhancement:

- **gcloud provider** recovers from a machine type simply not being offered in a zone (distinct from capacity exhaustion), and spreads concurrent VMs across zones so a large parallel run finds capacity faster and does not concentrate per-region quota.
- **Linux task fixes** for `mpc_control_building_v1`, `openroad_sky130_ibex_pnr_signoff`, and the two BSE-absorption tasks so their `main.py` runs cleanly on the eval box.
- **octavus_cli harness** installs a lightweight window manager on a bare display, adds a per-run reasoning-effort override, and pins a current `@octavus/agent` build, so the harness's browser / computer-use tools are reliable and its runs are reproducible on a headless VM.

## Changes

### gcloud provider (`ale_run/environments/providers/gcloud.py`)

- Add `_is_machine_unavailable_error` (a machine type not offered in a zone: "does not exist in zone", "machine type not found", etc.) and fold it with the existing capacity check into `_is_retryable_create_error`. Newer machine families (e.g. c4) are absent from some zones the n2 fallback still covers, so this recovers by trying the next machine/zone instead of failing the unit.
- Shuffle a per-VM copy of the zone list so concurrent units spread across zones/regions instead of all hammering `zones[0]`.
- Reorder create attempts to zone x machine (try every candidate machine within a zone before moving on), so the reliable fallback (c* -> n2) is reached in the first zone rather than after crawling the requested machine across every zone. First success wins; a retryable create error moves on, anything else is fatal and surfaced at once.
  - Tradeoff: this weakens machine-type preference. A unit can land on the n2 fallback when the requested family is missing or exhausted in the first zone tried, even though another zone still offers it. We think that is the right call for large parallel runs (capacity is found without a cross-zone crawl of doomed create attempts), and the fallback keeps the same shape (`c*-standard-N` -> `n2-standard-N`, family generation only). GPU units are unaffected (no machine fallback), so for them this is purely the zone spread.

### Linux task fixes (`tasks/**/main.py`)

- `engineering/mpc_control_building_v1`, `engineering/openroad_sky130_ibex_pnr_signoff`, `condensed_matter/{mose2_bse_absorption_soc,silicon_bse_absorption}`: robustness fixes so each task's `main.py` runs to completion on the Linux eval box.

### octavus_cli harness (`ale_run/agents/octavus_cli/`, `configs/agents/octavus_cli.yaml`)

- Add `fluxbox` to the harness's best-effort apt prerequisites: the CLI starts a window manager on a bare display so the computer-use `label` driver can find the foreground window. It is a no-op on the standard `:0` (which already runs a WM), so the CLI detects that and skips it.
- Add a per-run thinking/reasoning effort override. A new `thinking` config field is sent to the CLI as `octoagent run --thinking <off|low|medium|high|max>`, mirroring the existing `model` / `backup_model` per-run overrides, so an episode can pin reasoning effort without touching the agent's stored configuration. Leaving it `null` inherits the agent's default and omits the flag; the value is validated at config load, and `configs/agents/octavus_cli.yaml` documents the knob.
- Pin the default `cli_version` to `@octavus/agent@1.0.10` (the harness still accepts `null` to install the latest, or any pinned spec). `1.0.10` is the floor for the `--thinking` override above; older builds ignore the flag.

## Notes

- The gcloud and task fixes are provider/task-general and are not specific to any one agent harness.
- The `octavus_cli` deployer uses only the public `@octavus/agent` CLI and its consumer API (no privileged surface), so the integration relies only on what any user has.

## Test plan

- `uv run ruff check` on the changed files introduces no new findings (the tree's pre-existing findings are unchanged).
- A parallel run over a machine family missing from some zones (e.g. c4) no longer fails units with "machine type does not exist in zone" and falls back to n2 in-zone.
- The three affected tasks complete on a Linux eval VM.
- The `octavus_cli` harness passes `--thinking` to the CLI when the effort is set and omits it when unset; an invalid effort is rejected at config load.