### PR TITLE
feat(tasks): add business_finance/ashare_pit_factor_ic_01

### DIFF
--- a/tasks/business_finance/ashare_pit_factor_ic_01/main.py
+++ b/tasks/business_finance/ashare_pit_factor_ic_01/main.py
@@ -1,0 +1,208 @@
+"""ALE task: business_finance/ashare_pit_factor_ic_01.
+
+Point-in-time multi-factor construction and rank-IC evaluation on a simulated China A-share
+market. Input data (daily bars, cumulative quarterly statements with announcement dates and
+restatements, security master, trading calendar, rebalance dates) is staged by the framework under
+input/. The hidden reference (factor panel and IC report produced by the normative pipeline in
+input/factor_spec.md) is staged under reference/ only at evaluation time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import cua_bench as cb
+
+from tasks.common_setup import BaseTaskSetup
+from tasks.linux_runtime import LinuxTaskConfig
+
+_setup = BaseTaskSetup()
+
+SCRIPTS_DIR = Path(__file__).parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from score_factor_outputs import score_submission
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_NAME = "business_finance"
+TASK_NAME = "ashare_pit_factor_ic_01"
+
+VARIANTS = [
+    ("base", "300 securities, 2022-07 to 2025-12, 30 monthly rebalance dates, seed 20260907."),
+    ("variant_2", "320 securities, same period and rules, seed 20260908."),
+    ("variant_3", "280 securities, same period and rules, seed 20260909."),
+]
+
+
+@dataclass
+class TaskConfig(LinuxTaskConfig):
+    DOMAIN_NAME: str = DOMAIN_NAME
+    TASK_NAME: str = TASK_NAME
+    VARIANT_NAME: str = "base"
+
+    @property
+    def data_dir(self) -> str:
+        return f"{self.input_dir}/data"
+
+    @property
+    def task_brief_file(self) -> str:
+        return f"{self.input_dir}/task_brief.md"
+
+    @property
+    def factor_spec_file(self) -> str:
+        return f"{self.input_dir}/factor_spec.md"
+
+    @property
+    def output_contract_file(self) -> str:
+        return f"{self.input_dir}/output_contract.json"
+
+    @property
+    def requirements_file(self) -> str:
+        return f"{self.input_dir}/runtime_env/requirements.txt"
+
+    @property
+    def python_wrapper(self) -> str:
+        return f"{self.software_dir}/python.sh"
+
+    @property
+    def output_files(self) -> dict[str, str]:
+        return {
+            "factor_panel.csv": f"{self.remote_output_dir}/factor_panel.csv",
+            "ic_report.json": f"{self.remote_output_dir}/ic_report.json",
+        }
+
+    @property
+    def reference_files(self) -> dict[str, str]:
+        return {
+            "factor_panel.csv": f"{self.reference_dir}/factor_panel.csv",
+            "ic_report.json": f"{self.reference_dir}/ic_report.json",
+        }
+
+    @property
+    def task_description(self) -> str:
+        return f"""\
+You are the quant researcher on a China A-share equity team. Build the team's point-in-time factor pipeline from the staged vendor data and evaluate the factors with rank IC.
+
+Task directory: `{self.task_dir}`
+
+Read these first, in this order:
+- Task brief: `{self.task_brief_file}`
+- Normative factor specification (the grader implements exactly this): `{self.factor_spec_file}`
+- Output schema: `{self.output_contract_file}`
+
+Input data under `{self.data_dir}`:
+- `daily_bars.csv` (unadjusted OHLC, volume, amount, adj_factor, share counts, trade_status)
+- `financials.csv` (quarterly statements, cumulative year-to-date, with announce_date; restatements appear as a second row for the same report_period)
+- `securities.csv` (industry, list_date, delist_date)
+- `trading_calendar.csv`, `rebalance_dates.csv`
+
+Deliverables, written under `{self.remote_output_dir}`:
+- `factor_panel.csv`: one row per (rebalance date, eligible ticker) with the six processed factors `mom_6_1, rev_1m, vol_20, turnover_20, ep_ttm, size` and `fwd_ret_20`
+- `ic_report.json`: per-factor rank IC statistics (`mean_ic`, `ic_std`, `icir`, `n_periods`, `by_date`)
+
+Requirements:
+- Every statement is usable only from its `announce_date`; restatements replace the original only after their own announcement. Trailing-twelve-month net profit must be assembled from the cumulative year-to-date rows as the specification prescribes.
+- Eligibility, winsorisation, industry neutralisation, standardisation, forward-return and IC rules follow `{self.factor_spec_file}` exactly. No look-ahead, no survivorship filtering.
+- Python with pandas and numpy is available via `{self.python_wrapper}` (first call creates a virtual environment from `{self.requirements_file}`). Any other tooling is acceptable if the output files match the contract.
+- Do not modify files under `{self.input_dir}`.
+- The grader recomputes the rank IC from your own panel and rejects a report whose `mean_ic` disagrees with that recomputation.
+"""
+
+    def to_metadata(self) -> dict:
+        metadata = super().to_metadata()
+        metadata.update(
+            {
+                "data_dir": self.data_dir,
+                "task_brief_file": self.task_brief_file,
+                "factor_spec_file": self.factor_spec_file,
+                "output_contract_file": self.output_contract_file,
+                "requirements_file": self.requirements_file,
+                "python_wrapper": self.python_wrapper,
+                "output_files": self.output_files,
+                "reference_files": self.reference_files,
+            }
+        )
+        return metadata
+
+
+@cb.tasks_config(split="train")
+def load():
+    tasks = []
+    for variant_name, _label in VARIANTS:
+        cfg = TaskConfig(VARIANT_NAME=variant_name)
+        tasks.append(
+            cb.Task(
+                description=cfg.task_description,
+                metadata=cfg.to_metadata(),
+                computer={"provider": "computer", "setup_config": {"os_type": cfg.OS_TYPE}},
+            )
+        )
+    return tasks
+
+
+async def _exists(session: cb.DesktopSession, path: str) -> bool:
+    return bool(await session.file_exists(path) or await session.directory_exists(path))
+
+
+@cb.setup_task(split="train")
+async def start(task_cfg, session: cb.DesktopSession):
+    await _setup(task_cfg, session)
+    meta = task_cfg.metadata
+    out_dir = meta["remote_output_dir"]
+    await session.run_command(f"rm -rf {out_dir!r} && mkdir -p {out_dir!r}", check=False)
+    await session.run_command(f"chmod +x {meta['python_wrapper']!r}", check=False)
+    for path in (
+        meta["factor_spec_file"],
+        meta["output_contract_file"],
+        f"{meta['data_dir']}/daily_bars.csv",
+    ):
+        if not await _exists(session, path):
+            raise RuntimeError(f"staged input missing: {path}")
+    if await _exists(session, meta["reference_dir"]):
+        raise RuntimeError(
+            f"reference directory must not be visible during setup: {meta['reference_dir']}"
+        )
+    logger.info("[%s] input staged, output dir ready at %s", meta["variant_name"], out_dir)
+
+
+@cb.evaluate_task(split="train")
+async def evaluate(task_cfg, session: cb.DesktopSession) -> list[float]:
+    meta = task_cfg.metadata
+    tag = meta["variant_name"]
+
+    reference: dict[str, bytes] = {}
+    for name, path in meta["reference_files"].items():
+        if not await _exists(session, path):
+            raise RuntimeError(f"[{tag}] hidden reference missing: {path}")
+        reference[name] = await session.read_bytes(path)
+
+    outputs: dict[str, bytes | None] = {}
+    for name, path in meta["output_files"].items():
+        outputs[name] = await session.read_bytes(path) if await _exists(session, path) else None
+
+    try:
+        result = score_submission(
+            outputs["factor_panel.csv"],
+            outputs["ic_report.json"],
+            reference["factor_panel.csv"],
+            reference["ic_report.json"],
+        )
+    except RuntimeError:
+        raise
+    except Exception:
+        logger.exception("[%s] scoring failed on submitted artifacts", tag)
+        return [0.0]
+
+    logger.info("[%s] evaluation=%s", tag, json.dumps(result.to_dict(), sort_keys=True))
+    return [float(result.score)]
+
+
+if __name__ == "__main__":
+    for task in load():
+        print(task.description)

--- a/tasks/business_finance/ashare_pit_factor_ic_01/scripts/score_factor_outputs.py
+++ b/tasks/business_finance/ashare_pit_factor_ic_01/scripts/score_factor_outputs.py
@@ -1,0 +1,341 @@
+"""Host-side scorer for business_finance/ashare_pit_factor_ic_01.
+
+Pure standard library so the grader can run in the host process without pandas.
+
+Gate-and-score:
+  gates (any failure -> score 0): files present and parseable, exact panel columns, exact rebalance
+  date set, unique (date, ticker) keys, average per-date universe Jaccard >= 0.90, report schema,
+  and provenance: the reported mean_ic must match the rank IC recomputed from the submitted panel.
+  score = 0.10 * coverage + 0.55 * panel_fidelity + 0.35 * ic_accuracy
+  panel_fidelity is the weighted mean over columns of the per-date share of reference cells the
+  submission reproduces within tolerance (ep_ttm carries triple weight: it is the point-in-time part).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+FACTORS = ["mom_6_1", "rev_1m", "vol_20", "turnover_20", "ep_ttm", "size"]
+PANEL_COLUMNS = ["date", "ticker", "industry_sw1", *FACTORS, "fwd_ret_20"]
+SCORED_COLUMNS = [*FACTORS, "fwd_ret_20"]
+REPORT_FIELDS = ["mean_ic", "ic_std", "icir", "n_periods", "by_date"]
+MIN_IC_NAMES = 30
+COVERAGE_GATE = 0.90
+PROVENANCE_TOL = 0.005
+PASS_THRESHOLD = 0.95
+CELL_TOL = {col: 1e-3 for col in FACTORS}
+CELL_TOL["fwd_ret_20"] = 1e-5
+COLUMN_WEIGHT = {col: 1.0 for col in SCORED_COLUMNS}
+COLUMN_WEIGHT["ep_ttm"] = 3.0
+IC_TOL = (0.0005, 0.005)
+ICIR_TOL = (0.01, 0.10)
+
+
+@dataclass
+class ScoreResult:
+    score: float
+    passed: bool
+    reason: str
+    hard_gate: str | None = None
+    coverage_score: float = 0.0
+    panel_fidelity: float = 0.0
+    ic_accuracy: float = 0.0
+    mean_jaccard: float = 0.0
+    column_match_rate: dict[str, float] = field(default_factory=dict)
+    column_mean_rho: dict[str, float] = field(default_factory=dict)
+    ic_abs_error: dict[str, float] = field(default_factory=dict)
+    icir_abs_error: dict[str, float] = field(default_factory=dict)
+    provenance_gap: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _as_text(payload: str | bytes) -> str:
+    if isinstance(payload, bytes):
+        return payload.decode("utf-8-sig")
+    return payload.lstrip("﻿")
+
+
+def _to_float(cell: str) -> float:
+    cell = (cell or "").strip()
+    if cell == "" or cell.lower() in {"nan", "na", "none", "null"}:
+        return math.nan
+    return float(cell)
+
+
+def parse_panel(
+    csv_text: str | bytes,
+) -> tuple[dict[str, dict[str, dict[str, float | str]]] | None, str | None]:
+    """Return {date: {ticker: {col: value}}} or (None, reason)."""
+    reader = csv.reader(io.StringIO(_as_text(csv_text)))
+    try:
+        header = next(reader)
+    except StopIteration:
+        return None, "panel is empty"
+    header = [h.strip() for h in header]
+    if header != PANEL_COLUMNS:
+        return None, f"panel columns must be exactly {PANEL_COLUMNS}, got {header}"
+    panel: dict[str, dict[str, dict]] = {}
+    for line_no, row in enumerate(reader, start=2):
+        if not row or all(not c.strip() for c in row):
+            continue
+        if len(row) != len(PANEL_COLUMNS):
+            return None, f"panel line {line_no} has {len(row)} cells, expected {len(PANEL_COLUMNS)}"
+        d, s = row[0].strip(), row[1].strip()
+        if len(d) != 10 or d[4] != "-" or d[7] != "-":
+            return None, f"panel line {line_no} has malformed date {d!r}"
+        rec: dict[str, float | str] = {"industry_sw1": row[2].strip()}
+        try:
+            for col, cell in zip(SCORED_COLUMNS, row[3:]):
+                rec[col] = _to_float(cell)
+        except ValueError:
+            return None, f"panel line {line_no} has a non-numeric factor cell"
+        bucket = panel.setdefault(d, {})
+        if s in bucket:
+            return None, f"duplicate (date, ticker) key {d} {s}"
+        bucket[s] = rec
+    if not panel:
+        return None, "panel has no data rows"
+    return panel, None
+
+
+def _rank(values: list[float]) -> list[float]:
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        avg = (i + j) / 2 + 1
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def spearman(x: list[float], y: list[float]) -> float:
+    if len(x) < 3:
+        return math.nan
+    rx, ry = _rank(x), _rank(y)
+    mx, my = sum(rx) / len(rx), sum(ry) / len(ry)
+    sxx = sum((a - mx) ** 2 for a in rx)
+    syy = sum((b - my) ** 2 for b in ry)
+    if sxx == 0 or syy == 0:
+        return math.nan
+    sxy = sum((a - mx) * (b - my) for a, b in zip(rx, ry))
+    return sxy / math.sqrt(sxx * syy)
+
+
+def rank_ic_by_date(panel: dict, factor: str) -> dict[str, float]:
+    out = {}
+    for d in sorted(panel):
+        xs, ys = [], []
+        for rec in panel[d].values():
+            a, b = rec[factor], rec["fwd_ret_20"]
+            if not (math.isnan(a) or math.isnan(b)):
+                xs.append(a)
+                ys.append(b)
+        if len(xs) < MIN_IC_NAMES:
+            continue
+        rho = spearman(xs, ys)
+        if not math.isnan(rho):
+            out[d] = rho
+    return out
+
+
+def _mean(v: list[float]) -> float:
+    return sum(v) / len(v) if v else math.nan
+
+
+def _linear_credit(x: float, full: float, zero: float) -> float:
+    """1.0 when x <= full, 0.0 when x >= zero, linear between."""
+    if math.isnan(x):
+        return 0.0
+    if x <= full:
+        return 1.0
+    if x >= zero:
+        return 0.0
+    return (zero - x) / (zero - full)
+
+
+def parse_report(text: str | bytes) -> tuple[dict | None, str | None]:
+    try:
+        data = json.loads(_as_text(text))
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, f"ic_report.json is not valid JSON: {exc}"
+    if not isinstance(data, dict) or not isinstance(data.get("rank_ic"), dict):
+        return None, "ic_report.json must be an object with a 'rank_ic' object"
+    rank_ic = data["rank_ic"]
+    for f in FACTORS:
+        block = rank_ic.get(f)
+        if not isinstance(block, dict):
+            return None, f"ic_report.json rank_ic is missing factor {f}"
+        for key in REPORT_FIELDS:
+            if key not in block:
+                return None, f"ic_report.json rank_ic[{f}] is missing {key}"
+        for key in ("mean_ic", "ic_std", "icir"):
+            if (
+                not isinstance(block[key], (int, float))
+                or isinstance(block[key], bool)
+                or math.isnan(float(block[key]))
+            ):
+                return None, f"ic_report.json rank_ic[{f}].{key} must be a finite number"
+        if not isinstance(block["by_date"], dict):
+            return None, f"ic_report.json rank_ic[{f}].by_date must be an object"
+    return rank_ic, None
+
+
+def score_submission(
+    output_panel: str | bytes | None,
+    output_report: str | bytes | None,
+    reference_panel: str | bytes,
+    reference_report: str | bytes,
+) -> ScoreResult:
+    if output_panel is None:
+        return ScoreResult(0.0, False, "missing output/factor_panel.csv", hard_gate="missing_panel")
+    if output_report is None:
+        return ScoreResult(0.0, False, "missing output/ic_report.json", hard_gate="missing_report")
+
+    ref_panel, err = parse_panel(reference_panel)
+    if err:
+        raise RuntimeError(f"reference panel invalid: {err}")
+    ref_report, err = parse_report(reference_report)
+    if err:
+        raise RuntimeError(f"reference report invalid: {err}")
+
+    panel, err = parse_panel(output_panel)
+    if err:
+        return ScoreResult(0.0, False, err, hard_gate="panel_schema")
+    if set(panel) != set(ref_panel):
+        missing = sorted(set(ref_panel) - set(panel))[:3]
+        extra = sorted(set(panel) - set(ref_panel))[:3]
+        return ScoreResult(
+            0.0,
+            False,
+            f"panel date set differs from rebalance dates (missing {missing}, extra {extra})",
+            hard_gate="date_set",
+        )
+    report, err = parse_report(output_report)
+    if err:
+        return ScoreResult(0.0, False, err, hard_gate="report_schema")
+
+    jaccards = []
+    for d in ref_panel:
+        a, b = set(panel[d]), set(ref_panel[d])
+        jaccards.append(len(a & b) / len(a | b))
+    mean_jaccard = _mean(jaccards)
+    if mean_jaccard < COVERAGE_GATE:
+        return ScoreResult(
+            0.0,
+            False,
+            f"universe overlap too low (mean Jaccard {mean_jaccard:.3f} < {COVERAGE_GATE})",
+            hard_gate="universe_coverage",
+            mean_jaccard=mean_jaccard,
+        )
+
+    provenance_gap = {}
+    for f in FACTORS:
+        recomputed = rank_ic_by_date(panel, f)
+        own_mean = _mean(list(recomputed.values()))
+        provenance_gap[f] = (
+            abs(float(report[f]["mean_ic"]) - own_mean) if not math.isnan(own_mean) else math.inf
+        )
+    worst = max(provenance_gap.values())
+    if worst > PROVENANCE_TOL:
+        return ScoreResult(
+            0.0,
+            False,
+            f"reported mean_ic is inconsistent with the submitted panel (max gap {worst:.4f})",
+            hard_gate="report_provenance",
+            mean_jaccard=mean_jaccard,
+            provenance_gap=provenance_gap,
+        )
+
+    coverage_score = _linear_credit(1.0 - mean_jaccard, full=0.01, zero=0.10)
+
+    column_match_rate, column_mean_rho = {}, {}
+    for col in SCORED_COLUMNS:
+        rates, rhos = [], []
+        for d in ref_panel:
+            n_ref = matched = 0
+            xs, ys = [], []
+            for s, rec in ref_panel[d].items():
+                b = rec[col]
+                if math.isnan(b):
+                    continue
+                n_ref += 1
+                a = panel[d][s][col] if s in panel[d] else math.nan
+                if math.isnan(a):
+                    continue
+                xs.append(a)
+                ys.append(b)
+                if abs(a - b) <= CELL_TOL[col]:
+                    matched += 1
+            if n_ref == 0:
+                continue
+            rates.append(matched / n_ref)
+            rho = spearman(xs, ys)
+            if not math.isnan(rho):
+                rhos.append(rho)
+        column_match_rate[col] = _mean(rates)
+        column_mean_rho[col] = _mean(rhos)
+    panel_fidelity = sum(COLUMN_WEIGHT[c] * column_match_rate[c] for c in SCORED_COLUMNS) / sum(
+        COLUMN_WEIGHT.values()
+    )
+
+    ic_abs_error, icir_abs_error, ic_credits = {}, {}, []
+    for f in FACTORS:
+        d_ic = abs(float(report[f]["mean_ic"]) - float(ref_report[f]["mean_ic"]))
+        d_icir = abs(float(report[f]["icir"]) - float(ref_report[f]["icir"]))
+        ic_abs_error[f] = d_ic
+        icir_abs_error[f] = d_icir
+        ic_credits.append(
+            0.5 * _linear_credit(d_ic, *IC_TOL) + 0.5 * _linear_credit(d_icir, *ICIR_TOL)
+        )
+    ic_accuracy = _mean(ic_credits)
+
+    score = 0.10 * coverage_score + 0.55 * panel_fidelity + 0.35 * ic_accuracy
+    score = max(0.0, min(1.0, score))
+    return ScoreResult(
+        score=score,
+        passed=score >= PASS_THRESHOLD,
+        reason="scored",
+        coverage_score=coverage_score,
+        panel_fidelity=panel_fidelity,
+        ic_accuracy=ic_accuracy,
+        mean_jaccard=mean_jaccard,
+        column_match_rate=column_match_rate,
+        column_mean_rho=column_mean_rho,
+        ic_abs_error=ic_abs_error,
+        icir_abs_error=icir_abs_error,
+        provenance_gap=provenance_gap,
+    )
+
+
+def _read_optional(path: Path) -> bytes | None:
+    return path.read_bytes() if path.is_file() else None
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(
+        description="Score an output/ directory against a reference/ directory."
+    )
+    ap.add_argument("--output-dir", required=True)
+    ap.add_argument("--reference-dir", required=True)
+    a = ap.parse_args()
+    out, ref = Path(a.output_dir), Path(a.reference_dir)
+    result = score_submission(
+        _read_optional(out / "factor_panel.csv"),
+        _read_optional(out / "ic_report.json"),
+        (ref / "factor_panel.csv").read_bytes(),
+        (ref / "ic_report.json").read_bytes(),
+    )
+    print(json.dumps(result.to_dict(), indent=2, sort_keys=True))

--- a/tasks/business_finance/ashare_pit_factor_ic_01/task_card.json
+++ b/tasks/business_finance/ashare_pit_factor_ic_01/task_card.json
@@ -1,0 +1,125 @@
+{
+  "taskId": "business_finance/ashare_pit_factor_ic_01",
+  "title": "A-share Point-in-Time Factor Panel and Rank IC",
+  "summary": "Build a point-in-time multi-factor panel (momentum, reversal, volatility, turnover, TTM earnings yield, size) for a simulated China A-share market from daily bars and cumulative quarterly statements with announcement dates and restatements, then report rank IC statistics against 20-day forward returns.",
+  "category": "business_finance",
+  "software": [
+    "Python",
+    "pandas",
+    "NumPy"
+  ],
+  "taskPrompt": "You are the quant researcher on a China A-share equity team. Build the team's point-in-time factor pipeline from the staged vendor data and evaluate the factors with rank IC.\n\nTask directory: `base`\n\nRead these first, in this order:\n- Task brief: `base/input/task_brief.md`\n- Normative factor specification (the grader implements exactly this): `base/input/factor_spec.md`\n- Output schema: `base/input/output_contract.json`\n\nInput data under `base/input/data`:\n- `daily_bars.csv` (unadjusted OHLC, volume, amount, adj_factor, share counts, trade_status)\n- `financials.csv` (quarterly statements, cumulative year-to-date, with announce_date; restatements appear as a second row for the same report_period)\n- `securities.csv` (industry, list_date, delist_date)\n- `trading_calendar.csv`, `rebalance_dates.csv`\n\nDeliverables, written under `base/output`:\n- `factor_panel.csv`: one row per (rebalance date, eligible ticker) with the six processed factors `mom_6_1, rev_1m, vol_20, turnover_20, ep_ttm, size` and `fwd_ret_20`\n- `ic_report.json`: per-factor rank IC statistics (`mean_ic`, `ic_std`, `icir`, `n_periods`, `by_date`)\n\nRequirements:\n- Every statement is usable only from its `announce_date`; restatements replace the original only after their own announcement. Trailing-twelve-month net profit must be assembled from the cumulative year-to-date rows as the specification prescribes.\n- Eligibility, winsorisation, industry neutralisation, standardisation, forward-return and IC rules follow `base/input/factor_spec.md` exactly. No look-ahead, no survivorship filtering.\n- Python with pandas and numpy is available via `base/software/python.sh` (first call creates a virtual environment from `base/input/runtime_env/requirements.txt`). Any other tooling is acceptable if the output files match the contract.\n- Do not modify files under `base/input`.\n- The grader recomputes the rank IC from your own panel and rejects a report whose `mean_ic` disagrees with that recomputation.\n",
+  "agentMustDo": [
+    "Read task_brief.md, factor_spec.md and output_contract.json in full before coding.",
+    "Determine the eligible universe on each rebalance date from listing history, delisting and trade_status.",
+    "Assemble point-in-time trailing-twelve-month net profit from cumulative year-to-date statements using announce_date, with restatements applied only after their own announcement.",
+    "Compute the six raw factors and the 20-trading-day forward return with adjusted prices for returns and unadjusted prices for market capitalisation, excluding suspended days as specified.",
+    "Winsorise, industry-neutralise and standardise each factor cross-sectionally per date.",
+    "Compute per-date Spearman rank IC per factor and the summary statistics.",
+    "Write output/factor_panel.csv and output/ic_report.json in the exact schema of output_contract.json."
+  ],
+  "inputFiles": [
+    {
+      "name": "task_brief.md",
+      "format": "Markdown",
+      "path": "input/task_brief.md",
+      "description": "Desk context, deliverables and the rules the grader enforces."
+    },
+    {
+      "name": "factor_spec.md",
+      "format": "Markdown",
+      "path": "input/factor_spec.md",
+      "description": "Normative definitions: eligibility, factor formulas, point-in-time TTM assembly, cross-sectional processing, forward return and rank IC."
+    },
+    {
+      "name": "output_contract.json",
+      "format": "JSON",
+      "path": "input/output_contract.json",
+      "description": "Exact schema of the two deliverables."
+    },
+    {
+      "name": "data/daily_bars.csv",
+      "format": "CSV",
+      "path": "input/data/daily_bars.csv",
+      "description": "Daily unadjusted OHLC, volume, amount, cumulative adj_factor, total and float shares, trade_status for about 300 securities over 852 trading days."
+    },
+    {
+      "name": "data/financials.csv",
+      "format": "CSV",
+      "path": "input/data/financials.csv",
+      "description": "Quarterly statements as disclosed: cumulative year-to-date revenue and net profit, total equity, announce_date; restated reports appear as additional rows; unsorted."
+    },
+    {
+      "name": "data/securities.csv",
+      "format": "CSV",
+      "path": "input/data/securities.csv",
+      "description": "Security master: name, exchange, Shenwan level-1 industry, list_date, delist_date."
+    },
+    {
+      "name": "data/trading_calendar.csv",
+      "format": "CSV",
+      "path": "input/data/trading_calendar.csv",
+      "description": "Exchange trading days; all trading-day offsets in the spec are positions in this calendar."
+    },
+    {
+      "name": "data/rebalance_dates.csv",
+      "format": "CSV",
+      "path": "input/data/rebalance_dates.csv",
+      "description": "The 30 month-end evaluation dates."
+    },
+    {
+      "name": "runtime_env/requirements.txt",
+      "format": "Text",
+      "path": "input/runtime_env/requirements.txt",
+      "description": "Pinned pandas / numpy / scipy versions for the staged runtime."
+    },
+    {
+      "name": "software/python.sh",
+      "format": "Shell script",
+      "path": "software/python.sh",
+      "description": "Canonical Python entry point; creates the virtual environment on first call."
+    }
+  ],
+  "referenceFiles": [
+    {
+      "name": "factor_panel.csv",
+      "format": "CSV",
+      "path": "reference/factor_panel.csv",
+      "description": "Panel produced by the normative pipeline: processed factors and forward returns for every eligible (date, ticker)."
+    },
+    {
+      "name": "ic_report.json",
+      "format": "JSON",
+      "path": "reference/ic_report.json",
+      "description": "Rank IC statistics produced by the normative pipeline."
+    }
+  ],
+  "evaluation": "**Hard gate conditions** (score = 0 when any triggers)\n- `output/factor_panel.csv` or `output/ic_report.json` missing or unparseable\n- Panel columns not exactly `date, ticker, industry_sw1, mom_6_1, rev_1m, vol_20, turnover_20, ep_ttm, size, fwd_ret_20`\n- Panel date set differs from the rebalance dates, or a duplicate (date, ticker) key\n- Mean per-date Jaccard overlap between the submitted universe and the reference universe below 0.90\n- `ic_report.json` missing any of the six factors or any of `mean_ic, ic_std, icir, n_periods, by_date`\n- Provenance: the grader recomputes the per-date Spearman rank IC from the submitted panel itself; if any factor's reported `mean_ic` deviates from that recomputation by more than 0.005 the report is rejected\n\n**Scoring method** (weighted rubric, deterministic, host-side, standard library only)\n1. Coverage (weight 0.10): mean per-date universe Jaccard mapped linearly from 0.90 (0 credit) to 0.99 (full credit).\n2. Panel fidelity (weight 0.55): for each of the seven numeric columns and each date, the share of reference cells (non-missing tickers) that the submission reproduces within tolerance (1e-3 for the six standardised factors, 1e-5 for fwd_ret_20). Averaged over dates, then weighted across columns with ep_ttm at triple weight because it carries the point-in-time logic.\n3. IC accuracy (weight 0.35): per factor, half credit for |mean_ic error| (full at 0.0005, zero at 0.005) and half for |ICIR error| (full at 0.01, zero at 0.10). Averaged over the six factors.\n\n**Current pass threshold:** 0.95.\n\n**Calibration on authored error modes** (the reference pipeline with exactly one rule broken, base variant): using report_period instead of announce_date 0.87; treating year-to-date figures as quarterly 0.79; unadjusted prices for returns 0.81; ignoring suspensions 0.59; skipping industry neutralisation 0.38; loosened listing-history rule 0.70; the three statement/price mistakes combined 0.62. Every single-rule mistake fails the pass threshold.\n\n**What does a perfect output look like?**\nA panel whose universe, factor ranks and forward returns match the reference on every date, and an IC report whose mean IC and ICIR match within tolerance for all six factors.\n\n**What does a wrong output look like?**\nA missing or malformed file, an extra or missing rebalance date, a universe that includes suspended or recently listed names, factor values built from future statements or unadjusted prices, or an IC report that was not computed from the submitted panel.",
+  "vm": {
+    "machineType": "c4-standard-4",
+    "snapshot": "cpu-free-ubuntu",
+    "timeout": 7200
+  },
+  "variants": 3,
+  "taxonomy": {
+    "domain_id": "6",
+    "domain_code": "business_finance",
+    "subdomain_id": "6.5",
+    "subdomain_code": "quant_finance",
+    "subdomain_name": "Quantitative Finance & Trading",
+    "classifier": {
+      "model": "manual",
+      "source": {
+        "fields": [
+          "taskPrompt",
+          "title",
+          "summary",
+          "software"
+        ],
+        "mode": "author"
+      },
+      "rationale": "Point-in-time factor construction and IC evaluation is the core daily workflow of an equity quant researcher."
+    }
+  },
+  "requiredSystemPackages": []
+}

--- a/tests/tasks/test_ashare_pit_factor_ic_scorer.py
+++ b/tests/tasks/test_ashare_pit_factor_ic_scorer.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+SCORER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tasks/business_finance/ashare_pit_factor_ic_01/scripts/score_factor_outputs.py"
+)
+SPEC = importlib.util.spec_from_file_location("ashare_pit_factor_scorer", SCORER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+SCORER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SCORER
+SPEC.loader.exec_module(SCORER)
+
+FACTORS = SCORER.FACTORS
+DATES = ["2024-01-31", "2024-02-29", "2024-03-29"]
+INDUSTRIES = ["电子", "医药生物", "计算机"]
+
+
+def _lcg(seed: int):
+    state = seed
+    while True:
+        state = (1103515245 * state + 12345) % (2**31)
+        yield state / 2**31
+
+
+def _build_panel(n_names: int = 60, seed: int = 7) -> dict:
+    rnd = _lcg(seed)
+    panel = {}
+    for d in DATES:
+        rows = {}
+        for i in range(n_names):
+            ticker = f"{600000 + i:06d}.SH"
+            rec = {"industry_sw1": INDUSTRIES[i % 3]}
+            for f in FACTORS:
+                rec[f] = round((next(rnd) - 0.5) * 4, 6)
+            rec["fwd_ret_20"] = round(0.2 * rec["ep_ttm"] + (next(rnd) - 0.5) * 0.3, 6)
+            rows[ticker] = rec
+        panel[d] = rows
+    return panel
+
+
+def _panel_csv(panel: dict, columns=None) -> str:
+    columns = columns or SCORER.PANEL_COLUMNS
+    lines = [",".join(columns)]
+    for d in sorted(panel):
+        for s in sorted(panel[d]):
+            rec = panel[d][s]
+            cells = []
+            for col in columns:
+                if col == "date":
+                    cells.append(d)
+                elif col == "ticker":
+                    cells.append(s)
+                elif col == "industry_sw1":
+                    cells.append(rec["industry_sw1"])
+                else:
+                    v = rec.get(col, math.nan)
+                    cells.append("" if math.isnan(v) else f"{v:.6f}")
+            lines.append(",".join(cells))
+    return "\n".join(lines) + "\n"
+
+
+def _report_from_panel(panel: dict) -> str:
+    rank_ic = {}
+    for f in FACTORS:
+        by_date = SCORER.rank_ic_by_date(panel, f)
+        ics = list(by_date.values())
+        mean = sum(ics) / len(ics)
+        var = sum((x - mean) ** 2 for x in ics) / (len(ics) - 1)
+        std = math.sqrt(var)
+        rank_ic[f] = {
+            "mean_ic": mean,
+            "ic_std": std,
+            "icir": mean / std,
+            "n_periods": len(ics),
+            "by_date": by_date,
+        }
+    return json.dumps({"rank_ic": rank_ic})
+
+
+@pytest.fixture(scope="module")
+def reference():
+    panel = _build_panel()
+    return panel, _panel_csv(panel), _report_from_panel(panel)
+
+
+def test_exact_reference_scores_one(reference):
+    _panel, csv_text, report = reference
+    result = SCORER.score_submission(csv_text, report, csv_text, report)
+    assert result.hard_gate is None
+    assert result.score == pytest.approx(1.0)
+    assert result.passed
+
+
+def test_missing_outputs_score_zero(reference):
+    _, csv_text, report = reference
+    assert SCORER.score_submission(None, report, csv_text, report).hard_gate == "missing_panel"
+    assert SCORER.score_submission(csv_text, None, csv_text, report).hard_gate == "missing_report"
+
+
+def test_wrong_columns_fail_gate(reference):
+    panel, csv_text, report = reference
+    bad = _panel_csv(panel, columns=["date", "ticker", *FACTORS, "fwd_ret_20"])
+    result = SCORER.score_submission(bad, report, csv_text, report)
+    assert result.hard_gate == "panel_schema"
+    assert result.score == 0.0
+
+
+def test_missing_rebalance_date_fails_gate(reference):
+    panel, csv_text, report = reference
+    partial = {d: rows for d, rows in panel.items() if d != DATES[-1]}
+    result = SCORER.score_submission(_panel_csv(partial), report, csv_text, report)
+    assert result.hard_gate == "date_set"
+
+
+def test_fabricated_report_fails_provenance(reference):
+    _panel, csv_text, report = reference
+    fake = json.loads(report)
+    fake["rank_ic"]["ep_ttm"]["mean_ic"] += 0.05
+    result = SCORER.score_submission(csv_text, json.dumps(fake), csv_text, report)
+    assert result.hard_gate == "report_provenance"
+
+
+def test_universe_gate_on_low_overlap(reference):
+    panel, csv_text, report = reference
+    shrunk = {
+        d: {s: rec for i, (s, rec) in enumerate(sorted(rows.items())) if i % 4 != 0}
+        for d, rows in panel.items()
+    }
+    result = SCORER.score_submission(
+        _panel_csv(shrunk), _report_from_panel(shrunk), csv_text, report
+    )
+    assert result.hard_gate == "universe_coverage"
+    assert result.mean_jaccard < SCORER.COVERAGE_GATE
+
+
+def test_perturbed_factor_loses_credit_but_no_gate(reference):
+    panel, csv_text, report = reference
+    wrong = {d: {s: dict(rec) for s, rec in rows.items()} for d, rows in panel.items()}
+    for rows in wrong.values():
+        for rec in rows.values():
+            rec["ep_ttm"] = round(rec["ep_ttm"] + 0.01, 6)
+    result = SCORER.score_submission(_panel_csv(wrong), _report_from_panel(wrong), csv_text, report)
+    assert result.hard_gate is None
+    assert result.column_match_rate["ep_ttm"] == 0.0
+    assert result.column_match_rate["mom_6_1"] == 1.0
+    expected_panel = (sum(SCORER.COLUMN_WEIGHT.values()) - SCORER.COLUMN_WEIGHT["ep_ttm"]) / sum(
+        SCORER.COLUMN_WEIGHT.values()
+    )
+    assert result.panel_fidelity == pytest.approx(expected_panel)
+    assert not result.passed
+    assert 0.0 < result.score < SCORER.PASS_THRESHOLD
+
+
+def test_tolerance_accepts_rounding_noise(reference):
+    panel, csv_text, report = reference
+    noisy = {d: {s: dict(rec) for s, rec in rows.items()} for d, rows in panel.items()}
+    for rows in noisy.values():
+        for rec in rows.values():
+            for f in FACTORS:
+                rec[f] = round(rec[f] + 4e-4, 6)
+    result = SCORER.score_submission(_panel_csv(noisy), _report_from_panel(noisy), csv_text, report)
+    assert result.hard_gate is None
+    assert result.panel_fidelity == pytest.approx(1.0)
+    assert result.passed
+
+
+def test_spearman_matches_known_value():
+    assert SCORER.spearman([1, 2, 3, 4, 5], [5, 6, 7, 8, 7]) == pytest.approx(0.8207826816681233)
+    assert SCORER.spearman([1, 2, 3], [3, 2, 1]) == pytest.approx(-1.0)


### PR DESCRIPTION
## Summary

New task `business_finance/ashare_pit_factor_ic_01` (subdomain Quantitative Finance & Trading): point-in-time multi-factor construction and rank-IC evaluation on a simulated China A-share market.

The agent receives daily bars (unadjusted OHLC, cumulative `adj_factor`, share counts, `trade_status`), quarterly statements as disclosed (cumulative year-to-date, `announce_date`, restatements as extra rows, unsorted), a security master with listing/delisting dates and Shenwan industries, the trading calendar and 30 month-end rebalance dates. It must build six processed factors (`mom_6_1, rev_1m, vol_20, turnover_20, ep_ttm, size`), the 20-day forward return, and per-factor rank IC statistics, following a normative `factor_spec.md`.

The workflow is the standard first week of an equity quant onboarding a new data feed. The traps are the ones practitioners actually hit: `announce_date` vs `report_period`, assembling TTM from year-to-date rows, adjusted vs unadjusted prices, suspension handling, listing-history eligibility, and industry neutralisation before standardisation.

## Files

- `tasks/business_finance/ashare_pit_factor_ic_01/task_card.json`
- `tasks/business_finance/ashare_pit_factor_ic_01/main.py` (`load` / `start` / `evaluate`, three variants)
- `tasks/business_finance/ashare_pit_factor_ic_01/scripts/score_factor_outputs.py` (host-side, standard library only)
- `tests/tasks/test_ashare_pit_factor_ic_scorer.py`

## Scoring

Gate-and-score. Gates: files parse, exact columns, exact rebalance-date set, unique keys, mean universe Jaccard >= 0.90, report schema, and provenance (the grader recomputes rank IC from the submitted panel and rejects a report whose `mean_ic` disagrees by more than 0.005). Score = 0.10 coverage + 0.55 weighted per-cell match rate (`ep_ttm` triple weight) + 0.35 IC accuracy. Pass threshold 0.95.

Calibration with the reference pipeline broken one rule at a time (base variant): report_period instead of announce_date 0.87, YTD treated as quarterly 0.79, unadjusted prices 0.81, loosened listing rule 0.70, suspensions ignored 0.59, no industry neutralisation 0.38, three mistakes combined 0.62. Reference vs reference 1.00. Expected tier: Near-term.

## Task data

Not in this PR. The canonical tree `business_finance/ashare_pit_factor_ic_01/{base,variant_2,variant_3}/{input,software,reference}` (about 23 MB per variant) plus the seeded generator and the reference pipeline are ready to hand over for the task-data bucket. The market is simulated with A-share conventions (price limits by board, suspensions, IPOs and delistings in sample, dividends and bonus shares through `adj_factor`, statutory announcement windows, same-day annual and Q1 releases, restatements); no vendor data is redistributed. Reference outputs are produced by running the normative pipeline on the shipped inputs. Happy to swap in licensed real data if the team prefers; the pipeline and scorer do not change.

I have not added the task to the curated lists under `selected_tasks/` since runs would fail until the data is in the bucket.

## Verification

- `uv run pytest tests/tasks/test_ashare_pit_factor_ic_scorer.py` (9 passed)
- `uv run ruff check` and `ruff format --check` on the new files (clean)
- `TaskLoader` loads all three variants; `start()` and `evaluate()` exercised in-process against the local task-data tree with a fake session: no output 0.0, reference as output 1.0, the no-PIT calibration output 0.87
- Not yet run on a real VM or the Docker provider (task data not staged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
